### PR TITLE
Fixes theme bug in FormField and Options components. Fixes styling bugs in Select, Radio, and Switch simple theme files.

### DIFF
--- a/source/components/Autocomplete.js
+++ b/source/components/Autocomplete.js
@@ -16,7 +16,7 @@ import _ from 'lodash';
 import THEME_API, { IDENTIFIERS } from '../themes/API';
 
 // internal utility functions
-import { StringOrElement, composeTheme, pickTheme } from '../utils';
+import { StringOrElement, composeTheme } from '../utils';
 
 class Autocomplete extends Component {
   static propTypes = {

--- a/source/components/Bubble.js
+++ b/source/components/Bubble.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { string, bool, func, object } from 'prop-types';
-import { addEventsToDocument, pickTheme, removeEventsFromDocument } from '../utils';
+import { addEventsToDocument, removeEventsFromDocument } from '../utils';
 
 // Bubble theme API
 import THEME_API, { IDENTIFIERS } from '../themes/API';

--- a/source/components/Button.js
+++ b/source/components/Button.js
@@ -4,7 +4,7 @@ import { string, bool, func, object } from 'prop-types';
 import THEME_API, { IDENTIFIERS } from '../themes/API';
 
 // internal utility functions
-import { StringOrElement, composeTheme, pickTheme } from '../utils';
+import { StringOrElement, composeTheme } from '../utils';
 
 class Button extends Component {
   static propTypes = {

--- a/source/components/Checkbox.js
+++ b/source/components/Checkbox.js
@@ -5,7 +5,7 @@ import { string, bool, func, object } from 'prop-types';
 import THEME_API, { IDENTIFIERS } from '../themes/API';
 
 // import utility functions
-import { StringOrElement, composeTheme, pickTheme } from '../utils';
+import { StringOrElement, composeTheme } from '../utils';
 
 class Checkbox extends Component {
   static propTypes = {

--- a/source/components/FormField.js
+++ b/source/components/FormField.js
@@ -32,9 +32,12 @@ class FormField extends Component {
 
   constructor(props, context) {
     super(props);
+
+    const theme = props.theme && props.theme[props.themeId] ? props.theme : null;
+    
     this.state = {
       error: '',
-      composedTheme: composeTheme(props.theme || context.theme, props.themeOverrides, THEME_API),
+      composedTheme: composeTheme(theme || context.theme, props.themeOverrides, THEME_API),
     };
   }
 

--- a/source/components/FormField.js
+++ b/source/components/FormField.js
@@ -5,7 +5,7 @@ import { string, bool, func, object } from 'prop-types';
 import THEME_API, { IDENTIFIERS } from '../themes/API';
 
 // import utility functions
-import { StringOrElement, composeTheme, pickTheme } from '../utils';
+import { StringOrElement, composeTheme } from '../utils';
 
 class FormField extends Component {
   static propTypes = {
@@ -34,7 +34,7 @@ class FormField extends Component {
     super(props);
 
     const theme = props.theme && props.theme[props.themeId] ? props.theme : null;
-    
+
     this.state = {
       error: '',
       composedTheme: composeTheme(theme || context.theme, props.themeOverrides, THEME_API),

--- a/source/components/Input.js
+++ b/source/components/Input.js
@@ -8,7 +8,7 @@ import { isString, flow } from 'lodash';
 import THEME_API, { IDENTIFIERS } from '../themes/API';
 
 // internal utility functions
-import { StringOrElement, composeTheme, pickTheme } from '../utils';
+import { StringOrElement, composeTheme } from '../utils';
 
 class Input extends Component {
   static propTypes = {

--- a/source/components/Modal.js
+++ b/source/components/Modal.js
@@ -5,7 +5,7 @@ import { string, bool, func, object } from 'prop-types';
 import THEME_API, { IDENTIFIERS } from '../themes/API';
 
 // internal utiltity functions
-import { StringOrElement, composeTheme, pickTheme } from '../utils';
+import { StringOrElement, composeTheme } from '../utils';
 
 class Modal extends Component {
   static propTypes = {

--- a/source/components/NumericInput.js
+++ b/source/components/NumericInput.js
@@ -8,7 +8,7 @@ import { flow } from 'lodash';
 import THEME_API, { IDENTIFIERS } from '../themes/API';
 
 // internal utility functions
-import { StringOrElement, composeTheme, pickTheme } from '../utils';
+import { StringOrElement, composeTheme } from '../utils';
 
 class NumericInput extends Component {
   static propTypes = {

--- a/source/components/Options.js
+++ b/source/components/Options.js
@@ -49,8 +49,11 @@ class Options extends Component {
 
   constructor(props, context) {
     super(props);
+
+    const theme = props.theme && props.theme[props.themeId] ? props.theme : null;
+
     this.state = {
-      composedTheme: composeTheme(props.theme || context.theme, props.themeOverrides, THEME_API),
+      composedTheme: composeTheme(theme || context.theme, props.themeOverrides, THEME_API),
       isOpen: props.isOpen,
       highlightedOptionIndex: 0
     };

--- a/source/components/Options.js
+++ b/source/components/Options.js
@@ -3,7 +3,7 @@ import { bool, func, object, array, string } from 'prop-types';
 import ReactDOM from 'react-dom';
 
 // Options theme API
-import { IDENTIFIERS, OPTIONS_THEME_API } from '../themes/API';
+import { IDENTIFIERS } from '../themes/API';
 
 // internal utility functions
 import {
@@ -11,7 +11,7 @@ import {
   composeTheme,
   addEventsToDocument,
   removeEventsFromDocument,
-  targetIsDescendant, pickTheme
+  targetIsDescendant
 } from '../utils';
 import THEME_API from '../themes/API';
 

--- a/source/components/Radio.js
+++ b/source/components/Radio.js
@@ -5,7 +5,7 @@ import { bool, func, object, string } from 'prop-types';
 import THEME_API, { IDENTIFIERS } from '../themes/API';
 
 // import utility functions
-import { StringOrElement, composeTheme, pickTheme } from '../utils';
+import { StringOrElement, composeTheme } from '../utils';
 
 class Radio extends Component {
   static propTypes = {

--- a/source/components/Select.js
+++ b/source/components/Select.js
@@ -5,7 +5,7 @@ import { bool, func, object, arrayOf, shape, string } from 'prop-types';
 import THEME_API, { IDENTIFIERS } from '../themes/API';
 
 // import the composeTheme utility function
-import { pickTheme, composeTheme } from '../utils';
+import { composeTheme } from '../utils';
 
 class Select extends Component {
   static propTypes = {

--- a/source/components/TextArea.js
+++ b/source/components/TextArea.js
@@ -8,7 +8,7 @@ import { isString, flow } from 'lodash';
 import THEME_API, { IDENTIFIERS } from '../themes/API';
 
 // import utility functions
-import { StringOrElement, composeTheme, pickTheme } from '../utils';
+import { StringOrElement, composeTheme } from '../utils';
 
 class TextArea extends Component {
   static propTypes = {

--- a/source/components/Tooltip.js
+++ b/source/components/Tooltip.js
@@ -5,7 +5,7 @@ import { bool, func, object, string } from 'prop-types';
 import THEME_API, { IDENTIFIERS } from '../themes/API';
 
 // import utility functions
-import { StringOrElement, composeTheme, pickTheme } from '../utils';
+import { StringOrElement, composeTheme } from '../utils';
 
 class Tooltip extends Component {
   static propTypes = {

--- a/source/themes/simple/SimpleInput.scss
+++ b/source/themes/simple/SimpleInput.scss
@@ -27,6 +27,10 @@ $input-errored-border: $theme-color-error;
   padding: $input-padding;
   width: $input-width;
 
+  &.errored {
+    border-color: $input-errored-border;
+  }
+
   &:focus {
     border-color: $input-border-focus-color;
     outline: none;
@@ -41,9 +45,7 @@ $input-errored-border: $theme-color-error;
 
 // BEGIN SPECIAL STATES ---------- //
 
-.errored {
-  border: 1px solid $input-errored-border;
-}
+.errored {}
 
 .disabled {
   background-color: $input-disabled-bg-color;

--- a/source/themes/simple/SimpleRadio.scss
+++ b/source/themes/simple/SimpleRadio.scss
@@ -16,9 +16,13 @@ $radio-label-disabled-color: $theme-color-light-grey !default;
   flex-direction: row;
   align-items: center;
   position: relative;
-
   &:hover {
     cursor: pointer;
+  }
+  &.disabled {
+    &:hover, .label:hover {
+      cursor: default;
+    }
   }
 }
 
@@ -61,11 +65,6 @@ $radio-label-disabled-color: $theme-color-light-grey !default;
 // BEGIN SPECIAL STATES ---------- //
 
 .disabled {
-  .root:hover,
-  .label:hover {
-    cursor: default;
-  }
-
   .label {
     color: $radio-label-disabled-color;
   }

--- a/source/themes/simple/SimpleSwitch.scss
+++ b/source/themes/simple/SimpleSwitch.scss
@@ -28,16 +28,15 @@ $switch-label-disabled-color: $theme-color-light-grey !default;
   &:hover {
     cursor: pointer;
   }
+
+  &.disabled {
+    &:hover, .label:hover, .switch:hover .thumb:hover {
+      cursor: default;
+    }
+  }
 }
 
 .disabled {
-  .root:hover,
-  .label:hover,
-  .switch,
-  .thumb {
-    cursor: default;
-  }
-
   .label {
     color: $switch-label-disabled-color;
   }
@@ -86,12 +85,14 @@ $switch-label-disabled-color: $theme-color-light-grey !default;
 
 .thumb {
   border-radius: 3px;
-  cursor: pointer;
   height: $switch-track-height;
   position: absolute;
   top: 0;
   transition: left 200ms ease-in-out;
   width: $switch-track-height;
+  &:hover {
+      cursor: pointer;
+  }
 }
 
 .label {

--- a/source/utils/index.js
+++ b/source/utils/index.js
@@ -6,7 +6,7 @@ import eventUtils from './events';
 export const { pickDOMProps, StringOrElement } = propsUtils;
 
 // named exports for theme utility functions
-export const { pickTheme, composeTheme } = themeUtils;
+export const { composeTheme } = themeUtils;
 
 // named exports for event utility functions
 export const {
@@ -26,7 +26,6 @@ export const {
 export default {
   pickDOMProps,
   StringOrElement,
-  pickTheme,
   composeTheme,
   getMousePosition,
   getTouchPosition,

--- a/stories/Autocomplete.stories.js
+++ b/stories/Autocomplete.stories.js
@@ -26,6 +26,7 @@ import CustomAutocompleteTheme from './theme-customizations/Autocomplete.custom.
 // custom styles & theme overrides
 import styles from './Autocomplete.stories.scss';
 import themeOverrides from './theme-overrides/customAutocomplete.scss';
+import { IDENTIFIERS } from '../source/themes/API';
 
 const OPTIONS = [
   'home',
@@ -198,7 +199,7 @@ storiesOf('Autocomplete', module)
 
   .add('composed theme', withState({ selectedOpts: [] }, store => (
       <Autocomplete
-        themeOverrides={themeOverrides}
+        themeOverrides={{ [IDENTIFIERS.AUTOCOMPLETE]: themeOverrides }}
         label="Recovery phrase"
         options={OPTIONS}
         placeholder="Enter mnemonic..."
@@ -213,7 +214,7 @@ storiesOf('Autocomplete', module)
 
   .add('custom theme', withState({ selectedOpts: [] }, store => (
       <Autocomplete
-        theme={CustomAutocompleteTheme}
+        theme={{ [IDENTIFIERS.AUTOCOMPLETE]: CustomAutocompleteTheme }}
         label="Custom Autocomplete theme"
         options={OPTIONS}
         placeholder="Enter mnemonic..."

--- a/stories/Autocomplete.stories.js
+++ b/stories/Autocomplete.stories.js
@@ -26,6 +26,8 @@ import CustomAutocompleteTheme from './theme-customizations/Autocomplete.custom.
 // custom styles & theme overrides
 import styles from './Autocomplete.stories.scss';
 import themeOverrides from './theme-overrides/customAutocomplete.scss';
+
+// constants
 import { IDENTIFIERS } from '../source/themes/API';
 
 const OPTIONS = [

--- a/stories/Bubble.stories.js
+++ b/stories/Bubble.stories.js
@@ -16,7 +16,7 @@ import BubbleCustomTheme from './theme-customizations/Bubble.custom.scss';
 
 // custom styles & theme overrides
 import styles from './Bubble.stories.scss';
-import customBubbleOverrides from './theme-overrides/customBubble.scss';
+import themeOverrides from './theme-overrides/customBubble.scss';
 import { IDENTIFIERS } from '../source/themes/API';
 
 storiesOf('Bubble', module)
@@ -83,7 +83,8 @@ storiesOf('Bubble', module)
   .add('theme overrides', () => (
     <div className={styles.container}>
       <Bubble
-        themeOverrides={{ [IDENTIFIERS.BUBBLE]: customBubbleOverrides }}
+        isTransparent={false}
+        themeOverrides={{ [IDENTIFIERS.BUBBLE]: themeOverrides }}
         skin={BubbleSkin}
       >
         theme overrides

--- a/stories/Button.stories.js
+++ b/stories/Button.stories.js
@@ -33,7 +33,7 @@ storiesOf("Button", module)
 
   .add("theme overrides", () => (
     <Button
-      label="Composed theme"
+      label="theme overrides"
       themeOverrides={{ [IDENTIFIERS.BUTTON]: themeOverrides }}
       skin={ButtonSkin}
     />

--- a/stories/Button.stories.js
+++ b/stories/Button.stories.js
@@ -13,7 +13,7 @@ import { ButtonSkin } from "../source/skins/simple";
 import SimpleTheme from "../source/themes/simple";
 import CustomButtonTheme from "./theme-customizations/Button.custom.scss";
 
-// custom styles & themeOverrides
+// theme overrides and identifiers
 import themeOverrides from "./theme-overrides/customButton.scss";
 import { IDENTIFIERS } from '../source/themes/API';
 

--- a/stories/Checkbox.stories.js
+++ b/stories/Checkbox.stories.js
@@ -14,7 +14,7 @@ import { CheckboxSkin } from '../source/skins/simple';
 import SimpleTheme from '../source/themes/simple';
 import CustomCheckboxTheme from './theme-customizations/Checkbox.custom.scss';
 
-// custom styles
+// custom styles & theme overrides
 import themeOverrides from './theme-overrides/customCheckbox.scss';
 import { IDENTIFIERS } from '../source/themes/API';
 

--- a/stories/Input.stories.js
+++ b/stories/Input.stories.js
@@ -15,7 +15,7 @@ import { FormFieldSkin, InputSkin } from '../source/skins/simple';
 import SimpleTheme from '../source/themes/simple';
 import CustomInputTheme from './theme-customizations/Input.custom.scss';
 
-// themeOverrides
+// theme overrides and identifiers
 import themeOverrides from './theme-overrides/customInput.scss';
 import { IDENTIFIERS } from '../source/themes/API';
 

--- a/stories/Modal.stories.js
+++ b/stories/Modal.stories.js
@@ -14,7 +14,7 @@ import { ModalSkin, ButtonSkin } from "../source/skins/simple";
 import SimpleTheme from "../source/themes/simple";
 import CustomModalTheme from "./theme-customizations/Modal.custom.scss";
 
-// custom styles & themeOverrides
+// custom styles & theme overrides
 import styles from "./Modal.stories.scss";
 import themeOverrides from "./theme-overrides/customModal.scss";
 import { IDENTIFIERS } from '../source/themes/API';

--- a/stories/NumericInput.stories.js
+++ b/stories/NumericInput.stories.js
@@ -14,7 +14,7 @@ import { FormFieldSkin, InputSkin } from '../source/skins/simple';
 import SimpleTheme from '../source/themes/simple';
 import CustomInputTheme from './theme-customizations/Input.custom.scss';
 
-// themeOverrides
+// theme overrides and identifiers
 import themeOverrides from './theme-overrides/customInput.scss';
 import { IDENTIFIERS } from '../source/themes/API';
 

--- a/stories/Options.stories.js
+++ b/stories/Options.stories.js
@@ -13,9 +13,10 @@ import { AutocompleteSkin, OptionsSkin, SelectSkin } from '../source/skins/simpl
 // themes
 import SimpleTheme from '../source/themes/simple';
 import CustomOptionsTheme from './theme-customizations/Options.custom.scss';
-import { IDENTIFIERS } from '../source/themes/API';
 
 // constants
+import { IDENTIFIERS } from '../source/themes/API';
+
 const OPTIONS_COLLECTION = [
   { value: 'EN-gb', label: 'England' },
   { value: 'ES-es', label: 'Spain' },

--- a/stories/Radio.stories.js
+++ b/stories/Radio.stories.js
@@ -14,7 +14,7 @@ import { RadioSkin } from '../source/skins/simple';
 import SimpleTheme from '../source/themes/simple';
 import CustomRadioTheme from './theme-customizations/Radio.custom.scss';
 
-// custom styles & themeOverrides
+// custom styles & theme overrides
 import styles from './Radio.stories.scss';
 import themeOverrides from './theme-overrides/customRadio.scss';
 import { IDENTIFIERS } from '../source/themes/API';

--- a/stories/Select.stories.js
+++ b/stories/Select.stories.js
@@ -22,9 +22,10 @@ import flagEngland from './images/gb.png';
 import flagSpain from './images/es.png';
 import flagThailand from './images/th.png';
 import flagUSA from './images/us.png';
-import { IDENTIFIERS } from '../source/themes/API';
 
 // constants
+import { IDENTIFIERS } from '../source/themes/API';
+
 const COUNTRIES = [
   { value: 'EN-gb', label: 'England' },
   { value: 'ES-es', label: 'Spain' },

--- a/stories/Switch.stories.js
+++ b/stories/Switch.stories.js
@@ -14,11 +14,9 @@ import { SwitchSkin } from '../source/skins/simple';
 import SimpleTheme from '../source/themes/simple';
 import CustomSwitchTheme from './theme-customizations/Switch.custom.scss';
 
-// theme API
-import { IDENTIFIERS, SWITCH_THEME_API } from '../source/themes/API';
-
-// theme overrides
+// custom styles & theme overrides
 import themeOverrides from './theme-overrides/customSwitch.scss';
+import { IDENTIFIERS } from '../source/themes/API';
 
 storiesOf('Switch', module)
 

--- a/stories/TextArea.stories.js
+++ b/stories/TextArea.stories.js
@@ -15,7 +15,7 @@ import { TextAreaSkin, FormFieldSkin } from '../source/skins/simple';
 import SimpleTheme from '../source/themes/simple';
 import CustomTextAreaTheme from './theme-customizations/TextArea.custom.scss';
 
-// themeOverrides
+// theme overrides and identifiers
 import themeOverrides from './theme-overrides/customTextarea.scss';
 import { IDENTIFIERS } from '../source/themes/API';
 

--- a/stories/Toggler.stories.js
+++ b/stories/Toggler.stories.js
@@ -14,10 +14,9 @@ import { TogglerSkin } from '../source/skins/simple';
 import SimpleTheme from '../source/themes/simple';
 import CustomTogglerTheme from './theme-customizations/Toggler.custom.scss';
 
-// theme API
-import { IDENTIFIERS } from '../source/themes/API';
-
+// theme overrides and identifiers
 import themeOverrides from './theme-overrides/customToggler.scss';
+import { IDENTIFIERS } from '../source/themes/API';
 
 storiesOf('Toggler', module)
   .addDecorator(story => {

--- a/stories/Tooltip.stories.js
+++ b/stories/Tooltip.stories.js
@@ -13,7 +13,7 @@ import { TooltipSkin } from '../source/skins/simple';
 import SimpleTheme from '../source/themes/simple';
 import CustomBubbleTheme from './theme-customizations/Bubble.custom.scss';
 
-// custom styles & themeOverrides
+// custom styles & theme overrides
 import styles from './Tooltip.stories.scss';
 import themeOverrides from './theme-overrides/customTooltipBubble.scss';
 import { IDENTIFIERS } from '../source/themes/API';


### PR DESCRIPTION
1. AutocompleteSkin contains both the FormField and Options components. When the Autocomplete component is passed themeOverrides or a custom theme, FormField and Options do not properly receive their styles via context because they mistook Autocomplete's theme object for their own. Inside of AutocompleteSkin, both FormField and Options get passed **props.theme**, in the case of Autocomplete receiving themeOverrides or a custom theme, both FormField and Options will return truthy for the existence of a theme even though the theme object _only_ contains one key (autocomplete) whose value is the custom theme or themeOverrides belonging to Autocomplete. In the constructor for both FormField and Options, there is now a check to see if the theme object passed contains a property that matches their respective themeId's, if that key doesn't exist on the theme object, they resort to the theme object in context instead. 

2. When Select had an errored state, it did not show a red border. When Radio and Switch had a disabled state, the cursor still showed a pointer on hover. Those styling bugs are fixed.

3. pickTheme function did not exist in utils so it's removed now.




