### PR TITLE
Fix/ddw 111 Fix Autocomplete component styling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ Changelog
 
 ## vNext
 
+### Fixes
+
+- Add `border-radius` CSS property to Autocomplete component [PR 45](https://github.com/input-output-hk/react-polymorph/pull/45)
+
 ## 0.6.3
 
 ### Fixes

--- a/source/themes/simple/SimpleAutocomplete.scss
+++ b/source/themes/simple/SimpleAutocomplete.scss
@@ -4,6 +4,7 @@
 
 $autocomplete-bg-color: #fafbfc !default;
 $autocomplete-border: 1px solid #c6cdd6 !default;
+$autocomplete-border-radius: 2px !default;
 $autocomplete-border-focus-color: #5e6066 !default;
 $autocomplete-error-color: $theme-color-error !default;
 $autocomplete-focus-outline: none !default;
@@ -23,6 +24,7 @@ $autocomplete-selected-word-box-background-color: rgba(68, 91, 124, 0.5) !defaul
   .autocompleteContent {
     background-color: $autocomplete-bg-color;
     border: $autocomplete-border;
+    border-radius: $tautocomplete-border-radius;
     box-sizing: border-box;
     font-size: $autocomplete-font-size;
     min-height: $autocomplete-min-height;

--- a/source/themes/simple/SimpleAutocomplete.scss
+++ b/source/themes/simple/SimpleAutocomplete.scss
@@ -24,7 +24,7 @@ $autocomplete-selected-word-box-background-color: rgba(68, 91, 124, 0.5) !defaul
   .autocompleteContent {
     background-color: $autocomplete-bg-color;
     border: $autocomplete-border;
-    border-radius: $tautocomplete-border-radius;
+    border-radius: $autocomplete-border-radius;
     box-sizing: border-box;
     font-size: $autocomplete-font-size;
     min-height: $autocomplete-min-height;


### PR DESCRIPTION
This PR introduces a small fix for `Autocomplete` component styling. There was `border-radius` CSS property missing.