### PR TITLE
Feature/provide unstyled skin parts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ Changelog
 
 ## vNext
 
-### Features
+### Fixes
 
 - Expose raw component skins ([PR 19](https://github.com/input-output-hk/react-polymorph/pull/19)) 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+## vNext
+
+### Features
+
+- Expose raw component skins ([PR 19](https://github.com/input-output-hk/react-polymorph/pull/19)) 
+
 ## 0.4.0
 
 ### Features

--- a/source/skins/simple/AutocompleteSkin.js
+++ b/source/skins/simple/AutocompleteSkin.js
@@ -1,102 +1,10 @@
 import React from 'react';
-import _ from 'lodash';
-import classnames from 'classnames';
 import { themr } from 'react-css-themr';
 import { AUTOCOMPLETE } from './identifiers';
-import FormFieldSkin from './FormFieldSkin';
-import Autocomplete from '../../components/Autocomplete';
 import DefaultAutocompleteTheme from '../../themes/simple/SimpleAutocomplete.scss';
+import { autocompleteSkinFactory } from './raw/AutocompleteSkin';
+import FormFieldSkin from "./FormFieldSkin";
 
-export default themr(AUTOCOMPLETE, DefaultAutocompleteTheme, { withRef: true })((props) => {
-  const filteredAndLimitedSuggestions = _.slice(props.filteredWords, 0, props.maxVisibleSuggestions);
-  const isFirstOptionHighlighted = props.highlightedOptionIndex === 0;
-
-  let selectedWords = props.selectedWords && props.selectedWords.map((selectedWord, index) => {
-    return (
-      <span className={props.theme.selectedWordBox} key={index}>
-        <span className={props.theme.selectedWordValue}>
-          {selectedWord}
-          <span
-            className={props.theme.selectedWordRemoveButton}
-            onClick={props.component.removeWord.bind(null, index)}
-          >
-            &times;
-          </span>
-        </span>
-      </span>
-    );
-  });
-
-  // show placeholder only if no maximum selections declared or maximum not reached
-  const canMoreWordsBeSelected = props.selectedWords.length < props.maxSelections;
-  let placeholder = (!props.maxSelections || canMoreWordsBeSelected) ? props.placeholder : '';
-
-  // selected words and input for enter new one
-  const autocompleteContent = (
-    <div className={props.theme.selectedWords}>
-      {selectedWords}
-      <input
-        className={props.theme.selectWords}
-        onKeyDown={props.component.onKeyDown}
-        placeholder={placeholder}
-        onKeyUp={props.component.clearInvalidChars}
-        ref={element => {
-          props.component.registerSkinPart(Autocomplete.SKIN_PARTS.INPUT, element);
-        }}
-      />
-    </div>
-  );
-
-  return (
-    <div ref={(element) => props.component.registerSkinPart(Autocomplete.SKIN_PARTS.ROOT, element)}>
-    <FormFieldSkin input={
-      <div
-        className={props.theme.autocompleteWrapper}
-        onClick={props.component.handleAutocompleteClick}
-      >
-        <div
-          className={classnames([
-            props.theme.autocompleteContent,
-            props.isSuggestionsOpened ? props.theme.opened : null,
-            props.selectedWords.length ? props.theme.hasSelectedWords : null,
-            props.error ? props.theme.errored : null,
-          ])}
-          ref={element => {
-            props.component.registerSkinPart(Autocomplete.SKIN_PARTS.SUGGESTIONS, element);
-          }}
-        >
-          {autocompleteContent}
-        </div>
-        {props.suggestedWords &&
-          <ul
-            className={classnames([
-              props.theme.suggestionsList,
-              props.isSuggestionsOpened ? props.theme.opened : null,
-              isFirstOptionHighlighted ? props.theme.firstOptionHighlighted : null,
-            ])}
-          >
-            {props.filteredWords.length ? filteredAndLimitedSuggestions.map((option, index) => {
-              return (
-                <li
-                  key={index}
-                  className={classnames([
-                    props.theme.suggestionsListItem,
-                    index === props.highlightedOptionIndex ? props.theme.highlighted : null,
-                  ])}
-                  onMouseEnter={() => props.component.setHighlightedOptionIndex(index)}
-                  onClick={(event) => props.component.updateSelectedWords(event)}
-                >
-                  {option}
-                </li>
-              );
-            }) :
-            <li className={props.theme.suggestionsListItem}>No matching results</li>
-          }
-          </ul>
-        }
-      </div>
-
-    } {...props} />
-    </div>
-  );
-});
+export default themr(AUTOCOMPLETE, DefaultAutocompleteTheme)(
+  autocompleteSkinFactory(FormFieldSkin)
+);

--- a/source/skins/simple/ButtonSkin.js
+++ b/source/skins/simple/ButtonSkin.js
@@ -1,19 +1,7 @@
 import React from 'react';
-import classnames from 'classnames';
-import { pickDOMProps } from '../../utils/props';
 import { themr } from 'react-css-themr';
 import { BUTTON } from './identifiers';
 import DefaultButtonTheme from '../../themes/simple/SimpleButton.scss';
+import ButtonSkin from "./raw/ButtonSkin";
 
-export default themr(BUTTON, DefaultButtonTheme, { withRef: true })((props) => (
-  <button
-    {...pickDOMProps(props)}
-    className={classnames([
-      props.className,
-      props.theme.root,
-      props.disabled ? props.theme.disabled : null,
-    ])}
-  >
-    {props.label}
-  </button>
-));
+export default themr(BUTTON, DefaultButtonTheme)(ButtonSkin);

--- a/source/skins/simple/CheckboxSkin.js
+++ b/source/skins/simple/CheckboxSkin.js
@@ -1,33 +1,7 @@
 import React from 'react';
-import classnames from 'classnames';
-import { pickDOMProps } from '../../utils/props';
 import { themr } from 'react-css-themr';
 import { CHECKBOX } from './identifiers';
 import DefaultCheckboxTheme from '../../themes/simple/SimpleCheckbox.scss';
+import CheckboxSkin from "./raw/CheckboxSkin";
 
-export default themr(CHECKBOX, DefaultCheckboxTheme, { withRef: true })((props) => (
-  <div
-    className={classnames([
-      props.className,
-      props.theme.root,
-      props.disabled ? props.theme.disabled : null,
-      props.checked ? props.theme.checked : null,
-    ])}
-    onClick={(event) => {
-      if (!props.disabled && props.onChange) {
-        props.onChange(!props.checked, event);
-      }
-    }}
-  >
-    <input
-      {...pickDOMProps(props)}
-      className={props.theme.input}
-      type="checkbox"
-    />
-    <div className={classnames([
-      props.theme.check,
-      props.checked ? props.theme.checked : null,
-    ])} />
-    {props.label ? (<label className={props.theme.label}>{props.label}</label>) : null}
-  </div>
-));
+export default themr(CHECKBOX, DefaultCheckboxTheme)(CheckboxSkin);

--- a/source/skins/simple/FormFieldSkin.js
+++ b/source/skins/simple/FormFieldSkin.js
@@ -1,27 +1,7 @@
 import React from 'react';
-import classnames from 'classnames';
 import { themr } from 'react-css-themr';
 import { FORM_FIELD } from './identifiers';
 import DefaultFormFieldTheme from '../../themes/simple/SimpleFormField.scss';
+import FormFieldSkin from "./raw/FormFieldSkin";
 
-export default themr(FORM_FIELD, DefaultFormFieldTheme, { withRef: true })((props) => (
-  <div
-    className={classnames([
-      props.className,
-      props.theme.root,
-      props.disabled ? props.theme.disabled : null,
-      props.error ? props.theme.errored : null,
-    ])}
-  >
-    {props.error && <div className={props.theme.error}>{props.error}</div>}
-    {props.label && (
-      <label
-        className={props.theme.label}
-        onClick={props.component.focus ? props.component.focus : null}
-      >
-        {props.label}
-      </label>
-    )}
-    {props.input}
-  </div>
-));
+export default themr(FORM_FIELD, DefaultFormFieldTheme)(FormFieldSkin);

--- a/source/skins/simple/InputSkin.js
+++ b/source/skins/simple/InputSkin.js
@@ -1,22 +1,8 @@
 import React from 'react';
-import classnames from 'classnames';
 import { themr } from 'react-css-themr';
 import { INPUT } from './identifiers';
-import { pickDOMProps } from '../../utils/props';
-import FormFieldSkin from './FormFieldSkin';
-import Input from '../../components/Input';
 import DefaultInputTheme from '../../themes/simple/SimpleInput.scss';
+import { inputSkinFactory } from "./raw/InputSkin";
+import FormFieldSkin from "./FormFieldSkin";
 
-export default themr(INPUT, DefaultInputTheme, { withRef: true })((props) => (
-  <FormFieldSkin input={
-    <input
-      {...pickDOMProps(props)}
-      className={classnames([
-        props.theme.input,
-        props.disabled ? props.theme.disabled : null,
-        props.error ? props.theme.errored : null,
-      ])}
-      ref={input => props.component.registerSkinPart(Input.SKIN_PARTS.INPUT, input)}
-    />
-  } {...props} />
-));
+export default themr(INPUT, DefaultInputTheme)(inputSkinFactory(FormFieldSkin));

--- a/source/skins/simple/ModalSkin.js
+++ b/source/skins/simple/ModalSkin.js
@@ -1,20 +1,7 @@
 import React from 'react';
-// import classnames from 'classnames';
-import ReactModal from 'react-modal';
-// import { pickDOMProps } from '../../utils/props';
 import { themr } from 'react-css-themr';
 import { MODAL } from './identifiers';
 import DefaultModalTheme from '../../themes/simple/SimpleModal.scss';
+import ModalSkin from "./raw/ModalSkin";
 
-export default themr(MODAL, DefaultModalTheme, { withRef: true })((props) => (
-  <ReactModal
-    contentLabel={props.contentLabel}
-    isOpen={props.isOpen}
-    onRequestClose={props.onClose}
-    shouldCloseOnOverlayClick={props.triggerCloseOnOverlayClick}
-    className={props.theme.modal}
-    overlayClassName={props.theme.overlay}
-  >
-    {props.children}
-  </ReactModal>
-));
+export default themr(MODAL, DefaultModalTheme)(ModalSkin);

--- a/source/skins/simple/SelectSkin.js
+++ b/source/skins/simple/SelectSkin.js
@@ -1,70 +1,8 @@
-import React, { Component } from 'react';
-import classnames from 'classnames';
+import React from 'react';
 import { themr } from 'react-css-themr';
 import { SELECT } from './identifiers';
-import InputSkin from './InputSkin';
-import Select from '../../components/Select';
 import DefaultSelectTheme from '../../themes/simple/SimpleSelect.scss';
+import { selectSkinFactory } from "./raw/SelectSkin";
+import InputSkin from "./InputSkin";
 
-class SelectSkin extends Component {
-
-  render() {
-    const {
-      component, theme, className, options, optionRenderer, isOpen,
-      placeholder, label, error, isOpeningUpward
-    } = this.props;
-    const selectedOption = component.getSelectedOption();
-    const inputValue = selectedOption ? selectedOption.label : '';
-    const highlightedOptionIndex = component.getHighlightedOptionIndex();
-    const isFirstOptionHighlighted = highlightedOptionIndex === 0;
-    return (
-      <div
-        className={classnames([
-          className,
-          theme.select,
-          isOpen ? theme.isOpen : null,
-          isOpeningUpward ? theme.openUpward : null,
-        ])}
-        ref={(element) => component.registerSkinPart(Select.SKIN_PARTS.ROOT, element)}
-      >
-        <InputSkin
-          className={theme.selectInput}
-          label={label}
-          value={inputValue}
-          onClick={component.handleInputClick}
-          component={component}
-          placeholder={placeholder}
-          error={error}
-          readOnly
-        />
-        <ul
-          className={classnames([
-            theme.options,
-            isFirstOptionHighlighted ? theme.firstOptionHighlighted : null,
-          ])}
-          ref={(element) => component.registerSkinPart(Select.SKIN_PARTS.OPTIONS, element)}>
-          {(isOpeningUpward ? options.slice().reverse() : options).map((option, index) => {
-            return (
-              <li
-                key={index}
-                className={classnames([
-                  theme.option,
-                  component.isSelectedOption(option) ? theme.selectedOption : null,
-                  component.isHighlightedOption(index) ? theme.highlightedOption : null,
-                  option.isDisabled ? theme.disabledOption : null,
-                ])}
-                onClick={(event) => component.handleClickOnOption(option, event)}
-                onMouseEnter={() => component.setHighlightedOptionIndex(index)}
-              >
-                {optionRenderer ? optionRenderer(option) : option.label}
-              </li>
-            );
-          })}
-        </ul>
-      </div>
-    );
-  }
-
-};
-
-export default themr(SELECT, DefaultSelectTheme, { withRef: true })(SelectSkin);
+export default themr(SELECT, DefaultSelectTheme)(selectSkinFactory(InputSkin));

--- a/source/skins/simple/SwitchSkin.js
+++ b/source/skins/simple/SwitchSkin.js
@@ -1,36 +1,7 @@
 import React from 'react';
-import classnames from 'classnames';
-import { pickDOMProps } from '../../utils/props';
 import { themr } from 'react-css-themr';
 import { SWITCH } from './identifiers';
 import DefaultSwitchTheme from '../../themes/simple/SimpleSwitch.scss';
+import SwitchSkin from "./raw/SwitchSkin";
 
-export default themr(SWITCH, DefaultSwitchTheme, { withRef: true })((props) => (
-  <div
-    className={classnames([
-      props.className,
-      props.theme.root,
-      props.disabled ? props.theme.disabled : null,
-      props.checked ? props.theme.checked : null,
-    ])}
-    onClick={(event) => {
-      if (!props.disabled && props.onChange) {
-        props.onChange(!props.checked, event);
-      }
-    }}
-  >
-    <input
-      {...pickDOMProps(props)}
-      className={props.theme.input}
-      readOnly
-      type="checkbox"
-    />
-    <div className={classnames([
-      props.theme.switch,
-      props.checked ? props.theme.checked : null,
-    ])}>
-      <span className={props.theme.thumb} />
-    </div>
-    {props.label ? (<label className={props.theme.label}>{props.label}</label>) : null}
-  </div>
-));
+export default themr(SWITCH, DefaultSwitchTheme)(SwitchSkin);

--- a/source/skins/simple/TextAreaSkin.js
+++ b/source/skins/simple/TextAreaSkin.js
@@ -1,24 +1,8 @@
 import React from 'react';
-import classnames from 'classnames';
 import { themr } from 'react-css-themr';
 import { TEXT_AREA } from './identifiers';
-import { pickDOMProps } from '../../utils/props';
-import FormFieldSkin from './FormFieldSkin';
-import TextArea from '../../components/TextArea';
 import DefaultTextAreaTheme from '../../themes/simple/SimpleTextArea.scss';
+import { textAreaSkinFactory } from "./raw/TextAreaSkin";
+import FormFieldSkin from "./FormFieldSkin";
 
-export default themr(TEXT_AREA, DefaultTextAreaTheme, { withRef: true })((props) => (
-  <FormFieldSkin input={
-    <textarea
-      {...pickDOMProps(props)}
-      className={classnames([
-        props.theme.textarea,
-        props.disabled ? props.theme.disabled : null,
-        props.error ? props.theme.errored : null,
-      ])}
-      ref={textarea => {
-        props.component.registerSkinPart(TextArea.SKIN_PARTS.TEXT_AREA, textarea);
-      }}
-    />
-  } {...props} />
-));
+export default themr(TEXT_AREA, DefaultTextAreaTheme)(textAreaSkinFactory(FormFieldSkin));

--- a/source/skins/simple/TogglerSkin.js
+++ b/source/skins/simple/TogglerSkin.js
@@ -1,42 +1,7 @@
 import React from 'react';
-import classnames from 'classnames';
-import { pickDOMProps } from '../../utils/props';
 import { themr } from 'react-css-themr';
 import { TOGGLER } from './identifiers';
 import DefaultTogglerTheme from '../../themes/simple/SimpleToggler.scss';
+import TogglerSkin from "./raw/TogglerSkin";
 
-export default themr(TOGGLER, DefaultTogglerTheme, { withRef: true })((props) => (
-  <div
-    className={classnames([
-      props.className,
-      props.theme.root,
-      props.disabled ? props.theme.disabled : null,
-    ])}
-    onClick={(event) => {
-      if (!props.disabled && props.onChange) {
-        props.onChange(!props.checked, event);
-      }
-    }}
-  >
-    <input
-      {...pickDOMProps(props)}
-      className={props.theme.input}
-      readOnly
-      type="checkbox"
-    />
-    <div className={props.theme.toggler}>
-      <span className={classnames([
-        props.theme.label,
-        props.checked ? props.theme.checked : null,
-      ])}>
-        {props.labelLeft}
-      </span>
-      <span className={classnames([
-        props.theme.label,
-        props.checked ? null : props.theme.checked,
-      ])}>
-        {props.labelRight}
-      </span>
-    </div>
-  </div>
-));
+export default themr(TOGGLER, DefaultTogglerTheme)(TogglerSkin);

--- a/source/skins/simple/raw/AutocompleteSkin.js
+++ b/source/skins/simple/raw/AutocompleteSkin.js
@@ -1,0 +1,119 @@
+import React from 'react';
+import _ from 'lodash';
+import classnames from 'classnames';
+import { themr } from 'react-css-themr';
+import { AUTOCOMPLETE } from '../identifiers';
+import RawFormFieldSkin from './FormFieldSkin';
+import Autocomplete from '../../../components/Autocomplete';
+
+/**
+ * The raw skin for the Autocomplete component.
+ *
+ * Since the skin uses raw sub-components by default, it exports this
+ * factory method to make this configurable from the outside. This
+ * is needed to provide components with a default skin (see one level up).
+ *
+ * @param FormFieldSkin
+ * @returns {Component}
+ */
+
+export const autocompleteSkinFactory = (FormFieldSkin) => (
+  (props) => {
+    const filteredAndLimitedSuggestions = _.slice(props.filteredWords, 0, props.maxVisibleSuggestions);
+    const isFirstOptionHighlighted = props.highlightedOptionIndex === 0;
+
+    let selectedWords = props.selectedWords && props.selectedWords.map((selectedWord, index) => {
+      return (
+        <span className={props.theme.selectedWordBox} key={index}>
+        <span className={props.theme.selectedWordValue}>
+          {selectedWord}
+          <span
+            className={props.theme.selectedWordRemoveButton}
+            onClick={props.component.removeWord.bind(null, index)}
+          >
+            &times;
+          </span>
+        </span>
+      </span>
+      );
+    });
+
+    // show placeholder only if no maximum selections declared or maximum not reached
+    const canMoreWordsBeSelected = props.selectedWords.length < props.maxSelections;
+    let placeholder = (!props.maxSelections || canMoreWordsBeSelected) ? props.placeholder : '';
+
+    // selected words and input for enter new one
+    const autocompleteContent = (
+      <div className={props.theme.selectedWords}>
+        {selectedWords}
+        <input
+          className={props.theme.selectWords}
+          onKeyDown={props.component.onKeyDown}
+          placeholder={placeholder}
+          onKeyUp={props.component.clearInvalidChars}
+          ref={element => {
+            props.component.registerSkinPart(Autocomplete.SKIN_PARTS.INPUT, element);
+          }}
+        />
+      </div>
+    );
+
+    return (
+      <div ref={(element) => props.component.registerSkinPart(Autocomplete.SKIN_PARTS.ROOT, element)}>
+        <FormFieldSkin input={
+          <div
+            className={props.theme.autocompleteWrapper}
+            onClick={props.component.handleAutocompleteClick}
+          >
+            <div
+              className={classnames([
+                props.theme.autocompleteContent,
+                props.isSuggestionsOpened ? props.theme.opened : null,
+                props.selectedWords.length ? props.theme.hasSelectedWords : null,
+                props.error ? props.theme.errored : null,
+              ])}
+              ref={element => {
+                props.component.registerSkinPart(Autocomplete.SKIN_PARTS.SUGGESTIONS, element);
+              }}
+            >
+              {autocompleteContent}
+            </div>
+            {props.suggestedWords &&
+            <ul
+              className={classnames([
+                props.theme.suggestionsList,
+                props.isSuggestionsOpened ? props.theme.opened : null,
+                isFirstOptionHighlighted ? props.theme.firstOptionHighlighted : null,
+              ])}
+            >
+              {props.filteredWords.length ? filteredAndLimitedSuggestions.map((option, index) => {
+                  return (
+                    <li
+                      key={index}
+                      className={classnames([
+                        props.theme.suggestionsListItem,
+                        index === props.highlightedOptionIndex ? props.theme.highlighted : null,
+                      ])}
+                      onMouseEnter={() => props.component.setHighlightedOptionIndex(index)}
+                      onClick={(event) => props.component.updateSelectedWords(event)}
+                    >
+                      {option}
+                    </li>
+                  );
+                }) :
+                <li className={props.theme.suggestionsListItem}>No matching results</li>
+              }
+            </ul>
+            }
+          </div>
+
+        } {...props} />
+      </div>
+    );
+  }
+);
+
+/**
+ * Export the raw version of this component which does not include any styles.
+ */
+export default themr(AUTOCOMPLETE)(autocompleteSkinFactory(RawFormFieldSkin));

--- a/source/skins/simple/raw/ButtonSkin.js
+++ b/source/skins/simple/raw/ButtonSkin.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import classnames from 'classnames';
+import { pickDOMProps } from '../../../utils/props';
+import { themr } from 'react-css-themr';
+import { BUTTON } from '../identifiers';
+
+export default themr(BUTTON)((props) => (
+  <button
+    {...pickDOMProps(props)}
+    className={classnames([
+      props.className,
+      props.theme.root,
+      props.disabled ? props.theme.disabled : null,
+    ])}
+  >
+    {props.label}
+  </button>
+));

--- a/source/skins/simple/raw/CheckboxSkin.js
+++ b/source/skins/simple/raw/CheckboxSkin.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import classnames from 'classnames';
+import { pickDOMProps } from '../../../utils/props';
+import { themr } from 'react-css-themr';
+import { CHECKBOX } from '../identifiers';
+
+export default themr(CHECKBOX)((props) => (
+  <div
+    className={classnames([
+      props.className,
+      props.theme.root,
+      props.disabled ? props.theme.disabled : null,
+      props.checked ? props.theme.checked : null,
+    ])}
+    onClick={(event) => {
+      if (!props.disabled && props.onChange) {
+        props.onChange(!props.checked, event);
+      }
+    }}
+  >
+    <input
+      {...pickDOMProps(props)}
+      className={props.theme.input}
+      type="checkbox"
+    />
+    <div className={classnames([
+      props.theme.check,
+      props.checked ? props.theme.checked : null,
+    ])} />
+    {props.label ? (<label className={props.theme.label}>{props.label}</label>) : null}
+  </div>
+));

--- a/source/skins/simple/raw/FormFieldSkin.js
+++ b/source/skins/simple/raw/FormFieldSkin.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import classnames from 'classnames';
+import { themr } from 'react-css-themr';
+import { FORM_FIELD } from '../identifiers';
+
+export default themr(FORM_FIELD)((props) => (
+  <div
+    className={classnames([
+      props.className,
+      props.theme.root,
+      props.disabled ? props.theme.disabled : null,
+      props.error ? props.theme.errored : null,
+    ])}
+  >
+    {props.error && <div className={props.theme.error}>{props.error}</div>}
+    {props.label && (
+      <label
+        className={props.theme.label}
+        onClick={props.component.focus ? props.component.focus : null}
+      >
+        {props.label}
+      </label>
+    )}
+    {props.input}
+  </div>
+));

--- a/source/skins/simple/raw/InputSkin.js
+++ b/source/skins/simple/raw/InputSkin.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import classnames from 'classnames';
+import { themr } from 'react-css-themr';
+import { INPUT } from '../identifiers';
+import { pickDOMProps } from '../../../utils/props';
+import RawFormFieldSkin from './FormFieldSkin';
+import Input from '../../../components/Input';
+
+export const inputSkinFactory = (FormFieldSkin) => (
+  (props) => (
+    <FormFieldSkin input={
+      <input
+        {...pickDOMProps(props)}
+        className={classnames([
+          props.theme.input,
+          props.disabled ? props.theme.disabled : null,
+          props.error ? props.theme.errored : null,
+        ])}
+        ref={input => props.component.registerSkinPart(Input.SKIN_PARTS.INPUT, input)}
+      />
+    } {...props} />
+  )
+);
+
+export default themr(INPUT)(inputSkinFactory(RawFormFieldSkin));

--- a/source/skins/simple/raw/ModalSkin.js
+++ b/source/skins/simple/raw/ModalSkin.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import ReactModal from 'react-modal';
+import { themr } from 'react-css-themr';
+import { MODAL } from '../identifiers';
+
+export default themr(MODAL)((props) => (
+  <ReactModal
+    contentLabel={props.contentLabel}
+    isOpen={props.isOpen}
+    onRequestClose={props.onClose}
+    shouldCloseOnOverlayClick={props.triggerCloseOnOverlayClick}
+    className={props.theme.modal}
+    overlayClassName={props.theme.overlay}
+  >
+    {props.children}
+  </ReactModal>
+));

--- a/source/skins/simple/raw/SelectSkin.js
+++ b/source/skins/simple/raw/SelectSkin.js
@@ -1,0 +1,72 @@
+import React, { Component } from 'react';
+import classnames from 'classnames';
+import { themr } from 'react-css-themr';
+import { SELECT } from '../identifiers';
+import RawInputSkin from './InputSkin';
+import Select from '../../../components/Select';
+
+export const selectSkinFactory = (InputSkin) => (
+
+  class SelectSkin extends Component {
+
+    render() {
+      const {
+        component, theme, className, options, optionRenderer, isOpen,
+        placeholder, label, error, isOpeningUpward
+      } = this.props;
+      const selectedOption = component.getSelectedOption();
+      const inputValue = selectedOption ? selectedOption.label : '';
+      const highlightedOptionIndex = component.getHighlightedOptionIndex();
+      const isFirstOptionHighlighted = highlightedOptionIndex === 0;
+      return (
+        <div
+          className={classnames([
+            className,
+            theme.select,
+            isOpen ? theme.isOpen : null,
+            isOpeningUpward ? theme.openUpward : null,
+          ])}
+          ref={(element) => component.registerSkinPart(Select.SKIN_PARTS.ROOT, element)}
+        >
+          <InputSkin
+            className={theme.selectInput}
+            label={label}
+            value={inputValue}
+            onClick={component.handleInputClick}
+            component={component}
+            placeholder={placeholder}
+            error={error}
+            readOnly
+          />
+          <ul
+            className={classnames([
+              theme.options,
+              isFirstOptionHighlighted ? theme.firstOptionHighlighted : null,
+            ])}
+            ref={(element) => component.registerSkinPart(Select.SKIN_PARTS.OPTIONS, element)}>
+            {(isOpeningUpward ? options.slice().reverse() : options).map((option, index) => {
+              return (
+                <li
+                  key={index}
+                  className={classnames([
+                    theme.option,
+                    component.isSelectedOption(option) ? theme.selectedOption : null,
+                    component.isHighlightedOption(index) ? theme.highlightedOption : null,
+                    option.isDisabled ? theme.disabledOption : null,
+                  ])}
+                  onClick={(event) => component.handleClickOnOption(option, event)}
+                  onMouseEnter={() => component.setHighlightedOptionIndex(index)}
+                >
+                  {optionRenderer ? optionRenderer(option) : option.label}
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      );
+    }
+
+  }
+);
+
+export default themr(SELECT)(selectSkinFactory(RawInputSkin));

--- a/source/skins/simple/raw/SwitchSkin.js
+++ b/source/skins/simple/raw/SwitchSkin.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import classnames from 'classnames';
+import { pickDOMProps } from '../../../utils/props';
+import { themr } from 'react-css-themr';
+import { SWITCH } from '../identifiers';
+
+export default themr(SWITCH)((props) => (
+  <div
+    className={classnames([
+      props.className,
+      props.theme.root,
+      props.disabled ? props.theme.disabled : null,
+      props.checked ? props.theme.checked : null,
+    ])}
+    onClick={(event) => {
+      if (!props.disabled && props.onChange) {
+        props.onChange(!props.checked, event);
+      }
+    }}
+  >
+    <input
+      {...pickDOMProps(props)}
+      className={props.theme.input}
+      readOnly
+      type="checkbox"
+    />
+    <div className={classnames([
+      props.theme.switch,
+      props.checked ? props.theme.checked : null,
+    ])}>
+      <span className={props.theme.thumb} />
+    </div>
+    {props.label ? (<label className={props.theme.label}>{props.label}</label>) : null}
+  </div>
+));

--- a/source/skins/simple/raw/TextAreaSkin.js
+++ b/source/skins/simple/raw/TextAreaSkin.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import classnames from 'classnames';
+import { themr } from 'react-css-themr';
+import { TEXT_AREA } from '../identifiers';
+import { pickDOMProps } from '../../../utils/props';
+import RawFormFieldSkin from './FormFieldSkin';
+import TextArea from '../../../components/TextArea';
+
+export const textAreaSkinFactory = (FormFieldSkin) => (
+  (props) => (
+    <FormFieldSkin input={
+      <textarea
+        {...pickDOMProps(props)}
+        className={classnames([
+          props.theme.textarea,
+          props.disabled ? props.theme.disabled : null,
+          props.error ? props.theme.errored : null,
+        ])}
+        ref={textarea => {
+          props.component.registerSkinPart(TextArea.SKIN_PARTS.TEXT_AREA, textarea);
+        }}
+      />
+    } {...props} />
+  )
+);
+
+export default themr(TEXT_AREA)(textAreaSkinFactory(RawFormFieldSkin));

--- a/source/skins/simple/raw/TogglerSkin.js
+++ b/source/skins/simple/raw/TogglerSkin.js
@@ -1,0 +1,41 @@
+import React from 'react';
+import classnames from 'classnames';
+import { pickDOMProps } from '../../../utils/props';
+import { themr } from 'react-css-themr';
+import { TOGGLER } from '../identifiers';
+
+export default themr(TOGGLER)((props) => (
+  <div
+    className={classnames([
+      props.className,
+      props.theme.root,
+      props.disabled ? props.theme.disabled : null,
+    ])}
+    onClick={(event) => {
+      if (!props.disabled && props.onChange) {
+        props.onChange(!props.checked, event);
+      }
+    }}
+  >
+    <input
+      {...pickDOMProps(props)}
+      className={props.theme.input}
+      readOnly
+      type="checkbox"
+    />
+    <div className={props.theme.toggler}>
+      <span className={classnames([
+        props.theme.label,
+        props.checked ? props.theme.checked : null,
+      ])}>
+        {props.labelLeft}
+      </span>
+      <span className={classnames([
+        props.theme.label,
+        props.checked ? null : props.theme.checked,
+      ])}>
+        {props.labelRight}
+      </span>
+    </div>
+  </div>
+));

--- a/stories/Autocomplete.stories.js
+++ b/stories/Autocomplete.stories.js
@@ -53,7 +53,6 @@ storiesOf('Autocomplete', module)
   .add('Enter mnemonics (9-word mnemonic) - not sorted', () => (
     <Autocomplete
       label="Recovery phrase"
-      placeholder="Enter recovery phrase"
       suggestedWords = {SUGGESTED_WORDS}
       placeholder="Enter mnemonic..."
       sortAlphabetically={false}
@@ -66,7 +65,6 @@ storiesOf('Autocomplete', module)
   .add('Enter mnemonics (9-word mnemonic) - sorted with multiple same selections', () => (
     <Autocomplete
       label="Recovery phrase"
-      placeholder="Enter recovery phrase"
       suggestedWords = {SUGGESTED_WORDS}
       placeholder="Enter mnemonic..."
       maxSelections={9}
@@ -77,7 +75,6 @@ storiesOf('Autocomplete', module)
   .add('Enter mnemonics - (12-word mnemonic) with 5 visible suggestions', () => (
     <Autocomplete
       label="Recovery phrase"
-      placeholder="Enter recovery phrase"
       suggestedWords = {SUGGESTED_WORDS}
       placeholder="Enter mnemonic..."
       maxSelections={12}
@@ -89,7 +86,6 @@ storiesOf('Autocomplete', module)
   .add('Enter mnemonics - (12-word mnemonic) with 5 visible suggestions and regex that allows only letters', () => (
     <Autocomplete
       label="Recovery phrase"
-      placeholder="Enter recovery phrase"
       suggestedWords = {SUGGESTED_WORDS}
       placeholder="Enter mnemonic..."
       maxSelections={12}


### PR DESCRIPTION
This PR moves the raw skin components into the sub folder `skins/simple/raw` and improves the configurability of the skins by exporting a factory method for parts that use other skin parts within their markup (The same way react-toolbox does it).

This is necessary to avoid CSS duplication (until now the default theme was always loaded alongside the custom css) and loading-order issues (sometimes the default theme was loaded after the custom css, effectively rendering any customization useless).

Now you can choose between the default themed component skins by simply importing and using it like `import InputSkin from 'react-polymorph/lib/skins/simple/InputSkin';` (includes the default theme!) or importing the raw, unstyled skin via `import InputSkin from 'react-polymorph/lib/skins/simple/raw/InputSkin';` … then you have to configure a theme for this (but now the styles are only loaded once, as expected!)

**NOTE: i added this as a `fix` to the changelog because that's more appropriate i think** 