### PR TITLE
Fix/form field error prop type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+## vNext
+
+### Fixes
+
+- Allow string or element props for `FormField` errors [PR 25](https://github.com/input-output-hk/react-polymorph/pull/25)
+
 ## 0.5.4
 
 ### Fixes

--- a/source/components/Autocomplete.js
+++ b/source/components/Autocomplete.js
@@ -2,6 +2,7 @@ import React from 'react';
 import _ from 'lodash';
 import PropTypes from 'prop-types';
 import FormField from './FormField';
+import { StringOrElement } from '../utils/props';
 
 export default class Autocomplete extends FormField {
 
@@ -11,7 +12,7 @@ export default class Autocomplete extends FormField {
   };
 
   static propTypes = Object.assign({}, FormField.propTypes, {
-    error: PropTypes.string,
+    error: StringOrElement,
     maxSelections: PropTypes.number,
     placeholder: PropTypes.string,
     options: PropTypes.array,

--- a/source/components/Checkbox.js
+++ b/source/components/Checkbox.js
@@ -1,13 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import SkinnableComponent from './SkinnableComponent';
-import { LabelProp } from '../utils/props';
+import { StringOrElement } from '../utils/props';
 
 export default class Checkbox extends SkinnableComponent {
 
   static propTypes = Object.assign({}, SkinnableComponent.propTypes, {
     checked: PropTypes.bool,
-    label: LabelProp,
+    label: StringOrElement,
     onChange: PropTypes.func,
     onFocus: PropTypes.func,
     onBlur: PropTypes.func,

--- a/source/components/FormField.js
+++ b/source/components/FormField.js
@@ -12,7 +12,7 @@ export default class FormField extends SkinnableComponent {
     onFocus: PropTypes.func,
     onBlur: PropTypes.func,
     disabled: PropTypes.bool,
-    error: PropTypes.string,
+    error: StringOrElement,
   });
 
   static defaultProps = {

--- a/source/components/FormField.js
+++ b/source/components/FormField.js
@@ -1,13 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import SkinnableComponent from './SkinnableComponent';
-import { LabelProp } from '../utils/props';
+import { StringOrElement } from '../utils/props';
 
 export default class FormField extends SkinnableComponent {
 
   static propTypes = Object.assign({}, SkinnableComponent.propTypes, {
     skin: PropTypes.element.isRequired,
-    label: LabelProp,
+    label: StringOrElement,
     onChange: PropTypes.func,
     onFocus: PropTypes.func,
     onBlur: PropTypes.func,

--- a/source/components/Modal.js
+++ b/source/components/Modal.js
@@ -1,12 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import SkinnableComponent from './SkinnableComponent';
+import { StringOrElement } from '../utils/props';
 
 export default class Modal extends SkinnableComponent {
 
   static propTypes = Object.assign({}, SkinnableComponent.propTypes, {
     isActive: PropTypes.bool,
-    contentLabel: PropTypes.string,
+    contentLabel: StringOrElement,
     onClose: PropTypes.func,
     triggerCloseOnOverlayClick: PropTypes.bool
   });

--- a/source/components/NumericInput.js
+++ b/source/components/NumericInput.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { flow } from 'lodash';
 import Input from './Input';
 import FormField from './FormField';
+import { StringOrElement } from '../utils/props';
 
 export default class NumericInput extends FormField {
 
@@ -19,7 +20,7 @@ export default class NumericInput extends FormField {
   };
 
   static propTypes = Object.assign({}, FormField.propTypes, {
-    error: PropTypes.string,
+    error: StringOrElement,
     value: PropTypes.string,
     placeholder: PropTypes.string,
     maxBeforeDot: PropTypes.number, // max number of characters before dot

--- a/source/components/Options.js
+++ b/source/components/Options.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import SkinnableComponent from './SkinnableComponent';
 import events from '../utils/events';
-import { LabelProp } from '../utils/props';
+import { StringOrElement } from '../utils/props';
 
 export default class Options extends SkinnableComponent {
 
@@ -18,7 +18,7 @@ export default class Options extends SkinnableComponent {
     optionRenderer: PropTypes.func,
     selectedOptionValue: PropTypes.string,
     noResults: PropTypes.bool,
-    noResultsMessage: LabelProp,
+    noResultsMessage: StringOrElement,
   });
 
   static defaultProps = {

--- a/source/utils/props.js
+++ b/source/utils/props.js
@@ -3,4 +3,4 @@ import filterReactDomProps from 'filter-react-dom-props';
 
 export const pickDOMProps = filterReactDomProps;
 
-export const LabelProp = PropTypes.oneOfType([PropTypes.string, PropTypes.element]);
+export const StringOrElement = PropTypes.oneOfType([PropTypes.string, PropTypes.element]);


### PR DESCRIPTION
This PR improves the `FormField` component by allowing strings **and** elements to be passed to the `error` prop. This is useful in cases where you want to pass a rendered i18n component as error message.