### PR TITLE
[DDW-352] show red error state border also around focused textareas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,9 @@
 ## vNEXT
 ### Fixes
 
+- Fixed wrong border color for errored & focused textareas [PR 73](https://github.com/input-output-hk/react-polymorph/pull/73)
 - De-nests the class definitions in SimpleInput.scss. Ensures the border color of both Input and NumericInput remain the correct color when in an errored state. Improves composability when theme overrides is used with both Input components. Updates stories to reflect fixes. [PR 71](https://github.com/input-output-hk/react-polymorph/pull/71)
-
 - Adds a new HOC GlobalListeners which is used in Select and Autocomplete that attaches document and window listeners for closing the window. Fixes bubble and arrow positioning when Bubble is rendered via Select and Autocomplete. NumericInput does not execute the user's onChange prop unless the value changes internally after being processed. Removes index.js in components and skins directories to reduce size of library. [PR 69](https://github.com/input-output-hk/react-polymorph/pull/69)
-
 - Wraps TextAreaSkin's render method in FormField so labels and errors are rendered the same as in Input and NumericInput. Fixes Input, NumericInput, and TextArea components so they pass a prop called inputRef or textareaRef to FormField in their skins. This properly makes use of React v16.3.1+'s ref API instead of using the onRef callback. Adds autoFocus, onBlur, and onFocus props to NumericInput and TextArea. [PR 67](https://github.com/input-output-hk/react-polymorph/pull/67)
 - Fixed wrong positioning of select options when opening upward [PR 68](https://github.com/input-output-hk/react-polymorph/pull/68)
 - Fixed vertical positioning of select arrow when opened [PR 68](https://github.com/input-output-hk/react-polymorph/pull/68)

--- a/source/themes/simple/SimpleTextArea.scss
+++ b/source/themes/simple/SimpleTextArea.scss
@@ -47,4 +47,7 @@ $textarea-error-color: $theme-color-error !default;
 
 .errored {
   border-color: $textarea-error-color;
+  &:focus {
+    border-color: $textarea-error-color;
+  }
 }


### PR DESCRIPTION
This PR fixes the same issue as #71 for textareas ;)

<img width="555" alt="screenshot 2018-07-10 um 11 08 32" src="https://user-images.githubusercontent.com/172414/42500441-a0f48680-8431-11e8-9716-6462f64d256b.png">
