### PR TITLE
Fix/daef 349 Fix react-polymorph Textarea component CSS-class inheritance bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Changelog
 ### Fixes
 
 - Updated simple theme styles
+- Prevent CSS-classes inheritance on TextAreaSkin textarea element
 
 ### Features
 

--- a/source/skins/simple/TextAreaSkin.js
+++ b/source/skins/simple/TextAreaSkin.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import classnames from 'classnames';
-import { pickDOMProps } from '../../utils/props';
 import { themr } from 'react-css-themr';
 import { TEXT_AREA } from './identifiers';
+import { pickDOMProps } from '../../utils/props';
 import FormFieldSkin from './FormFieldSkin';
 import TextArea from '../../components/TextArea';
 import DefaultTextAreaTheme from '../../themes/simple/SimpleTextArea.scss';
@@ -12,7 +12,6 @@ export default themr(TEXT_AREA, DefaultTextAreaTheme, { withRef: true })((props)
     <textarea
       {...pickDOMProps(props)}
       className={classnames([
-        props.className,
         props.theme.textarea,
         props.disabled ? props.theme.disabled : null,
         props.error ? props.theme.errored : null,

--- a/source/themes/simple/SimpleFormField.scss
+++ b/source/themes/simple/SimpleFormField.scss
@@ -8,7 +8,7 @@ $form-field-label-color: #5e6066 !default;
 $form-field-label-margin-bottom: 10px !default;
 $form-field-error-font: $theme-font-regular !default;
 $form-field-error-font-size: 14px !default;
-$form-field-margin: 0 0 10px 0 !default;
+$form-field-error-margin: 1.5px 0 11.5px 0 !default;
 
 .root {
   position: relative;
@@ -19,6 +19,7 @@ $form-field-margin: 0 0 10px 0 !default;
   display: block;
   font-family: $form-field-label-font, sans-serif;
   font-size: $form-field-label-font-size;
+  line-height: 1.38;
   margin-bottom: $form-field-label-margin-bottom;
 }
 
@@ -27,7 +28,8 @@ $form-field-margin: 0 0 10px 0 !default;
   float: right;
   font-family: $form-field-error-font, sans-serif;
   font-size: $form-field-error-font-size;
-  margin: $form-field-margin;
+  line-height: 1.36;
+  margin: $form-field-error-margin;
 }
 
 .disabled {

--- a/source/themes/simple/SimpleTextArea.scss
+++ b/source/themes/simple/SimpleTextArea.scss
@@ -20,6 +20,7 @@ $textarea-error-color: $theme-color-error !default;
   border: $textarea-border;
   box-sizing: border-box;
   color: $textarea-color;
+  display: block;
   font-family: $textarea-font-family;
   font-size: $textarea-font-size;
   padding: $textarea-padding;


### PR DESCRIPTION
This PR introduces a fix which prevents CSS-class inheritance on TextAreaSkin textarea element.
When passing `className` property to Textarea component it should be consumed only by TextAreaSkin's top level element which is a `FormFieldSkin`.