### PR TITLE
[DAEF-488] allow react elements as checkbox and form field labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+## vNext
+
+### Features
+
+- Allow React element as `label` for checkboxes and form fields ([PR 17](https://github.com/input-output-hk/react-polymorph/pull/17))
+
 ## 0.3.4
 
 ### Fixes

--- a/source/components/Checkbox.js
+++ b/source/components/Checkbox.js
@@ -1,11 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import SkinnableComponent from './SkinnableComponent';
+import { LabelProp } from "../utils/props";
 
 export default class Checkbox extends SkinnableComponent {
   static propTypes = Object.assign({}, SkinnableComponent.propTypes, {
     checked: PropTypes.bool,
-    label: PropTypes.string,
+    label: LabelProp,
     onChange: PropTypes.func,
     onFocus: PropTypes.func,
     onBlur: PropTypes.func,

--- a/source/components/FormField.js
+++ b/source/components/FormField.js
@@ -1,12 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import SkinnableComponent from './SkinnableComponent';
+import { LabelProp } from "../utils/props";
 
 export default class FormField extends SkinnableComponent {
 
   static propTypes = Object.assign({}, SkinnableComponent.propTypes, {
     skin: PropTypes.element.isRequired,
-    label: PropTypes.string,
+    label: LabelProp,
     onChange: PropTypes.func,
     onFocus: PropTypes.func,
     onBlur: PropTypes.func,

--- a/source/utils/props.js
+++ b/source/utils/props.js
@@ -1,6 +1,7 @@
 import DOMProperty from 'react-dom/lib/DOMProperty';
 import EventPluginRegistry from 'react-dom/lib/EventPluginRegistry';
 import { pickBy } from 'lodash';
+import PropTypes from 'prop-types';
 
 const reactProps = {
   children: true,
@@ -22,3 +23,5 @@ export const pickDOMProps = (props) => pickBy(props, (_, key) => (
   reactProps.hasOwnProperty(key) && reactProps[key] ||
   EventPluginRegistry.registrationNameModules.hasOwnProperty(key)
 ));
+
+export const LabelProp = PropTypes.oneOfType([PropTypes.string, PropTypes.element]);

--- a/stories/Checkbox.stories.js
+++ b/stories/Checkbox.stories.js
@@ -42,4 +42,11 @@ storiesOf('Checkbox', module)
              my money can be only recovered with the backup phrase which
              were written down in a secure place"
     />
+  ))
+
+  .add('html label', () => (
+    <Checkbox
+      skin={<SimpleCheckboxSkin />}
+      label={<div>Example for a <strong>bold</strong> word in an html label</div>}
+    />
   ));


### PR DESCRIPTION
This PR improves the prop types used for `label` property in various components to also allow React elements in addition to strings:

![screenshot 2017-09-19 um 15 23 41](https://user-images.githubusercontent.com/172414/30594605-dd512ab8-9d4e-11e7-9a7c-ec64fabf5fa6.png)

Before this triggered a prop types error.