### PR TITLE
[DDW-91] fix broken styling for options bubble within select component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Changelog
 
 ### Fixes
 
-- Fix broken theming setup that led to default theme overrides [PR 36](https://github.com/input-output-hk/react-polymorph/pull/36)
+- Fix broken theming setup for `InputSkin`, `BubbleSkin` and `SelectSkin` [PR 36](https://github.com/input-output-hk/react-polymorph/pull/36)
 
 ## 0.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Changelog
 
 - Add Radio component [PR 34](https://github.com/input-output-hk/react-polymorph/pull/34)
 
+### Fixes
+
+- Fix broken theming setup that led to default theme overrides [PR 36](https://github.com/input-output-hk/react-polymorph/pull/36)
+
 ## 0.6.0
 
 ### Features

--- a/source/skins/simple/AutocompleteSkin.js
+++ b/source/skins/simple/AutocompleteSkin.js
@@ -4,7 +4,8 @@ import { AUTOCOMPLETE } from './identifiers';
 import DefaultAutocompleteTheme from '../../themes/simple/SimpleAutocomplete.scss';
 import { autocompleteSkinFactory } from './raw/AutocompleteSkin';
 import FormFieldSkin from './FormFieldSkin';
+import SimpleOptionsSkin from './OptionsSkin';
 
 export default themr(AUTOCOMPLETE, DefaultAutocompleteTheme)(
-  autocompleteSkinFactory(FormFieldSkin),
+  autocompleteSkinFactory(FormFieldSkin, SimpleOptionsSkin),
 );

--- a/source/skins/simple/OptionsSkin.js
+++ b/source/skins/simple/OptionsSkin.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { themr } from 'react-css-themr';
 import { OPTIONS } from './identifiers';
 import DefaultOptionsTheme from '../../themes/simple/SimpleOptions.scss';
-import OptionsSkin from './raw/OptionsSkin';
+import BubbleSkin from './BubbleSkin';
+import { optionsSkinFactory } from './raw/OptionsSkin';
 
-export default themr(OPTIONS, DefaultOptionsTheme)(OptionsSkin);
+export default themr(OPTIONS, DefaultOptionsTheme)(optionsSkinFactory(BubbleSkin));

--- a/source/skins/simple/SelectSkin.js
+++ b/source/skins/simple/SelectSkin.js
@@ -4,5 +4,8 @@ import { SELECT } from './identifiers';
 import DefaultSelectTheme from '../../themes/simple/SimpleSelect.scss';
 import { selectSkinFactory } from './raw/SelectSkin';
 import InputSkin from './InputSkin';
+import OptionsSkin from './OptionsSkin';
 
-export default themr(SELECT, DefaultSelectTheme)(selectSkinFactory(InputSkin));
+export default themr(SELECT, DefaultSelectTheme)(
+  selectSkinFactory(InputSkin, OptionsSkin)
+);

--- a/source/skins/simple/raw/AutocompleteSkin.js
+++ b/source/skins/simple/raw/AutocompleteSkin.js
@@ -6,7 +6,7 @@ import { AUTOCOMPLETE } from '../identifiers';
 import RawFormFieldSkin from './FormFieldSkin';
 import Autocomplete from '../../../components/Autocomplete';
 import Options from '../../../components/Options';
-import SimpleOptionsSkin from '../../../skins/simple/OptionsSkin';
+import RawSimpleOptionsSkin from './OptionsSkin';
 
 /**
  * The raw skin for the Autocomplete component.
@@ -16,10 +16,11 @@ import SimpleOptionsSkin from '../../../skins/simple/OptionsSkin';
  * is needed to provide components with a default skin (see one level up).
  *
  * @param FormFieldSkin
+ * @param SimpleOptionsSkin
  * @returns {Component}
  */
 
-export const autocompleteSkinFactory = (FormFieldSkin) => (
+export const autocompleteSkinFactory = (FormFieldSkin, SimpleOptionsSkin) => (
   (props) => {
     const filteredAndLimitedOptions = _.slice(props.filteredOptions, 0, props.maxVisibleOptions);
     const isFirstOptionHighlighted = props.highlightedOptionIndex === 0;
@@ -101,4 +102,4 @@ export const autocompleteSkinFactory = (FormFieldSkin) => (
 /**
  * Export the raw version of this component which does not include any styles.
  */
-export default themr(AUTOCOMPLETE)(autocompleteSkinFactory(RawFormFieldSkin));
+export default themr(AUTOCOMPLETE)(autocompleteSkinFactory(RawFormFieldSkin, RawSimpleOptionsSkin));

--- a/source/skins/simple/raw/OptionsSkin.js
+++ b/source/skins/simple/raw/OptionsSkin.js
@@ -4,49 +4,53 @@ import { themr } from 'react-css-themr';
 import { OPTIONS } from '../identifiers';
 import Options from '../../../components/Options';
 import Bubble from '../../../components/Bubble';
-import BubbleSkin from '../../../skins/simple/BubbleSkin';
+import RawBubbleSkin from './BubbleSkin';
 
-export default themr(OPTIONS)((props) => {
-  const {
-    component, theme, options, optionRenderer,
-    isOpeningUpward, isOpen, noResults,
-    noResultsMessage,
-  } = props;
-  const highlightedOptionIndex = component.getHighlightedOptionIndex();
-  const isFirstOptionHighlighted = highlightedOptionIndex === 0;
-  const sortedOptions = isOpeningUpward ? options.slice().reverse() : options;
+export const optionsSkinFactory = (BubbleSkin) => (
+  (props) => {
+    const {
+      component, theme, options, optionRenderer,
+      isOpeningUpward, isOpen, noResults,
+      noResultsMessage,
+    } = props;
+    const highlightedOptionIndex = component.getHighlightedOptionIndex();
+    const isFirstOptionHighlighted = highlightedOptionIndex === 0;
+    const sortedOptions = isOpeningUpward ? options.slice().reverse() : options;
 
-  return (
-    <Bubble
-      className={classnames([
-        theme.options,
-        isOpen ? theme.isOpen : null,
-        isOpeningUpward ? theme.openUpward : null,
-        (isFirstOptionHighlighted && !noResults) ? theme.firstOptionHighlighted : null,
-      ])}
-      ref={(element) => component.registerSkinPart(Options.SKIN_PARTS.OPTIONS, element)}
-      isTransparent={false}
-      skin={<BubbleSkin />}
-      isOpeningUpward={isOpeningUpward}
-    >
-      <ul className={theme.ul}>
-        {!noResults ? sortedOptions.map((option, index) => (
-          <li
-            key={index}
-            className={classnames([
-              theme.option,
-              component.isHighlightedOption(index) ? theme.highlightedOption : null,
-              option.isDisabled ? theme.disabledOption : null,
-            ])}
-            onClick={(event) => component.handleClickOnOption(option, event)}
-            onMouseEnter={() => component.setHighlightedOptionIndex(index)}
-          >
-            {optionRenderer ? optionRenderer(option) : (typeof option === 'object' ? option.label : option)}
-          </li>
-        )) : (
-          <li className={theme.option}>{noResultsMessage}</li>
-        )}
-      </ul>
-    </Bubble>
-  );
-});
+    return (
+      <Bubble
+        className={classnames([
+          theme.options,
+          isOpen ? theme.isOpen : null,
+          isOpeningUpward ? theme.openUpward : null,
+          (isFirstOptionHighlighted && !noResults) ? theme.firstOptionHighlighted : null,
+        ])}
+        ref={(element) => component.registerSkinPart(Options.SKIN_PARTS.OPTIONS, element)}
+        isTransparent={false}
+        skin={<BubbleSkin />}
+        isOpeningUpward={isOpeningUpward}
+      >
+        <ul className={theme.ul}>
+          {!noResults ? sortedOptions.map((option, index) => (
+            <li
+              key={index}
+              className={classnames([
+                theme.option,
+                component.isHighlightedOption(index) ? theme.highlightedOption : null,
+                option.isDisabled ? theme.disabledOption : null,
+              ])}
+              onClick={(event) => component.handleClickOnOption(option, event)}
+              onMouseEnter={() => component.setHighlightedOptionIndex(index)}
+            >
+              {optionRenderer ? optionRenderer(option) : (typeof option === 'object' ? option.label : option)}
+            </li>
+          )) : (
+            <li className={theme.option}>{noResultsMessage}</li>
+          )}
+        </ul>
+      </Bubble>
+    );
+  }
+);
+
+export default themr(OPTIONS)(optionsSkinFactory(RawBubbleSkin));

--- a/source/skins/simple/raw/SelectSkin.js
+++ b/source/skins/simple/raw/SelectSkin.js
@@ -5,9 +5,9 @@ import { SELECT } from '../identifiers';
 import RawInputSkin from './InputSkin';
 import Select from '../../../components/Select';
 import Options from '../../../components/Options';
-import SimpleOptionsSkin from '../../../skins/simple/OptionsSkin';
+import RawSimpleOptionsSkin from './OptionsSkin';
 
-export const selectSkinFactory = (InputSkin) => (
+export const selectSkinFactory = (InputSkin, OptionsSkin) => (
 
   class SelectSkin extends Component {
 
@@ -42,7 +42,7 @@ export const selectSkinFactory = (InputSkin) => (
             <Options
               isOpen={isOpen}
               options={options}
-              skin={<SimpleOptionsSkin />}
+              skin={<OptionsSkin />}
               isOpeningUpward={isOpeningUpward}
               onChange={component.handleChange}
               optionRenderer={optionRenderer}
@@ -58,4 +58,4 @@ export const selectSkinFactory = (InputSkin) => (
   }
 );
 
-export default themr(SELECT)(selectSkinFactory(RawInputSkin));
+export default themr(SELECT)(selectSkinFactory(RawInputSkin, RawSimpleOptionsSkin));

--- a/source/themes/simple/SimpleBubble.scss
+++ b/source/themes/simple/SimpleBubble.scss
@@ -27,6 +27,7 @@ $bubble-shadow: none !default;
   position: absolute;
   left: 0;
   right: 0;
+  z-index: 1;
 }
 
 .bubble {

--- a/source/themes/simple/SimpleInput.scss
+++ b/source/themes/simple/SimpleInput.scss
@@ -13,6 +13,7 @@ $input-border: 1px solid #c6cdd6 !default;
 $input-border-radius: 2px !default;
 $input-border-focus-color: #5e6066 !default;
 $input-padding: 14px 20px !default;
+$input-errored-border: $theme-color-error;
 
 .input {
   background-color: $input-bg-color;
@@ -43,5 +44,5 @@ $input-padding: 14px 20px !default;
 }
 
 .errored {
-  border-color: $theme-color-error;
+  border: $input-errored-border;
 }

--- a/source/themes/simple/SimpleOptions.scss
+++ b/source/themes/simple/SimpleOptions.scss
@@ -31,9 +31,14 @@ $option-padding: 14px 20px !default;
     @include arrow(up, $option-bg-color, $options-border-color, $options-arrow-size);
   }
 
-  &.firstOptionHighlighted [data-bubble-arrow] {
-    height: inherit;
-    @include arrow(up, $option-highlight-color, $options-border-color, $options-arrow-size);
+  &.firstOptionHighlighted {
+    &:not(.openUpward) [data-bubble-arrow] {
+      @include arrow(up, $option-highlight-color !important, $options-border-color, $options-arrow-size);
+    }
+    &.openUpward [data-bubble-arrow] {
+      height: inherit;
+      @include arrow(down, $option-highlight-color !important, $options-border-color, $options-arrow-size);
+    }
   }
 }
 

--- a/source/themes/simple/SimpleSelect.scss
+++ b/source/themes/simple/SimpleSelect.scss
@@ -1,11 +1,12 @@
 @import "theme";
+@import "SimpleInput";
 @import "mixins/arrow";
 
 // OVERRIDABLE CONFIGURATION VARIABLES
 
-$select-input-bg-color: #fafbfc !default;
-$select-input-border-focus-color: #5e6066 !default;
-$select-input-padding: 0 0 0 48px !default;
+$select-input-bg-color: $input-bg-color !default;
+$select-input-border-focus-color: $input-border-focus-color !default;
+$select-input-padding: $input-padding !default;
 $select-arrow-color: #c6cdd6 !default;
 $select-arrow-focus-color: #5e6066 !default;
 $select-up-arrow-url: url('#{$theme-assets-path}/select-up-arrow.svg') !default;


### PR DESCRIPTION
This PR fixes an issue with the way the `OptionsSkin` was included in the `SelectSkin` component which resulted in non-configurable styles, since always the default theme was chosen instead of the raw / configurable version.