### PR TITLE
[DAEF-342] adds basic modal dialog component

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "themes"
   ],
   "dependencies": {
-    "postinstall-build": "^5.0.0"
+    "postinstall-build": "^5.0.0",
+    "react-modal": "^2.2.1"
   },
   "peerDependencies": {
     "react": "^0.14 || ~15.4.0",

--- a/source/components/Modal.js
+++ b/source/components/Modal.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import SkinnableComponent from './SkinnableComponent';
+
+export default class Modal extends SkinnableComponent {
+  static propTypes = Object.assign({}, SkinnableComponent.propTypes, {
+    isActive: PropTypes.bool,
+    contentLabel: PropTypes.string,
+    onClose: PropTypes.func,
+    triggerCloseOnOverlayClick: PropTypes.bool
+  });
+
+  static defaultProps = {
+    isActive: false,
+    contentLabel: "Modal Dialog",
+    triggerCloseOnOverlayClick: true,
+  };
+}

--- a/source/skins/simple/ModalSkin.js
+++ b/source/skins/simple/ModalSkin.js
@@ -1,0 +1,20 @@
+import React from 'react';
+// import classnames from 'classnames';
+import ReactModal from 'react-modal';
+// import { pickDOMProps } from '../../utils/props';
+import { themr } from 'react-css-themr';
+import { MODAL } from './identifiers';
+import DefaultModalTheme from '../../themes/simple/SimpleModal.scss';
+
+export default themr(MODAL, DefaultModalTheme, { withRef: true })((props) => (
+  <ReactModal
+    contentLabel={props.contentLabel}
+    isOpen={props.isOpen}
+    onRequestClose={props.onClose}
+    shouldCloseOnOverlayClick={props.triggerCloseOnOverlayClick}
+    className={props.theme.modal}
+    overlayClassName={props.theme.overlay}
+  >
+    {props.children}
+  </ReactModal>
+));

--- a/source/skins/simple/identifiers.js
+++ b/source/skins/simple/identifiers.js
@@ -5,3 +5,4 @@ export const BUTTON = 'ReactPolymorphSimpleButton';
 export const SELECT = 'ReactPolymorphSimpleSelect';
 export const CHECKBOX = 'ReactPolymorphSimpleCheckbox';
 export const SWITCH = 'ReactPolymorphSimpleSwitch';
+export const MODAL = 'ReactPolymorphSimpleModal';

--- a/source/themes/simple/SimpleModal.scss
+++ b/source/themes/simple/SimpleModal.scss
@@ -1,0 +1,33 @@
+@import "theme";
+
+// OVERRIDABLE CONFIGURATION VARIABLES
+
+$modal-overlay-color: rgba(black, 0.6) !default;
+$modal-bg: white !default;
+$modal-border-radius: 10px !default;
+$modal-padding: 20px 30px !default;
+$modal-box-shadow: 0 5px 20px 0 rgba(0, 0, 0, 0.25);
+
+.overlay {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: $modal-overlay-color;
+}
+
+.modal {
+  min-width: 500px;
+  max-width: 640px;
+  border-radius: $modal-border-radius;
+  background: $modal-bg;
+  padding: $modal-padding;
+  box-shadow: $modal-box-shadow;
+  &:focus {
+    outline: none;
+  }
+}

--- a/stories/Modal.stories.js
+++ b/stories/Modal.stories.js
@@ -1,0 +1,61 @@
+import React from 'react';
+import { storiesOf } from '@kadira/storybook';
+import { observable, action as mobxAction } from 'mobx';
+import PropsObserver from './support/PropsObserver';
+import Modal from '../source/components/Modal';
+import Button from '../source/components/Button';
+import SimpleModalSkin from '../source/skins/simple/ModalSkin';
+import SimpleButtonSkin from '../source/skins/simple/ButtonSkin';
+import styles from './Modal.stories.scss';
+
+let state;
+const closeModal = mobxAction(() => { state.isOpen = false; });
+
+storiesOf('Modal', module)
+
+  .addDecorator((story) => {
+    state = observable({
+      isOpen: true,
+      contentLabel: "Example Modal",
+    });
+    return <PropsObserver propsForChildren={state}>{story()}</PropsObserver>;
+  })
+
+  // ====== Stories ======
+
+  .add('cancelable via overlay', () => (
+    <Modal
+      triggerCloseOnOverlayClick
+      onClose={closeModal}
+      skin={<SimpleModalSkin />}
+    >
+      <h1 className={styles.modalTitle}>
+        Click outside of modal to cancel
+      </h1>
+    </Modal>
+  ))
+
+  .add('cancelable via buttons', () => (
+    <Modal
+      triggerCloseOnOverlayClick={false}
+      skin={<SimpleModalSkin />}
+    >
+      <h1 className={styles.modalTitle}>
+        Are you sure you want to delete this thing?
+      </h1>
+      <div className={styles.buttonsContainer}>
+        <Button
+          className={styles.cancelButton}
+          label="Cancel"
+          onClick={closeModal}
+          skin={<SimpleButtonSkin />}
+        />
+        <Button
+          className={styles.deleteButton}
+          label="Delete"
+          onClick={closeModal}
+          skin={<SimpleButtonSkin />}
+        />
+      </div>
+    </Modal>
+  ));

--- a/stories/Modal.stories.scss
+++ b/stories/Modal.stories.scss
@@ -1,0 +1,35 @@
+@import "../source/themes/simple/theme";
+
+.modalTitle {
+  font-family: $theme-font-medium;
+  font-size: 16px;
+  text-align: center;
+}
+
+.buttonsContainer {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 40px;
+}
+
+.cancelButton {
+  width: calc(50% - 10px);
+  background-color: lightgrey;
+  &:not(.disabled) {
+    &:hover, &:active {
+      background-color: grey;
+      cursor: pointer;
+    }
+  }
+}
+
+.deleteButton {
+  width: calc(50% - 10px);
+  background-color: indianred;
+  &:not(.disabled) {
+    &:hover, &:active {
+      background-color: darkred;
+      cursor: pointer;
+    }
+  }
+}

--- a/stories/index.js
+++ b/stories/index.js
@@ -6,3 +6,4 @@ import './Select.stories';
 import './NumericInput.stories';
 import './Checkbox.stories';
 import './Switch.stories';
+import './Modal.stories';


### PR DESCRIPTION
This PR introduces a simple modal dialog component based on [react-modal](https://reactcommunity.org/react-modal/) (instead of react-polymorph, which is way too complicated for our needs):

<img width="749" alt="screenshot 2017-07-05 um 20 14 21" src="https://user-images.githubusercontent.com/172414/27880903-95fe5a6c-61be-11e7-8c41-26815b46f8fb.png">

**NOTE:** This component is very basic and does not support any kind of special functionality apart from the usual modal (close on overlay click etc.). All the "actions" like button clicks simply have to be defined by the using application … which makes more sense anyway because the requirements for the dialogs are very app specific anyway.