### PR TITLE
fix broken select checkmark positioning for right-to-left screens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## vNEXT
 
+### Fixes
+
+- Fixed broken right-to-left positiong of selected option checkmark [PR 62](https://github.com/input-output-hk/react-polymorph/pull/62)
+
 ### Chores
 
 - Adds polyfills for React's new context API and ref API released in v16.3.0. Drops support for React versions less than v16.[PR 61](https://github.com/input-output-hk/react-polymorph/pull/61)

--- a/source/components/Options.js
+++ b/source/components/Options.js
@@ -302,7 +302,6 @@ class Options extends Component<Props, State> {
     return {
       keydown: this._handleKeyDown,
       click: this._handleDocumentClick,
-      touchend: this._handleDocumentClick,
       scroll: this._handleScroll
     };
   }

--- a/source/skins/simple/OptionsSkin.js
+++ b/source/skins/simple/OptionsSkin.js
@@ -59,7 +59,7 @@ export default (props: Props) => {
     if (optionRenderer) {
       return optionRenderer(option);
     } else if (typeof option === 'object') {
-      return option.label;
+      return <span className={theme[themeId].label}>{option.label}</span>;
     }
     return option;
   };

--- a/source/themes/simple/SimpleOptions.scss
+++ b/source/themes/simple/SimpleOptions.scss
@@ -76,6 +76,9 @@ $options-bubble-arrow: true !default;
 
   &.selectedOption {
     display: flex;
+    .label {
+      flex-grow: 1;
+    }
     &:after {
       align-self: center;
       border-color: $option-checkmark-color;

--- a/source/themes/simple/SimpleSelect.scss
+++ b/source/themes/simple/SimpleSelect.scss
@@ -86,7 +86,7 @@ $select-down-arrow-rtl-position-left: 15px !default;
 // END SPECIAL STATES ---------- //
 
 // right-to-left languages support
-body[dir='rtl'] {
+[dir='rtl'] {
   .selectInput:after {
     left: $select-down-arrow-rtl-position-left;
   }

--- a/stories/Select.stories.js
+++ b/stories/Select.stories.js
@@ -172,6 +172,19 @@ storiesOf('Select', module)
     ))
   )
 
+  .add('countries - rtl support',
+    withState({ value: COUNTRIES[0].value }, store => (
+      <div dir="rtl">
+        <Select
+          value={store.state.value}
+          onChange={value => store.set({ value })}
+          options={COUNTRIES}
+          skin={SelectSkin}
+        />
+      </div>
+    ))
+  )
+
   .add('custom theme',
     withState({ value: '' }, store => (
       <Select


### PR DESCRIPTION
This PR fixes broken positioning of the selected option checkmark for right-to-left screens (e.g: Arabic).

Before:
![screenshot 2018-06-07 um 15 08 59](https://user-images.githubusercontent.com/172414/41101586-d7c6fd78-6a64-11e8-9ef2-70ab7432ab36.png)

After:
![screenshot 2018-06-07 um 15 09 19](https://user-images.githubusercontent.com/172414/41101602-dc70c020-6a64-11e8-94fa-82903b8253e2.png)
