### PR TITLE
[DAEF-346] add switch skin for checkbox component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Changelog
 ### Features
 
 - Add checkbox component
+- Add switch component
 
 ## 0.2.7
 

--- a/source/skins/simple/SwitchSkin.js
+++ b/source/skins/simple/SwitchSkin.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import classnames from 'classnames';
+import { pickDOMProps } from '../../utils/props';
+import { themr } from 'react-css-themr';
+import { SWITCH } from './identifiers';
+import DefaultSwitchTheme from '../../themes/simple/SimpleSwitch.scss';
+
+export default themr(SWITCH, DefaultSwitchTheme, { withRef: true })((props) => (
+  <div
+    className={classnames([
+      props.className,
+      props.theme.root,
+      props.disabled ? props.theme.disabled : null,
+      props.checked ? props.theme.checked : null,
+    ])}
+    onClick={(event) => {
+      if (!props.disabled && props.onChange) {
+        props.onChange(!props.checked, event);
+      }
+    }}
+  >
+    <input
+      {...pickDOMProps(props)}
+      className={props.theme.input}
+      readOnly
+      type="checkbox"
+    />
+    <div className={classnames([
+      props.theme.switch,
+      props.checked ? props.theme.checked : null,
+    ])}>
+      <span className={props.theme.thumb} />
+    </div>
+    {props.label ? (<label className={props.theme.label}>{props.label}</label>) : null}
+  </div>
+));

--- a/source/skins/simple/identifiers.js
+++ b/source/skins/simple/identifiers.js
@@ -4,3 +4,4 @@ export const TEXT_AREA = 'ReactPolymorphSimpleTextArea';
 export const BUTTON = 'ReactPolymorphSimpleButton';
 export const SELECT = 'ReactPolymorphSimpleSelect';
 export const CHECKBOX = 'ReactPolymorphSimpleCheckbox';
+export const SWITCH = 'ReactPolymorphSimpleSwitch';

--- a/source/themes/simple/SimpleSwitch.scss
+++ b/source/themes/simple/SimpleSwitch.scss
@@ -18,10 +18,10 @@ $switch-label-disabled-color: $theme-color-light-grey !default;
 }
 
 %switch {
-  width: 50px !important;
+  border-radius: 3px !important;
   height: 23px !important;
   margin-top: 0 !important;
-  border-radius: 3px !important;
+  width: 50px !important;
 }
 
 .root {
@@ -49,23 +49,23 @@ $switch-label-disabled-color: $theme-color-light-grey !default;
 }
 
 .switch {
-  position: relative;
   align-self: center;
   border-radius: 3px;
   box-sizing: border-box;
   flex-shrink: 0;
   height: $switch-track-height;
-  width: $switch-track-length;
+  position: relative;
   transition: background-color 200ms ease-in-out;
+  width: $switch-track-length;
 
   .thumb {
+    border-radius: 3px;
+    cursor: pointer;
+    height: $switch-track-height;
     position: absolute;
     top: 0;
-    width: $switch-track-height;
-    height: $switch-track-height;
-    cursor: pointer;
-    border-radius: 2px;
     transition: left 200ms ease-in-out;
+    width: $switch-track-height;
   }
 
   &.checked {

--- a/source/themes/simple/SimpleSwitch.scss
+++ b/source/themes/simple/SimpleSwitch.scss
@@ -1,0 +1,105 @@
+@import "theme";
+
+// OVERRIDABLE CONFIGURATION VARIABLES
+
+$switch-on-accent-color: #2f496e !default;
+$switch-off-accent-color: #b4bdca !default;
+$switch-thumb-accent-color: #ffffff !default;
+$switch-track-height: 23px !default;
+$switch-track-length: 50px !default;
+$switch-label-color: #5e6066 !default;
+$switch-label-disabled-color: $theme-color-light-grey !default;
+
+@mixin thumbBoxShadow ($color) {
+  box-shadow: -1.5px -1.5px 0 $color inset,
+  1.5px 1.5px 0 $color inset,
+  1.5px -1.5px 0 $color inset,
+  -1.5px 1.5px 0 $color inset !important;
+}
+
+%switch {
+  width: 50px !important;
+  height: 23px !important;
+  margin-top: 0 !important;
+  border-radius: 3px !important;
+}
+
+.root {
+  display: flex;
+  position: relative;
+  &:hover {
+    cursor: pointer;
+  }
+  &.disabled {
+    &:hover, .label:hover, .switch .thumb {
+      cursor: default;
+    }
+    .label {
+      color: $switch-label-disabled-color;
+    }
+  }
+}
+
+.input {
+  height: 0;
+  opacity: 0;
+  overflow: hidden;
+  position: absolute;
+  width: 0;
+}
+
+.switch {
+  position: relative;
+  align-self: center;
+  border-radius: 3px;
+  box-sizing: border-box;
+  flex-shrink: 0;
+  height: $switch-track-height;
+  width: $switch-track-length;
+  transition: background-color 200ms ease-in-out;
+
+  .thumb {
+    position: absolute;
+    top: 0;
+    width: $switch-track-height;
+    height: $switch-track-height;
+    cursor: pointer;
+    border-radius: 2px;
+    transition: left 200ms ease-in-out;
+  }
+
+  &.checked {
+    @extend %switch;
+    background-color: $switch-on-accent-color !important;
+    .thumb {
+      left: 27px !important;
+      @include thumbBoxShadow($switch-on-accent-color);
+      background-color: $switch-thumb-accent-color !important;
+    }
+  }
+
+  &:not(.checked) {
+    @extend %switch;
+    background-color: $switch-off-accent-color !important;
+    .thumb {
+      left: 0 !important;
+      @include thumbBoxShadow($switch-off-accent-color);
+      background-color: $switch-thumb-accent-color !important;
+    }
+  }
+}
+
+.label {
+  color: $switch-label-color;
+  font-family: $theme-font-light;
+  font-size: 16px;
+  line-height: 1.38;
+  margin-left: 20px;
+  white-space: normal;
+  &:hover {
+    cursor: pointer;
+  }
+  strong {
+    font-family: $theme-font-bold;
+  }
+}

--- a/stories/Switch.stories.js
+++ b/stories/Switch.stories.js
@@ -1,0 +1,45 @@
+import React from 'react';
+import { storiesOf, action } from '@kadira/storybook';
+import { observable, action as mobxAction } from 'mobx';
+import PropsObserver from './support/PropsObserver';
+import Checkbox from '../source/components/Checkbox';
+import SimpleSwitchSkin from '../source/skins/simple/SwitchSkin';
+
+storiesOf('Switch', module)
+
+  .addDecorator((story) => {
+    const onChangeAction = action('onChange');
+    const state = observable({
+      checked: false,
+      onChange: mobxAction((value, event) => {
+        state.checked = value;
+        onChangeAction(value, event);
+      })
+    });
+    return <PropsObserver propsForChildren={state}>{story()}</PropsObserver>;
+  })
+
+  // ====== Stories ======
+
+  .add('plain', () => <Checkbox skin={<SimpleSwitchSkin />} />)
+
+  .add('disabled', () => <Checkbox disabled skin={<SimpleSwitchSkin />} />)
+
+  .add('short label', () => <Checkbox label="My checkbox" skin={<SimpleSwitchSkin />} />)
+
+  .add('disabled with label', () => (
+    <Checkbox
+      disabled
+      label="My checkbox"
+      skin={<SimpleSwitchSkin />}
+    />
+  ))
+
+  .add('long label', () => (
+    <Checkbox
+      skin={<SimpleSwitchSkin />}
+      label="I understand that if this application is moved to another device or deleted,
+             my money can be only recovered with the backup phrase which
+             were written down in a secure place"
+    />
+  ));

--- a/stories/index.js
+++ b/stories/index.js
@@ -5,3 +5,4 @@ import './Button.stories';
 import './Select.stories';
 import './NumericInput.stories';
 import './Checkbox.stories';
+import './Switch.stories';


### PR DESCRIPTION
This PR adds a `SwitchSkin` which can be used with the `Checkbox` logic to render a switch:

<img width="521" alt="screenshot 2017-07-04 um 11 32 25" src="https://user-images.githubusercontent.com/172414/27826906-cf95d240-60ac-11e7-96b0-484fb68c2ac6.png">

<img width="520" alt="screenshot 2017-07-04 um 11 32 31" src="https://user-images.githubusercontent.com/172414/27826911-d317b9d8-60ac-11e7-94de-e4fb90bcdb3a.png">
