### PR TITLE
[DDW-348] fix input border when invalid in react polymorph

### DIFF
--- a/source/themes/simple/SimpleInput.scss
+++ b/source/themes/simple/SimpleInput.scss
@@ -28,10 +28,6 @@ $input-errored-border: $theme-color-error;
   padding: $input-padding;
   width: $input-width;
 
-  &.errored {
-    border-color: $input-errored-border;
-  }
-
   &:focus {
     border-color: $input-border-focus-color;
     outline: none;
@@ -48,6 +44,15 @@ $input-errored-border: $theme-color-error;
 // BEGIN SPECIAL STATES ---------- //
 
 .errored {
+  border-color: $input-errored-border;
+
+  &:focus {
+    border-color: $input-errored-border;
+  }
+
+  &:hover {
+    border-color: $input-errored-border;
+  }
 }
 
 .disabled {

--- a/stories/Input.stories.js
+++ b/stories/Input.stories.js
@@ -34,7 +34,7 @@ storiesOf('Input', module)
   .add('label',
     withState({ value: '' }, store => (
       <Input
-        label="Some label"
+        label="Click Me to Focus"
         value={store.state.value}
         onChange={value => store.set({ value })}
         skin={InputSkin}
@@ -57,6 +57,7 @@ storiesOf('Input', module)
     withState({ value: '' }, store => (
       <Input
         autoFocus
+        label="With autoFocus"
         value={store.state.value}
         placeholder="autoFocus"
         onChange={value => store.set({ value })}
@@ -77,7 +78,7 @@ storiesOf('Input', module)
   .add('with error',
     withState({ value: '' }, store => (
       <Input
-        label="With Label"
+        label="With Error"
         error="Something went wrong"
         value={store.state.value}
         onChange={value => store.set({ value })}
@@ -89,7 +90,7 @@ storiesOf('Input', module)
   .add('minLength(8)',
     withState({ value: '' }, store => (
       <Input
-        label="Input with min. 5 Characters"
+        label="Minimum 8 Characters"
         value={store.state.value}
         placeholder="min length"
         minLength={8}
@@ -102,7 +103,7 @@ storiesOf('Input', module)
   .add('maxLength(5)',
     withState({ value: '' }, store => (
       <Input
-        label="Input with max. 5 Characters"
+        label="Maximum 5 Characters"
         value={store.state.value}
         placeholder="max length"
         maxLength={5}
@@ -127,6 +128,7 @@ storiesOf('Input', module)
   .add('onFocus / onBlur',
     withState({ value: '', focused: false, blurred: false }, store => (
       <Input
+        label="See the State Tab Below"
         value={store.state.value}
         placeholder="onFocus / onBlur"
         onChange={value => store.set({ value })}
@@ -140,9 +142,9 @@ storiesOf('Input', module)
   .add('onKeyPress',
     withState({ value: '' }, store => (
       <Input
-        label="Type to see events logged"
+        label="Type to See Events Logged"
         value={store.state.value}
-        placeholder="max length"
+        placeholder="max 5 characters"
         maxLength={5}
         onKeyPress={action('onKeyPress')}
         onChange={value => store.set({ value })}
@@ -151,10 +153,11 @@ storiesOf('Input', module)
     ))
   )
 
-  .add('theme overrides',
+  .add('theme overrides, minLength(8)',
     withState({ value: '' }, store => (
       <Input
-        label="Theme overrides"
+        label="Composed Theme"
+        minLength={8}
         themeOverrides={themeOverrides}
         value={store.state.value}
         placeholder="type here..."
@@ -167,7 +170,7 @@ storiesOf('Input', module)
   .add('custom theme',
     withState({ value: '' }, store => (
       <Input
-        label="Custom theme"
+        label="Custom Theme"
         theme={CustomInputTheme}
         value={store.state.value}
         placeholder="type here..."

--- a/stories/NumericInput.stories.js
+++ b/stories/NumericInput.stories.js
@@ -62,6 +62,7 @@ storiesOf('NumericInput', module)
     withState({ value: '' }, store => (
       <NumericInput
         autoFocus
+        label="With autoFocus"
         value={store.state.value}
         placeholder="18.000000"
         maxBeforeDot={6}
@@ -173,10 +174,11 @@ storiesOf('NumericInput', module)
     ))
   )
 
-  .add('theme overrides',
+  .add('theme overrides, minValue(50)',
     withState({ value: '' }, store => (
       <NumericInput
-        label="Amount"
+        label="Composed Theme"
+        minValue={50}
         themeOverrides={themeOverrides}
         value={store.state.value}
         placeholder="0.000000"
@@ -187,7 +189,7 @@ storiesOf('NumericInput', module)
     ))
   )
 
-  .add('custom theme',
+  .add('Custom Theme',
     withState({ value: '' }, store => (
       <NumericInput
         label="Amount"

--- a/stories/theme-overrides/customInput.scss
+++ b/stories/theme-overrides/customInput.scss
@@ -2,6 +2,18 @@
   width: 25%;
   transition: all 0.4s ease-in-out;
 
+  &.errored {
+    border-color: rgba(#de3226, 0.5);
+
+    &:focus {
+      border-color: rgba(#de3226, 0.5);
+    }
+
+    &:hover {
+      border-color: rgba(#de3226, 0.5);
+    }
+  }
+
   &:focus {
     width: 50%;
     border-color: rgba(10, 145, 48, 0.8);


### PR DESCRIPTION
- This PR de-nests the class definitions in`SimpleInput.scss`. 

- These fixes ensure the border color of both Input and NumericInput remain the correct color when in an errored state. 

- Also, theme overrides will work as intended without relying on `!important` or needing a higher specificity in order to overwrite the base theme.