### PR TITLE
[DDW-98] fix bubble and options positioning logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Changelog
 ### Fixes
 
 - Fixes dependencies to be React 16 compatible [PR 41](https://github.com/input-output-hk/react-polymorph/pull/41)
+- Fixes broken options positioning logic that was accidentially removed when bubble was introduced 
+  [PR 42](https://github.com/input-output-hk/react-polymorph/pull/42)
 
 ## 0.6.1
 

--- a/source/components/Bubble.js
+++ b/source/components/Bubble.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import SkinnableComponent from './SkinnableComponent';
+import events from '../utils/events';
 
 export default class Bubble extends SkinnableComponent {
 
@@ -10,12 +11,123 @@ export default class Bubble extends SkinnableComponent {
   };
 
   static propTypes = Object.assign({}, SkinnableComponent.propTypes, {
-    isOpeningUpwards: PropTypes.bool,
+    isOpeningUpward: PropTypes.bool,
     isTransparent: PropTypes.bool,
+    isFloating: PropTypes.bool,
+    isHidden: PropTypes.bool,
   });
 
   static defaultProps = {
+    isOpeningUpward: false,
     isTransparent: true,
+    isFloating: false,
+    isHidden: false,
   };
+
+  state = {
+    position: null,
+  };
+
+  _hasEventListeners = false;
+
+  componentDidMount() {
+    setTimeout(() => {
+      if (this.props.isFloating) this._updatePosition();
+    }, 0);
+  }
+
+  componentWillUpdate(nextProps) {
+    const { isFloating } = this.props;
+    // Add listeners when the bubble
+    if (isFloating && !nextProps.isHidden && !this._hasEventListeners) {
+      this._handleScrollEventListener('add');
+      events.addEventsToDocument(this._getDocumentEvents());
+      window.addEventListener('resize', this._updatePosition);
+      this._hasEventListeners = true;
+    }
+  }
+
+  componentDidUpdate(prevProps) {
+    const { isHidden } = this.props;
+    const didVisibilityChange = isHidden !== prevProps.isHidden;
+    const wasBubbleHidden = !prevProps.isHidden && isHidden;
+
+    if (wasBubbleHidden) this._removeAllEventListeners();
+    if (didVisibilityChange) this._updatePosition();
+  }
+
+  componentWillUnmount() {
+    if (this._hasEventListeners) this._removeAllEventListeners();
+  }
+
+  prepareSkinProps(props) {
+    return Object.assign({}, super.prepareSkinProps(props), {
+      position: this.state.position,
+    });
+  };
+
+  // =========== PRIVATE HELPERS ==============
+
+  _handleScrollEventListener = (action) => {
+    const rootNode = this._getRootSkinPart();
+    const scrollableNode = this._getFirstScrollableParent(rootNode);
+    if (scrollableNode) {
+      if (action === 'add') {
+        scrollableNode.addEventListener('scroll', this._updatePosition);
+      } else if (action === 'remove') {
+        scrollableNode.removeEventListener('scroll', this._updatePosition);
+      }
+    }
+  };
+
+  _removeAllEventListeners() {
+    if (this._hasEventListeners) {
+      events.removeEventsFromDocument(this._getDocumentEvents());
+      this._handleScrollEventListener('remove');
+      window.removeEventListener('resize', this._updatePosition);
+      this._hasEventListeners = false;
+    }
+  }
+
+  _getFirstScrollableParent = (node) => {
+    if (node == null) return null;
+    if (node === this._getRootSkinPart() || node.scrollHeight <= node.clientHeight) {
+      return this._getFirstScrollableParent(node.parentNode);
+    } else {
+      return node;
+    }
+  };
+
+  _getRootSkinPart() {
+    return this.skinParts[Bubble.SKIN_PARTS.ROOT];
+  }
+
+  _updatePosition = () => {
+    const { isOpeningUpward } = this.props;
+    const rootNode = this._getRootSkinPart();
+    const parentNode = rootNode.parentNode;
+    const parentNodeParams = parentNode.getBoundingClientRect();
+
+    let positionY;
+    if (isOpeningUpward) {
+      positionY = window.innerHeight - parentNodeParams.top + 20;
+    } else {
+      positionY = parentNodeParams.bottom + 20;
+    }
+
+    const position = {
+      width: parentNodeParams.width,
+      positionX: parentNodeParams.left,
+      positionY,
+    };
+    this.setState({ position });
+  };
+
+  _getDocumentEvents() {
+    return {
+      resize: this._updatePosition,
+      scroll: this._updatePosition
+    };
+  }
 
 }

--- a/source/components/Options.js
+++ b/source/components/Options.js
@@ -33,28 +33,27 @@ export default class Options extends SkinnableComponent {
     highlightedOptionIndex: 0,
   };
 
-  componentWillReceiveProps(nextProps) {
-    if (this.props.isOpen !== nextProps.isOpen) {
-      this.setState({isOpen: nextProps.isOpen});
-    }
-  }
-
   componentWillUpdate(nextProps, nextState) {
     // update isOpen state when parent component force open / close options
     // (e.g. click on Input in Select component)
     if (!this.state.isOpen && nextState.isOpen) {
       window.addEventListener('resize', this._handleWindowResize);
-      this.handleScrollEventListener('add');
       events.addEventsToDocument(this._getDocumentEvents());
     }
   }
 
   componentDidUpdate(prevProps, prevState) {
-    if (prevState.isOpen && !this.state.isOpen) this.removeAllEventListeners();
+    if (prevState.isOpen && !this.state.isOpen) this._removeAllEventListeners();
+  }
+
+  componentWillReceiveProps(nextProps) {
+    if (this.props.isOpen !== nextProps.isOpen) {
+      this.setState({ isOpen: nextProps.isOpen });
+    }
   }
 
   componentWillUnmount() {
-    if (this.state.isOpen) this.removeAllEventListeners();
+    this._removeAllEventListeners();
   }
 
   prepareSkinProps(props) {
@@ -62,33 +61,6 @@ export default class Options extends SkinnableComponent {
       isOpen: this.state.isOpen,
       highlightedOptionIndex: this.state.highlightedOptionIndex,
     });
-  };
-
-  removeAllEventListeners() {
-    events.removeEventsFromDocument(this._getDocumentEvents());
-    window.removeEventListener('resize', this._handleWindowResize);
-    this.handleScrollEventListener('remove');
-  }
-
-  getFirstScrollableParent = (node) => {
-    if (node == null) return null;
-    if (node.scrollHeight > node.clientHeight) {
-      return node;
-    } else {
-      return this.getFirstScrollableParent(node.parentNode);
-    }
-  };
-
-  handleScrollEventListener = (action) => {
-    const rootNode = this._getRootSkinPart();
-    const scrollableNode = this.getFirstScrollableParent(rootNode);
-    if (scrollableNode) {
-      if (action === 'add') {
-        scrollableNode.addEventListener('scroll', this._handleScroll);
-      } else if (action === 'remove') {
-        scrollableNode.addEventListener('scroll', this._handleScroll);
-      }
-    }
   };
 
   open = () => {
@@ -223,6 +195,15 @@ export default class Options extends SkinnableComponent {
 
   _handleScroll = () => this.state.isOpen && this.close();
 
+  _getRootSkinPart() {
+    return this.skinParts[Options.SKIN_PARTS.OPTIONS];
+  }
+
+  _removeAllEventListeners() {
+    events.removeEventsFromDocument(this._getDocumentEvents());
+    window.removeEventListener('resize', this._updatePosition);
+  }
+
   _getDocumentEvents() {
     return {
       keydown: this._handleKeyDown,
@@ -230,10 +211,6 @@ export default class Options extends SkinnableComponent {
       touchend: this._handleDocumentClick,
       scroll: this._handleScroll,
     };
-  }
-
-  _getRootSkinPart() {
-    return this.skinParts[Options.SKIN_PARTS.OPTIONS];
   }
 
 }

--- a/source/components/Tooltip.js
+++ b/source/components/Tooltip.js
@@ -7,7 +7,7 @@ export default class Tooltip extends SkinnableComponent {
 
   static propTypes = Object.assign({}, SkinnableComponent.propTypes, {
     isAligningRight: PropTypes.bool,
-    isOpeningUpwards: PropTypes.bool,
+    isOpeningUpward: PropTypes.bool,
     isBounded: PropTypes.bool,
     tip: StringOrElement,
   });

--- a/source/skins/simple/raw/BubbleSkin.js
+++ b/source/skins/simple/raw/BubbleSkin.js
@@ -1,22 +1,38 @@
-import React from 'react';
+import React, { Component } from 'react';
 import classnames from 'classnames';
 import { pickDOMProps } from '../../../utils/props';
 import { themr } from 'react-css-themr';
 import { BUBBLE } from '../identifiers';
+import Bubble from '../../../components/Bubble';
 
-export default themr(BUBBLE)((props) => (
-  <div
-    {...pickDOMProps(props)}
-    className={classnames([
-      props.className,
-      props.theme.root,
-      props.isOpeningUpward ? props.theme.openUpward : null,
-      props.isTransparent ? props.theme.transparent : null,
-    ])}
-  >
-    <div className={props.theme.bubble} data-bubble-container >
-      {props.children}
-    </div>
-    <span className={props.theme.arrow} data-bubble-arrow />
-  </div>
-));
+class BubbleSkin extends Component {
+  render() {
+    const { props } = this;
+    return (
+      <div
+        {...pickDOMProps(props)}
+        className={classnames([
+          props.className,
+          props.theme.root,
+          props.isOpeningUpward ? props.theme.openUpward : null,
+          props.isTransparent ? props.theme.transparent : null,
+          props.isFloating ? props.theme.isFloating : null,
+          props.isHidden ? props.theme.isHidden : null,
+        ])}
+        style={props.position && {
+          [props.isOpeningUpward ? 'bottom' : 'top']: props.position.positionY,
+          left: props.position.positionX,
+          width: props.position.width,
+        }}
+        ref={(element) => props.component.registerSkinPart(Bubble.SKIN_PARTS.ROOT, element)}
+      >
+        <div className={props.theme.bubble} data-bubble-container >
+          {props.children}
+        </div>
+        <span className={props.theme.arrow} data-bubble-arrow />
+      </div>
+    );
+  }
+}
+
+export default themr(BUBBLE)(BubbleSkin);

--- a/source/skins/simple/raw/OptionsSkin.js
+++ b/source/skins/simple/raw/OptionsSkin.js
@@ -29,6 +29,8 @@ export const optionsSkinFactory = (BubbleSkin) => (
         isTransparent={false}
         skin={<BubbleSkin />}
         isOpeningUpward={isOpeningUpward}
+        isHidden={!isOpen}
+        isFloating
       >
         <ul className={theme.ul}>
           {!noResults ? sortedOptions.map((option, index) => (

--- a/source/skins/simple/raw/TooltipSkin.js
+++ b/source/skins/simple/raw/TooltipSkin.js
@@ -3,6 +3,7 @@ import classnames from 'classnames';
 import { pickDOMProps } from '../../../utils/props';
 import { themr } from 'react-css-themr';
 import { TOOLTIP } from '../identifiers';
+import Bubble from '../../../components/Bubble';
 import RawBubbleSkin from './BubbleSkin';
 
 /**
@@ -25,7 +26,8 @@ export const tooltipSkinFactory = (BubbleSkin) => (
         props.theme.root,
       ])}
     >
-      <BubbleSkin
+      <Bubble
+        skin={<BubbleSkin />}
         isOpeningUpward={props.isOpeningUpward}
         className={classnames([
           props.theme.bubble,
@@ -34,7 +36,7 @@ export const tooltipSkinFactory = (BubbleSkin) => (
         ])}
       >
         {props.tip}
-      </BubbleSkin>
+      </Bubble>
       {props.children}
     </span>
   )

--- a/source/themes/simple/SimpleBubble.scss
+++ b/source/themes/simple/SimpleBubble.scss
@@ -42,6 +42,23 @@ $bubble-shadow: none !default;
 // ======= SPECIAL STATES =======
 .root {
 
+  // ==== STATE: isHidden ====
+
+  &.isHidden {
+    display: none;
+  }
+
+  // ==== STATE: isFloating ====
+
+  &.isFloating {
+    overflow: visible;
+    width: 100%;
+    position: fixed;
+    z-index: 99;
+    left: inherit;
+    right: inherit;
+  }
+
   // ==== STATE: openUpward ====
 
   &.openUpward {

--- a/source/themes/simple/SimpleInput.scss
+++ b/source/themes/simple/SimpleInput.scss
@@ -36,13 +36,13 @@ $input-errored-border: $theme-color-error;
   &::-webkit-input-placeholder {
     color: $input-placeholder-color;
   }
+
+  &.errored {
+    border: 1px solid $input-errored-border;
+  }
 }
 
 .disabled {
   background-color: $input-disabled-bg-color;
   border-color: $input-disabled-color;
-}
-
-.errored {
-  border: $input-errored-border;
 }

--- a/source/themes/simple/SimpleOptions.scss
+++ b/source/themes/simple/SimpleOptions.scss
@@ -17,14 +17,8 @@ $option-highlight-color: #edf0f3 !default;
 $option-padding: 14px 20px !default;
 
 .options {
-  display: none; // only show when open
-
   & > div {
     padding: 0;
-  }
-
-  &.isOpen {
-    display: block;
   }
 
   & [data-bubble-arrow] {

--- a/stories/Bubble.stories.js
+++ b/stories/Bubble.stories.js
@@ -61,4 +61,25 @@ storiesOf('Bubble', module)
         tiny
       </Bubble>
     </div>
+  ))
+  .add('isHidden', () => (
+    <div className={styles.container}>
+      There should be no bubble shown!
+      <Bubble isHidden skin={<SimpleBubbleSkin/>} >
+        should not be visible!
+      </Bubble>
+    </div>
+  ))
+  .add('isFloating', () => (
+    <div className={styles.scrollContainer}>
+      <div className={styles.scrollContent}>
+        <Bubble isFloating skin={<SimpleBubbleSkin/>} >
+          floating above scroll content
+        </Bubble>
+      </div>
+      <p>
+        Here is some text that should break<br/>
+        and trigger scroll bars<br/>
+      </p>
+    </div>
   ));

--- a/stories/Bubble.stories.scss
+++ b/stories/Bubble.stories.scss
@@ -10,3 +10,18 @@
   white-space: nowrap;
   right: 0;
 }
+
+.scrollContainer {
+  width: 110px;
+  height: 126px;
+  margin: 75px auto 0;
+  overflow-x: hidden;
+  overflow-y: overlay;
+}
+
+.scrollContent {
+  position: relative;
+  border: 1px solid grey;
+  width: 100px;
+  height: 100px;
+}


### PR DESCRIPTION
This PR fixes the positioning logic of the select/autocomplete options that was accidentally removed when the bubble component was introduced. I also added a simple story for the bubble to showcase the "floating over the other content" state that is used in certain situations.

![screenshot 2018-02-16 um 12 06 41](https://user-images.githubusercontent.com/172414/36305021-25a05ada-1312-11e8-97a5-11ec7b63402d.png)

This also fixes the issues we have been seeing in Daedalus dialogs:

![screenshot 2018-02-16 um 12 07 29](https://user-images.githubusercontent.com/172414/36305024-28ba2fca-1312-11e8-852b-b86645123b06.png)

