### PR TITLE
[DAEF-480] toggle dropdown on label clicks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+## Next Version
+
+### Fixes
+
+- Toggle dropdown on label clicks ([PR 15](https://github.com/input-output-hk/react-polymorph/pull/15))
+
 ## 0.3.2
 
 ### Features

--- a/source/components/Select.js
+++ b/source/components/Select.js
@@ -123,7 +123,8 @@ export default class Select extends FormField {
     return option && !option.isDisabled;
   };
 
-  focus = () => this.open();
+  // Focus the component - toggle dropdown isOpen state
+  focus = () => this.setState({ isOpen: !this.state.isOpen });
 
   open = () => {
     if (!this.state.isOpen) {

--- a/source/skins/simple/FormFieldSkin.js
+++ b/source/skins/simple/FormFieldSkin.js
@@ -14,7 +14,14 @@ export default themr(FORM_FIELD, DefaultFormFieldTheme, { withRef: true })((prop
     ])}
   >
     {props.error && <div className={props.theme.error}>{props.error}</div>}
-    {props.label && <label className={props.theme.label} onClick={props.component.focus ? props.component.focus : null}>{props.label}</label>}
+    {props.label && (
+      <label
+        className={props.theme.label}
+        onClick={props.component.focus ? props.component.focus : null}
+      >
+        {props.label}
+      </label>
+    )}
     {props.input}
   </div>
 ));


### PR DESCRIPTION
This PR makes dropdowns toggle their open state on label clicks, instead of only opening (but not closing) as described in https://issues.serokell.io/issue/DAEF-480.

I could not reproduce the second issue (small lag/delay on first open) on my machine. I won't spend more time on that since it's not a critical bug (and i can't fix it here).