### PR TITLE
[DDW-336] fix refs for input components in react polymorph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## vNEXT
 ### Fixes
 
+- Wraps TextAreaSkin's render method in FormField so labels and errors are rendered the same as in Input and NumericInput. Fixes Input, NumericInput, and TextArea components so they pass a prop called inputRef or textareaRef to FormField in their skins. This properly makes use of React v16.3.1+'s ref API instead of using the onRef callback. Adds autoFocus, onBlur, and onFocus props to NumericInput and TextArea. [PR 67](https://github.com/input-output-hk/react-polymorph/pull/67)
+
 ### Chores
 
 - Adds support for React v15 - v16.4.1. Upgrades devDependencies to latest versions of react, jest, and enzyme related libraries. Adds Autocomplete simulation test for deleting a selected option via backspace key. [PR 65](https://github.com/input-output-hk/react-polymorph/pull/65)

--- a/__tests__/__snapshots__/TextArea.test.js.snap
+++ b/__tests__/__snapshots__/TextArea.test.js.snap
@@ -1,43 +1,92 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`TextArea renders correctly 1`] = `
-<textarea
-  className="textarea"
-  onChange={[Function]}
-  value=""
-/>
+<div
+  className="root"
+>
+  
+  <div
+    className="inputWrapper"
+  >
+    <textarea
+      className="textarea"
+      onChange={[Function]}
+      value=""
+    />
+  </div>
+</div>
 `;
 
 exports[`TextArea renders with 5 rows 1`] = `
-<textarea
-  className="textarea"
-  onChange={[Function]}
-  rows={5}
-  value=""
-/>
+<div
+  className="root"
+>
+  
+  <div
+    className="inputWrapper"
+  >
+    <textarea
+      className="textarea"
+      onChange={[Function]}
+      rows={5}
+      value=""
+    />
+  </div>
+</div>
 `;
 
 exports[`TextArea renders with a value 1`] = `
-<textarea
-  className="textarea"
-  onChange={[Function]}
-  value="this one has a value"
-/>
+<div
+  className="root"
+>
+  
+  <div
+    className="inputWrapper"
+  >
+    <textarea
+      className="textarea"
+      onChange={[Function]}
+      value="this one has a value"
+    />
+  </div>
+</div>
 `;
 
 exports[`TextArea renders with an error 1`] = `
-<textarea
-  className="textarea errored"
-  onChange={[Function]}
-  value=""
-/>
+<div
+  className="root errored"
+>
+  <div
+    className="error"
+  >
+    Please enter valid input
+  </div>
+  <div
+    className="inputWrapper"
+  >
+    <textarea
+      className="textarea errored"
+      onChange={[Function]}
+      value=""
+    />
+  </div>
+</div>
 `;
 
 exports[`TextArea renders with placeholder 1`] = `
-<textarea
-  className="textarea"
-  onChange={[Function]}
-  placeholder="0.0000"
-  value=""
-/>
+<div
+  className="root"
+>
+  
+  <div
+    className="inputWrapper"
+  >
+    <textarea
+      className="textarea"
+      onChange={[Function]}
+      placeholder="0.0000"
+      value=""
+    />
+  </div>
+</div>
 `;

--- a/source/components/FormField.js
+++ b/source/components/FormField.js
@@ -17,6 +17,7 @@ type Props = {
   },
   disabled: boolean,
   error: string,
+  inputRef: Object,
   label: string | Element<any>,
   render: Function,
   skin: ComponentType<any>,
@@ -31,8 +32,6 @@ type State = {
 };
 
 class FormFieldBase extends Component<Props, State> {
-  child: Element<'input'>;
-
   static defaultProps = {
     disabled: false,
     theme: null,
@@ -58,14 +57,10 @@ class FormFieldBase extends Component<Props, State> {
   setError = (error: string) => this.setState({ error });
 
   focusChild = () => {
-    if (this.child && this.child.focus !== undefined) {
-      this.child.focus();
-    }
+    const { inputRef } = this.props;
+    if (!inputRef.current) return;
+    inputRef.current.focus();
   };
-
-  // onRef is passed to Input/NumericInput components rendered
-  // via this.props.render, which makes this.focusChild possible
-  onRef = (ref: Element<'input'>) => (this.child = ref);
 
   render() {
     // destructuring props ensures only the "...rest" get passed down
@@ -75,6 +70,7 @@ class FormFieldBase extends Component<Props, State> {
       themeOverrides,
       error,
       context,
+      inputRef,
       ...rest
     } = this.props;
 
@@ -84,7 +80,6 @@ class FormFieldBase extends Component<Props, State> {
         setError={this.setError}
         theme={this.state.composedTheme}
         focusChild={this.focusChild}
-        onRef={this.onRef}
         {...rest}
       />
     );

--- a/source/components/Input.js
+++ b/source/components/Input.js
@@ -21,11 +21,10 @@ type Props = {
   },
   disabled: boolean,
   error: string,
-  label: string,
+  label: string | Element<any>,
   onBlur: Function,
   onChange: Function,
   onFocus: Function,
-  onRef: Function,
   maxLength: number,
   minLength: number,
   onKeyPress: Function,
@@ -50,7 +49,6 @@ class InputBase extends Component<Props, State> {
   static defaultProps = {
     autoFocus: false,
     error: '',
-    onRef: () => {},
     readOnly: false,
     theme: null,
     themeId: IDENTIFIERS.INPUT,
@@ -77,13 +75,7 @@ class InputBase extends Component<Props, State> {
   }
 
   componentDidMount() {
-    const { onRef, autoFocus } = this.props;
-
-    if (autoFocus) this.focus();
-
-    // if Input is rendered by FormField, onRef allows FormField to call
-    // Input's focus method when someone clicks on FormField's label
-    onRef(this);
+    if (this.props.autoFocus) this.focus();
   }
 
   onChange = (event: SyntheticInputEvent<Element<'input'>>) => {
@@ -95,9 +87,8 @@ class InputBase extends Component<Props, State> {
 
   focus = () => {
     const { inputElement } = this;
-    if (inputElement && inputElement.current) {
-      return inputElement.current.focus();
-    }
+    if (!inputElement.current) return;
+    inputElement.current.focus();
   }
 
   _setError = (error: string) => {
@@ -154,7 +145,6 @@ class InputBase extends Component<Props, State> {
       themeOverrides,
       onChange,
       error,
-      onRef,
       maxLength,
       minLength,
       setError,

--- a/source/components/NumericInput.js
+++ b/source/components/NumericInput.js
@@ -15,6 +15,7 @@ import { composeTheme, addThemeId } from '../utils';
 import { IDENTIFIERS } from '../themes/API';
 
 type Props = {
+  autoFocus: boolean,
   className: string,
   context: {
     theme: Object,
@@ -22,15 +23,16 @@ type Props = {
   },
   disabled: boolean,
   enforceMax: boolean,
-  label: string,
+  label: string | Element<any>,
   enforceMin: boolean,
   error: string,
+  onBlur: Function,
   onChange: Function,
+  onFocus: Function,
   maxAfterDot: number,
   maxBeforeDot: number,
   maxValue: number,
   minValue: number,
-  onRef: Function,
   readOnly: boolean,
   placeholder: string,
   setError: Function,
@@ -57,7 +59,6 @@ class NumericInputBase extends Component<Props, State> {
     error: '',
     enforceMax: false,
     enforceMin: false,
-    onRef: () => {},
     readOnly: false,
     theme: null,
     themeId: IDENTIFIERS.INPUT,
@@ -93,14 +94,12 @@ class NumericInputBase extends Component<Props, State> {
   }
 
   componentDidMount() {
-    // if this NumericInput instance is rendered within FormField's render prop,
-    // this.props.onRef allows FormField to call NumericInput's focus method
-    // when user clicks FormField's label
-    this.props.onRef(this);
-
     const { inputElement } = this;
+    // check for autoFocus prop
+    if (this.props.autoFocus) this.focus();
+
+    // Set last input caret position on updates
     if (inputElement && inputElement.current) {
-      // Set last input caret position on updates
       this.setState({ caretPosition: inputElement.current.selectionStart });
     }
   }
@@ -152,16 +151,8 @@ class NumericInputBase extends Component<Props, State> {
 
   focus = () => {
     const { inputElement } = this;
-    if (inputElement && inputElement.current) {
-      return inputElement.current.focus();
-    }
-  }
-
-  blur = () => {
-    const { inputElement } = this;
-    if (inputElement && inputElement.current) {
-      return inputElement.current.blur();
-    }
+    if (!inputElement.current) return;
+    inputElement.current.focus();
   }
 
   _validateLimitProps(minValue: number, maxBeforeDot: number, maxAfterDot: number) {
@@ -451,7 +442,6 @@ class NumericInputBase extends Component<Props, State> {
       onChange,
       error,
       context,
-      onRef,
       maxValue,
       minValue,
       maxBeforeDot,

--- a/source/components/Select.js
+++ b/source/components/Select.js
@@ -13,11 +13,13 @@ import { IDENTIFIERS } from '../themes/API';
 type Props = {
   allowBlank: boolean,
   autoFocus: boolean,
-  error: string | Element<any>,
+  className: string,
   context: {
     theme: Object,
     ROOT_THEME_API: Object
   },
+  error: string | Element<any>,
+  label: string | Element<any>,
   isOpeningUpward: boolean,
   onBlur: Function,
   onChange: Function,
@@ -27,7 +29,6 @@ type Props = {
     isDisabled: boolean,
     value: any
   }>,
-  label: string | Element<any>,
   placeholder: string,
   skin: ComponentType<any>,
   theme: Object, // will take precedence over theme in context if passed

--- a/source/components/TextArea.js
+++ b/source/components/TextArea.js
@@ -16,18 +16,19 @@ import { IDENTIFIERS } from '../themes/API';
 type Props = {
   autoFocus: boolean,
   autoResize: boolean,
+  className: string,
   context: {
     theme: Object,
     ROOT_THEME_API: Object
   },
   disabled: boolean,
+  label: string | Element<any>,
   error: string | Node,
   maxLength: number,
   minLength: number,
   onBlur: Function,
   onChange: Function,
   onFocus: Function,
-  onRef: Function,
   placeholder: string,
   rows: number,
   skin: ComponentType<any>,
@@ -48,7 +49,6 @@ class TextAreaBase extends Component<Props, State> {
   static defaultProps = {
     autoFocus: false,
     autoResize: true,
-    onRef: () => {},
     theme: null,
     themeId: IDENTIFIERS.TEXT_AREA,
     themeOverrides: {},
@@ -74,20 +74,14 @@ class TextAreaBase extends Component<Props, State> {
   }
 
   componentDidMount() {
-    const { autoResize, autoFocus, onRef } = this.props;
+    const { autoResize, autoFocus } = this.props;
 
     if (autoResize) {
       window.addEventListener('resize', this._handleAutoresize);
       this._handleAutoresize();
     }
 
-    if (autoFocus) {
-      this.focus();
-    }
-
-    // if TextArea is rendered by FormField, onRef allows FormField to call
-    // TextArea's focus method when someone clicks on FormField's label
-    onRef(this);
+    if (autoFocus) { this.focus(); }
   }
 
   componentWillReceiveProps(nextProps) {
@@ -110,9 +104,8 @@ class TextAreaBase extends Component<Props, State> {
 
   focus = () => {
     const { textareaElement } = this;
-    if (textareaElement && textareaElement.current) {
-      textareaElement.current.focus();
-    }
+    if (!textareaElement.current) return;
+    textareaElement.current.focus();
   }
 
   onChange = (event: SyntheticInputEvent<>) => {

--- a/source/skins/simple/AutocompleteSkin.js
+++ b/source/skins/simple/AutocompleteSkin.js
@@ -1,6 +1,6 @@
 // @flow
 import React from 'react';
-import type { Ref, Node } from 'react';
+import type { Ref, Element } from 'react';
 
 // external libraries
 import _ from 'lodash';
@@ -25,7 +25,7 @@ type Props = {
   inputValue: string,
   isOpeningUpward: boolean,
   isOpen: boolean,
-  label: string | Node,
+  label: string | Element<any>,
   maxSelections: number,
   maxVisibleOptions: number,
   onKeyDown: Function,
@@ -100,6 +100,7 @@ export const AutocompleteSkin = (props: Props) => {
   return (
     <div className={props.className} ref={props.rootRef}>
       <FormField
+        inputRef={props.inputRef}
         error={props.error}
         label={props.label}
         skin={FormFieldSkin}

--- a/source/skins/simple/FormFieldSkin.js
+++ b/source/skins/simple/FormFieldSkin.js
@@ -11,7 +11,6 @@ type Props = {
   focusChild: Function,
   label: string | Element<any>,
   onChange: Function,
-  onRef: Function,
   render: Function,
   setError: Function,
   theme: Object,

--- a/source/skins/simple/InputSkin.js
+++ b/source/skins/simple/InputSkin.js
@@ -1,6 +1,6 @@
 // @flow
 import React from 'react';
-import type { Ref } from 'react';
+import type { Ref, Element } from 'react';
 
 // external libraries
 import classnames from 'classnames';
@@ -16,7 +16,7 @@ type Props = {
   className: string,
   disabled: boolean,
   error: string,
-  label: string,
+  label: string | Element<any>,
   inputRef: Ref<'input'>,
   onBlur: Function,
   onChange: Function,
@@ -35,6 +35,7 @@ export const InputSkin = (props: Props) => (
     disabled={props.disabled}
     label={props.label}
     error={props.error}
+    inputRef={props.inputRef}
     skin={FormFieldSkin}
     render={() => (
       <input

--- a/source/skins/simple/TextAreaSkin.js
+++ b/source/skins/simple/TextAreaSkin.js
@@ -1,20 +1,25 @@
 // @flow
 import React from 'react';
-import type { Ref } from 'react';
+import type { Ref, Element } from 'react';
 
 // external libraries
 import classnames from 'classnames';
+
+// components & skins
+import { FormField } from '../../components';
+import { FormFieldSkin } from './';
 
 // import utility functions
 import { pickDOMProps } from '../../utils';
 
 type Props = {
+  className: string,
   disabled: boolean,
-  error: string | Node,
+  error: string | Element<any>,
+  label: string | Element<any>,
   onBlur: Function,
   onChange: Function,
   onFocus: Function,
-  onRef: Function,
   placeholder: string,
   rows: number,
   textareaRef: Ref<*>,
@@ -26,14 +31,24 @@ type Props = {
 export const TextAreaSkin = (props: Props) => {
   const { theme, themeId } = props;
   return (
-    <textarea
-      ref={props.textareaRef}
-      {...pickDOMProps(props)}
-      className={classnames([
-        theme[themeId].textarea,
-        props.disabled ? theme[themeId].disabled : null,
-        props.error ? theme[themeId].errored : null
-      ])}
+    <FormField
+      className={props.className}
+      disabled={props.disabled}
+      label={props.label}
+      error={props.error}
+      inputRef={props.textareaRef}
+      skin={FormFieldSkin}
+      render={() => (
+        <textarea
+          ref={props.textareaRef}
+          {...pickDOMProps(props)}
+          className={classnames([
+            theme[themeId].textarea,
+            props.disabled ? theme[themeId].disabled : null,
+            props.error ? theme[themeId].errored : null
+          ])}
+        />
+      )}
     />
   );
 };

--- a/stories/Autocomplete.stories.js
+++ b/stories/Autocomplete.stories.js
@@ -7,15 +7,9 @@ import classnames from 'classnames';
 import { storiesOf } from '@storybook/react';
 import { withState } from '@dump247/storybook-state';
 
-// components
+// components & skins
 import { Autocomplete, Modal, Button } from '../source/components';
-
-// skins
-import {
-  AutocompleteSkin,
-  ModalSkin,
-  ButtonSkin
-} from '../source/skins/simple';
+import { AutocompleteSkin, ModalSkin, ButtonSkin } from '../source/skins/simple';
 
 // themes
 import CustomAutocompleteTheme from './theme-customizations/Autocomplete.custom.scss';

--- a/stories/Input.stories.js
+++ b/stories/Input.stories.js
@@ -74,7 +74,7 @@ storiesOf('Input', module)
     />
   ))
 
-  .add('error',
+  .add('with error',
     withState({ value: '' }, store => (
       <Input
         label="With Label"
@@ -124,11 +124,11 @@ storiesOf('Input', module)
     ))
   )
 
-  .add('focus / blur',
+  .add('onFocus / onBlur',
     withState({ value: '', focused: false, blurred: false }, store => (
       <Input
         value={store.state.value}
-        placeholder="focus / blur"
+        placeholder="onFocus / onBlur"
         onChange={value => store.set({ value })}
         onFocus={() => store.set({ focused: true })}
         onBlur={() => store.set({ blurred: true })}

--- a/stories/Input.stories.js
+++ b/stories/Input.stories.js
@@ -130,8 +130,8 @@ storiesOf('Input', module)
         value={store.state.value}
         placeholder="onFocus / onBlur"
         onChange={value => store.set({ value })}
-        onFocus={() => store.set({ focused: true })}
-        onBlur={() => store.set({ blurred: true })}
+        onFocus={() => store.set({ focused: true, blurred: false })}
+        onBlur={() => store.set({ blurred: true, focused: false })}
         skin={InputSkin}
       />
     ))

--- a/stories/NumericInput.stories.js
+++ b/stories/NumericInput.stories.js
@@ -80,8 +80,8 @@ storiesOf('NumericInput', module)
         maxBeforeDot={6}
         maxAfterDot={6}
         onChange={value => store.set({ value })}
-        onFocus={() => store.set({ focused: true })}
-        onBlur={() => store.set({ blurred: true })}
+        onFocus={() => store.set({ focused: true, blurred: false })}
+        onBlur={() => store.set({ blurred: true, focused: false })}
         skin={InputSkin}
       />
     ))

--- a/stories/NumericInput.stories.js
+++ b/stories/NumericInput.stories.js
@@ -32,10 +32,10 @@ storiesOf('NumericInput', module)
     ))
   )
 
-  .add('send amount - label',
+  .add('label',
     withState({ value: '' }, store => (
       <NumericInput
-        label="Some label"
+        label="Amount"
         value={store.state.value}
         maxBeforeDot={6}
         maxAfterDot={6}
@@ -45,7 +45,7 @@ storiesOf('NumericInput', module)
     ))
   )
 
-  .add('send amount - placeholder',
+  .add('placeholder',
     withState({ value: '' }, store => (
       <NumericInput
         value={store.state.value}
@@ -58,11 +58,25 @@ storiesOf('NumericInput', module)
     ))
   )
 
-  .add('send amount - focus / blur',
+  .add('autoFocus',
+    withState({ value: '' }, store => (
+      <NumericInput
+        autoFocus
+        value={store.state.value}
+        placeholder="18.000000"
+        maxBeforeDot={6}
+        maxAfterDot={6}
+        onChange={value => store.set({ value })}
+        skin={InputSkin}
+      />
+    ))
+  )
+
+  .add('onFocus / onBlur',
     withState({ value: '', focused: false, blurred: false }, store => (
       <NumericInput
         value={store.state.value}
-        placeholder="focus / blur"
+        placeholder="onFocus / onBlur"
         maxBeforeDot={6}
         maxAfterDot={6}
         onChange={value => store.set({ value })}
@@ -73,7 +87,7 @@ storiesOf('NumericInput', module)
     ))
   )
 
-  .add('send amount - error',
+  .add('with error',
     withState({ value: '' }, store => (
       <NumericInput
         label="Amount"
@@ -86,7 +100,7 @@ storiesOf('NumericInput', module)
     ))
   )
 
-  .add('send amount - beforeDot(3) and afterDot(4)',
+  .add('beforeDot(3) and afterDot(4)',
     withState({ value: '' }, store => (
       <NumericInput
         label="Amount"
@@ -100,7 +114,7 @@ storiesOf('NumericInput', module)
     ))
   )
 
-  .add('send amount - maxValue(30000) - unenforced',
+  .add('maxValue(30000) - unenforced',
     withState({ value: '' }, store => (
       <NumericInput
         label="Amount"
@@ -113,7 +127,7 @@ storiesOf('NumericInput', module)
     ))
   )
 
-  .add('send amount - minValue(50) - unenforced',
+  .add('minValue(50) - unenforced',
     withState({ value: '' }, store => (
       <NumericInput
         label="Amount"
@@ -127,7 +141,7 @@ storiesOf('NumericInput', module)
     ))
   )
 
-  .add('send amount - maxValue(30000), minValue(50) - unenforced',
+  .add('maxValue(30000), minValue(50) - unenforced',
     withState({ value: '' }, store => (
       <NumericInput
         label="Amount"
@@ -142,7 +156,7 @@ storiesOf('NumericInput', module)
     ))
   )
 
-  .add('send amount - maxValue(30000), minValue(50), enforceMax=true, enforceMin=true',
+  .add('maxValue(30000), minValue(50), enforceMax=true, enforceMin=true',
     withState({ value: '' }, store => (
       <NumericInput
         label="Amount"
@@ -153,22 +167,6 @@ storiesOf('NumericInput', module)
         maxAfterDot={6}
         enforceMax
         enforceMin
-        onChange={value => store.set({ value })}
-        skin={InputSkin}
-      />
-    ))
-  )
-
-  .add('send amount - onChange',
-    withState({ value: '' }, store => (
-      <NumericInput
-        label="Amount"
-        value={store.state.value}
-        placeholder="0.000000"
-        maxBeforeDot={12}
-        maxAfterDot={6}
-        maxValue={45000000000}
-        minValue={0.000001}
         onChange={value => store.set({ value })}
         skin={InputSkin}
       />

--- a/stories/Select.stories.js
+++ b/stories/Select.stories.js
@@ -5,11 +5,9 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { withState } from '@dump247/storybook-state';
 
-// components
-import { FormField, Select } from '../source/components';
-
-// skins
-import { SelectSkin, FormFieldSkin } from '../source/skins/simple';
+// components & skins
+import { Select } from '../source/components';
+import { SelectSkin } from '../source/skins/simple';
 
 // themes
 import SimpleTheme from '../source/themes/simple';
@@ -51,7 +49,7 @@ const COUNTRIES_WITH_DISABLED_OPTIONS = [
 storiesOf('Select', module)
   // ====== Stories ======
 
-  .add('countries - options',
+  .add('options',
     withState({ value: '' }, store => (
       <Select
         value={store.state.value}
@@ -62,25 +60,19 @@ storiesOf('Select', module)
     ))
   )
 
-  .add('countries - label',
+  .add('label',
     withState({ value: '' }, store => (
-      <FormField
-        label="Some label"
-        skin={FormFieldSkin}
-        render={() => (
-          <Select
-            value={store.state.value}
-            onChange={value => store.set({ value })}
-            label="Countries"
-            options={COUNTRIES}
-            skin={SelectSkin}
-          />
-        )}
+      <Select
+        label="Select a country"
+        value={store.state.value}
+        onChange={value => store.set({ value })}
+        options={COUNTRIES}
+        skin={SelectSkin}
       />
     ))
   )
 
-  .add('countries - placeholder',
+  .add('placeholder',
     withState({ value: '' }, store => (
       <Select
         value={store.state.value}
@@ -92,7 +84,7 @@ storiesOf('Select', module)
     ))
   )
 
-  .add('countries - value',
+  .add('value',
     withState({ value: COUNTRIES[0].value }, store => (
       <Select
         value={store.state.value}
@@ -103,26 +95,20 @@ storiesOf('Select', module)
     ))
   )
 
-  .add('countries - error',
+  .add('with error',
     withState({ value: COUNTRIES[0].value }, store => (
-      <FormField
+      <Select
         label="Countries"
         error="You picked the wrong country"
-        skin={FormFieldSkin}
-        render={props => (
-          <Select
-            {...props}
-            value={store.state.value}
-            onChange={value => store.set({ value })}
-            options={COUNTRIES}
-            skin={SelectSkin}
-          />
-        )}
+        value={store.state.value}
+        onChange={value => store.set({ value })}
+        options={COUNTRIES}
+        skin={SelectSkin}
       />
     ))
   )
 
-  .add('countries - custom options template',
+  .add('custom options template',
     withState({ value: '' }, store => (
       <Select
         value={store.state.value}
@@ -139,27 +125,22 @@ storiesOf('Select', module)
     ))
   )
 
-  .add('countries - isOpeningUpward',
+  .add('isOpeningUpward',
     withState({ value: '' }, store => (
-      <FormField
+      <Select
+        isOpeningUpward
         className={styles.customMargin}
         label="Countries (opening upward)"
-        skin={FormFieldSkin}
-        render={() => (
-          <Select
-            value={store.state.value}
-            onChange={value => store.set({ value })}
-            options={COUNTRIES}
-            placeholder="Select your country …"
-            skin={SelectSkin}
-            isOpeningUpward
-          />
-        )}
+        placeholder="Select your country …"
+        value={store.state.value}
+        onChange={value => store.set({ value })}
+        options={COUNTRIES}
+        skin={SelectSkin}
       />
     ))
   )
 
-  .add('countries - with disabled options',
+  .add('with disabled options',
     withState({ value: '' }, store => (
       <Select
         value={store.state.value}
@@ -172,7 +153,7 @@ storiesOf('Select', module)
     ))
   )
 
-  .add('countries - rtl support',
+  .add('rtl support',
     withState({ value: COUNTRIES[0].value }, store => (
       <div dir="rtl">
         <Select

--- a/stories/TextArea.stories.js
+++ b/stories/TextArea.stories.js
@@ -5,11 +5,9 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { withState } from '@dump247/storybook-state';
 
-// components
-import { TextArea, FormField } from '../source/components';
-
-// skins
-import { TextAreaSkin, FormFieldSkin } from '../source/skins/simple';
+// components & skins
+import { TextArea } from '../source/components';
+import { TextAreaSkin } from '../source/skins/simple';
 
 // themes
 import CustomTextAreaTheme from './theme-customizations/TextArea.custom.scss';
@@ -32,17 +30,11 @@ storiesOf('TextArea', module)
 
   .add('label',
     withState({ value: '' }, store => (
-      <FormField
+      <TextArea
         label="Your Comment"
-        skin={FormFieldSkin}
-        render={props => (
-          <TextArea
-            {...props}
-            value={store.state.value}
-            onChange={value => store.set({ value })}
-            skin={TextAreaSkin}
-          />
-        )}
+        value={store.state.value}
+        onChange={value => store.set({ value })}
+        skin={TextAreaSkin}
       />
     ))
   )
@@ -53,6 +45,18 @@ storiesOf('TextArea', module)
         value={store.state.value}
         onChange={value => store.set({ value })}
         placeholder="Your Comment"
+        skin={TextAreaSkin}
+      />
+    ))
+  )
+
+  .add('disabled',
+    withState({ value: '' }, store => (
+      <TextArea
+        disabled
+        label="Your Comment"
+        value={store.state.value}
+        onChange={value => store.set({ value })}
         skin={TextAreaSkin}
       />
     ))
@@ -70,6 +74,19 @@ storiesOf('TextArea', module)
     ))
   )
 
+  .add('onFocus / onBlur',
+    withState({ value: '', focused: false, blurred: false }, store => (
+      <TextArea
+        value={store.state.value}
+        placeholder="onFocus / onBlur"
+        onChange={value => store.set({ value })}
+        onFocus={() => store.set({ focused: true })}
+        onBlur={() => store.set({ blurred: true })}
+        skin={TextAreaSkin}
+      />
+    ))
+  )
+
   .add('maxLength(5)',
     withState({ value: '' }, store => (
       <TextArea
@@ -82,58 +99,40 @@ storiesOf('TextArea', module)
     ))
   )
 
-  .add('error',
+  .add('with error',
     withState({ value: '' }, store => (
-      <FormField
+      <TextArea
         label="With label"
         error="Something went wrong"
-        skin={FormFieldSkin}
-        render={props => (
-          <TextArea
-            {...props}
-            value={store.state.value}
-            onChange={value => store.set({ value })}
-            skin={TextAreaSkin}
-          />
-        )}
+        value={store.state.value}
+        onChange={value => store.set({ value })}
+        skin={TextAreaSkin}
       />
     ))
   )
 
   .add('rows={5}',
     withState({ value: '' }, store => (
-      <FormField
+      <TextArea
         label="Textarea with fixed amount of rows to start with"
-        skin={FormFieldSkin}
-        render={props => (
-          <TextArea
-            {...props}
-            value={store.state.value}
-            onChange={value => store.set({ value })}
-            placeholder="Your description here"
-            rows={5}
-            skin={TextAreaSkin}
-          />
-        )}
+        value={store.state.value}
+        onChange={value => store.set({ value })}
+        placeholder="Your description here"
+        rows={5}
+        skin={TextAreaSkin}
       />
     ))
   )
 
   .add('autoResize={false}',
     withState({ value: '' }, store => (
-      <FormField
+      <TextArea
         label="Textarea without auto resizing"
-        skin={FormFieldSkin}
-        render={props => (
-          <TextArea
-            {...props}
-            value={store.state.value}
-            onChange={value => store.set({ value })}
-            placeholder="Your description here"
-            autoResize={false}
-            skin={TextAreaSkin}
-          />
-        )}
+        value={store.state.value}
+        onChange={value => store.set({ value })}
+        placeholder="Your description here"
+        autoResize={false}
+        skin={TextAreaSkin}
       />
     ))
   )

--- a/stories/TextArea.stories.js
+++ b/stories/TextArea.stories.js
@@ -80,8 +80,8 @@ storiesOf('TextArea', module)
         value={store.state.value}
         placeholder="onFocus / onBlur"
         onChange={value => store.set({ value })}
-        onFocus={() => store.set({ focused: true })}
-        onBlur={() => store.set({ blurred: true })}
+        onFocus={() => store.set({ focused: true, blurred: false })}
+        onBlur={() => store.set({ blurred: true, focused: false })}
         skin={TextAreaSkin}
       />
     ))


### PR DESCRIPTION
- This PR wraps TextAreaSkin's render method in FormField so labels and errors are rendered the same as in Input and NumericInput. 

- Fixes Input, NumericInput, and TextArea components so they pass a prop called inputRef or textareaRef to FormField in their skins. This properly makes use of React v16.3.1+'s ref API instead of using the onRef callback.
- Adds autoFocus, onBlur, and onFocus props to NumericInput and TextArea