### PR TITLE
Feature/ddw 185 Add Autocomplete clear feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ Changelog
 
 ## vNext
 
+### Features
+
+- Add Autocomplete clear feature [PR 49](https://github.com/input-output-hk/react-polymorph/pull/49)
+
 ## 0.6.4
 
 ### Fixes

--- a/source/components/Autocomplete.js
+++ b/source/components/Autocomplete.js
@@ -16,6 +16,7 @@ export default class Autocomplete extends FormField {
     maxSelections: PropTypes.number,
     placeholder: PropTypes.string,
     options: PropTypes.array,
+    selectedOptions: PropTypes.array,
     sortAlphabetically: PropTypes.bool,
     multipleSameSelections: PropTypes.bool,
     maxVisibleOptions: PropTypes.number,
@@ -30,7 +31,7 @@ export default class Autocomplete extends FormField {
   };
 
   state = {
-    selectedOptions: [],
+    selectedOptions: this.props.selectedOptions || [],
     filteredOptions: (this.props.sortAlphabetically && this.props.options) ? this.props.options.sort() : (this.props.options || []),
     isOpen: false,
   };
@@ -43,6 +44,8 @@ export default class Autocomplete extends FormField {
       isOpen,
     });
   }
+
+  clear = () => this.removeOptions();
 
   focus = () => this.handleAutocompleteClick();
 
@@ -123,6 +126,13 @@ export default class Autocomplete extends FormField {
     _.pullAt(selectedOptions, index);
     this.selectionChanged(selectedOptions, event);
     this.setState({ selectedOptions });
+  };
+
+  removeOptions = () => {
+    this.selectionChanged([]);
+    this.setState({ selectedOptions: [] });
+    const input = this._getInputSkinPart();
+    input.value = '';
   };
 
   selectionChanged = (selectedOptions, event) => {

--- a/stories/Autocomplete.stories.js
+++ b/stories/Autocomplete.stories.js
@@ -114,6 +114,23 @@ storiesOf('Autocomplete', module)
     />
   ))
 
+  .add('Pre-entered mnemonics - Clear value on click', () => {
+    let autocomplete;
+    return (
+      <div>
+        <Autocomplete
+          ref={(ref) => autocomplete = ref}
+          label="Recovery phrase"
+          options={OPTIONS}
+          placeholder="Enter mnemonic..."
+          selectedOptions={['box', 'cat', 'dog']}
+          skin={<SimpleAutocompleteSkin />}
+        />
+        <button onClick={() => autocomplete.clear()}>clear</button>
+      </div>
+    );
+  })
+
   .add('Enter mnemonics in Modal', () => (
     <Modal
       isOpen


### PR DESCRIPTION
This PR adds two missing features to the Autocomplete component:
1. it exposes `clear()` method which is to be used to clear `selectedOptions`
2. it introduces `pre-selection` by picking up `selectedOptions` property on initial component rendering.