### PR TITLE
Improve theme exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 ### Chores
 
-- Replaces all default exports in the theme directory with constants and exports them. Puts all properties of SimpleTheme and ROOT_THEME_API objects in ABC and uses IDENTIFIERS constants for safety. [77](https://github.com/input-output-hk/react-polymorph/pull/77)
+- Replaces all default exports in the theme directory with constants and exports them. Additionally, all import statements previously importing a default export are replaced with an appropriate named import. Defines all properties of the SimpleTheme and ROOT_THEME_API objects using IDENTIFIERS and arranges their properties in ABC order for better readability. [77](https://github.com/input-output-hk/react-polymorph/pull/77)
 
 - Adds support for React v15 - v16.4.1. Upgrades devDependencies to latest versions of react, jest, and enzyme related libraries. Adds Autocomplete simulation test for deleting a selected option via backspace key. [PR 65](https://github.com/input-output-hk/react-polymorph/pull/65)
 - Refactor npm scripts to colon style [PR 66](https://github.com/input-output-hk/react-polymorph/pull/66)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 
 ### Chores
 
+- Replaces all default exports in the theme directory with constants and exports them. Puts all properties of SimpleTheme and ROOT_THEME_API objects in ABC and uses IDENTIFIERS constants for safety. [77](https://github.com/input-output-hk/react-polymorph/pull/77)
+
 - Adds support for React v15 - v16.4.1. Upgrades devDependencies to latest versions of react, jest, and enzyme related libraries. Adds Autocomplete simulation test for deleting a selected option via backspace key. [PR 65](https://github.com/input-output-hk/react-polymorph/pull/65)
 - Refactor npm scripts to colon style [PR 66](https://github.com/input-output-hk/react-polymorph/pull/66)
 

--- a/source/components/HOC/ThemeContext.js
+++ b/source/components/HOC/ThemeContext.js
@@ -2,21 +2,9 @@
 import React from 'react';
 import createReactContext, { type Context } from 'create-react-context';
 
-import ROOT_THEME_API from '../../themes/API';
-import SimpleAutocomplete from '../../themes/simple/SimpleAutocomplete.scss';
-import SimpleBubble from '../../themes/simple/SimpleBubble.scss';
-import SimpleButton from '../../themes/simple/SimpleButton.scss';
-import SimpleCheckbox from '../../themes/simple/SimpleCheckbox.scss';
-import SimpleFormField from '../../themes/simple/SimpleFormField.scss';
-import SimpleInput from '../../themes/simple/SimpleInput.scss';
-import SimpleModal from '../../themes/simple/SimpleModal.scss';
-import SimpleOptions from '../../themes/simple/SimpleOptions.scss';
-import SimpleRadio from '../../themes/simple/SimpleRadio.scss';
-import SimpleSelect from '../../themes/simple/SimpleSelect.scss';
-import SimpleSwitch from '../../themes/simple/SimpleSwitch.scss';
-import SimpleTextArea from '../../themes/simple/SimpleTextArea.scss';
-import SimpleToggler from '../../themes/simple/SimpleToggler.scss';
-import SimpleTooltip from '../../themes/simple/SimpleTooltip.scss';
+// import constants
+import { ROOT_THEME_API } from '../../themes/API';
+import { SimpleTheme } from '../../themes/simple/';
 
 // components that are NOT directly nested within a ThemeProvider
 // can access simple theme as "this.props.context.theme",
@@ -37,23 +25,6 @@ if (React.createContext) {
 type Theme = {
   theme: Object,
   ROOT_THEME_API: Object
-};
-
-const SimpleTheme = {
-  autocomplete: SimpleAutocomplete,
-  bubble: SimpleBubble,
-  button: SimpleButton,
-  checkbox: SimpleCheckbox,
-  formfield: SimpleFormField,
-  input: SimpleInput,
-  modal: SimpleModal,
-  options: SimpleOptions,
-  radio: SimpleRadio,
-  select: SimpleSelect,
-  switch: SimpleSwitch,
-  textarea: SimpleTextArea,
-  toggler: SimpleToggler,
-  tooltip: SimpleTooltip
 };
 
 const defaultContext = { theme: SimpleTheme, ROOT_THEME_API };

--- a/source/components/ThemeProvider.js
+++ b/source/components/ThemeProvider.js
@@ -10,7 +10,7 @@ import { ThemeContext } from './HOC/ThemeContext';
 
 // imports the Root Theme API object which specifies the shape
 // of a complete theme for every component in this library, used in this.composeLibraryTheme
-import ROOT_THEME_API from '../themes/API';
+import { ROOT_THEME_API } from '../themes/API';
 
 // internal utility functions
 import { composeTheme } from '../utils/themes';

--- a/source/themes/API/autocomplete.js
+++ b/source/themes/API/autocomplete.js
@@ -1,5 +1,5 @@
 // @flow
-export default {
+export const AUTOCOMPLETE_THEME_API = {
   autocompleteWrapper: '',
   autocompleteContent: '',
   selectedWords: '',

--- a/source/themes/API/bubble.js
+++ b/source/themes/API/bubble.js
@@ -1,5 +1,5 @@
 // @flow
-export default {
+export const BUBBLE_THEME_API = {
   root: '',
   bubble: '',
   openUpward: '',

--- a/source/themes/API/button.js
+++ b/source/themes/API/button.js
@@ -1,5 +1,5 @@
 // @flow
-export default {
+export const BUTTON_THEME_API = {
   root: '',
   disabled: ''
 };

--- a/source/themes/API/checkbox.js
+++ b/source/themes/API/checkbox.js
@@ -1,5 +1,5 @@
 // @flow
-export default {
+export const CHECKBOX_THEME_API = {
   root: '',
   disabled: '',
   checked: '',

--- a/source/themes/API/formfield.js
+++ b/source/themes/API/formfield.js
@@ -1,5 +1,5 @@
 // @flow
-export default {
+export const FORM_FIELD_THEME_API = {
   root: '',
   disabled: '',
   error: '',

--- a/source/themes/API/index.js
+++ b/source/themes/API/index.js
@@ -1,64 +1,49 @@
 // @flow
-import FORMFIELD from './formfield';
-import INPUT from './input';
-import CHECKBOX from './checkbox';
-import TOGGLER from './toggler';
-import SWITCH from './switch';
-import TEXTAREA from './textarea';
-import BUTTON from './button';
-import TOOLTIP from './tooltip';
-import BUBBLE from './bubble';
-import SELECT from './select';
-import AUTOCOMPLETE from './autocomplete';
-import OPTIONS from './options';
-import MODAL from './modal';
-import RADIO from './radio';
-
-export const FORMFIELD_THEME_API = FORMFIELD;
-export const INPUT_THEME_API = INPUT;
-export const CHECKBOX_THEME_API = CHECKBOX;
-export const TOGGLER_THEME_API = TOGGLER;
-export const SWITCH_THEME_API = SWITCH;
-export const TEXTAREA_THEME_API = TEXTAREA;
-export const BUTTON_THEME_API = BUTTON;
-export const TOOLTIP_THEME_API = TOOLTIP;
-export const BUBBLE_THEME_API = BUBBLE;
-export const SELECT_THEME_API = SELECT;
-export const AUTOCOMPLETE_THEME_API = AUTOCOMPLETE;
-export const OPTIONS_THEME_API = OPTIONS;
-export const MODAL_THEME_API = MODAL;
-export const RADIO_THEME_API = RADIO;
+import { AUTOCOMPLETE_THEME_API } from './autocomplete';
+import { BUBBLE_THEME_API } from './bubble';
+import { BUTTON_THEME_API } from './button';
+import { CHECKBOX_THEME_API } from './checkbox';
+import { FORM_FIELD_THEME_API } from './formfield';
+import { INPUT_THEME_API } from './input';
+import { MODAL_THEME_API } from './modal';
+import { OPTIONS_THEME_API } from './options';
+import { RADIO_THEME_API } from './radio';
+import { SELECT_THEME_API } from './select';
+import { SWITCH_THEME_API } from './switch';
+import { TEXT_AREA_THEME_API } from './textarea';
+import { TOGGLER_THEME_API } from './toggler';
+import { TOOLTIP_THEME_API } from './tooltip';
 
 export const IDENTIFIERS = {
+  AUTOCOMPLETE: 'autocomplete',
+  BUBBLE: 'bubble',
+  BUTTON: 'button',
+  CHECKBOX: 'checkbox',
   FORM_FIELD: 'formfield',
   INPUT: 'input',
-  CHECKBOX: 'checkbox',
-  TOGGLER: 'toggler',
+  MODAL: 'modal',
+  OPTIONS: 'options',
+  RADIO: 'radio',
+  SELECT: 'select',
   SWITCH: 'switch',
   TEXT_AREA: 'textarea',
-  BUTTON: 'button',
-  TOOLTIP: 'tooltip',
-  BUBBLE: 'bubble',
-  SELECT: 'select',
-  AUTOCOMPLETE: 'autocomplete',
-  OPTIONS: 'options',
-  MODAL: 'modal',
-  RADIO: 'radio'
+  TOGGLER: 'toggler',
+  TOOLTIP: 'tooltip'
 };
 
-export default {
-  [IDENTIFIERS.FORM_FIELD]: { ...FORMFIELD_THEME_API },
-  [IDENTIFIERS.INPUT]: { ...INPUT_THEME_API },
-  [IDENTIFIERS.CHECKBOX]: { ...CHECKBOX_THEME_API },
-  [IDENTIFIERS.TOGGLER]: { ...TOGGLER_THEME_API },
-  [IDENTIFIERS.SWITCH]: { ...SWITCH_THEME_API },
-  [IDENTIFIERS.TEXT_AREA]: { ...TEXTAREA_THEME_API },
-  [IDENTIFIERS.BUTTON]: { ...BUTTON_THEME_API },
-  [IDENTIFIERS.TOOLTIP]: { ...TOOLTIP_THEME_API },
-  [IDENTIFIERS.BUBBLE]: { ...BUBBLE_THEME_API },
-  [IDENTIFIERS.SELECT]: { ...SELECT_THEME_API },
-  [IDENTIFIERS.AUTOCOMPLETE]: { ...AUTOCOMPLETE_THEME_API },
-  [IDENTIFIERS.OPTIONS]: { ...OPTIONS_THEME_API },
-  [IDENTIFIERS.MODAL]: { ...MODAL_THEME_API },
-  [IDENTIFIERS.RADIO]: { ...RADIO_THEME_API }
+export const ROOT_THEME_API = {
+  [IDENTIFIERS.AUTOCOMPLETE]: AUTOCOMPLETE_THEME_API,
+  [IDENTIFIERS.BUBBLE]: BUBBLE_THEME_API,
+  [IDENTIFIERS.BUTTON]: BUTTON_THEME_API,
+  [IDENTIFIERS.CHECKBOX]: CHECKBOX_THEME_API,
+  [IDENTIFIERS.FORM_FIELD]: FORM_FIELD_THEME_API,
+  [IDENTIFIERS.INPUT]: INPUT_THEME_API,
+  [IDENTIFIERS.MODAL]: MODAL_THEME_API,
+  [IDENTIFIERS.OPTIONS]: OPTIONS_THEME_API,
+  [IDENTIFIERS.RADIO]: RADIO_THEME_API,
+  [IDENTIFIERS.SELECT]: SELECT_THEME_API,
+  [IDENTIFIERS.SWITCH]: SWITCH_THEME_API,
+  [IDENTIFIERS.TEXT_AREA]: TEXT_AREA_THEME_API,
+  [IDENTIFIERS.TOGGLER]: TOGGLER_THEME_API,
+  [IDENTIFIERS.TOOLTIP]: TOOLTIP_THEME_API
 };

--- a/source/themes/API/input.js
+++ b/source/themes/API/input.js
@@ -1,5 +1,5 @@
 // @flow
-export default {
+export const INPUT_THEME_API = {
   input: '',
   disabled: '',
   errored: ''

--- a/source/themes/API/modal.js
+++ b/source/themes/API/modal.js
@@ -1,5 +1,5 @@
 // @flow
-export default {
+export const MODAL_THEME_API = {
   overlay: '',
   modal: ''
 };

--- a/source/themes/API/options.js
+++ b/source/themes/API/options.js
@@ -1,5 +1,5 @@
 // @flow
-export default {
+export const OPTIONS_THEME_API = {
   disabledOption: '',
   firstOptionHighlighted: '',
   highlightedOption: '',

--- a/source/themes/API/radio.js
+++ b/source/themes/API/radio.js
@@ -1,5 +1,5 @@
 // @flow
-export default {
+export const RADIO_THEME_API = {
   root: '',
   disabled: '',
   input: '',

--- a/source/themes/API/select.js
+++ b/source/themes/API/select.js
@@ -1,5 +1,5 @@
 // @flow
-export default {
+export const SELECT_THEME_API = {
   select: '',
   selectInput: '',
   input: '',

--- a/source/themes/API/switch.js
+++ b/source/themes/API/switch.js
@@ -1,5 +1,5 @@
 // @flow
-export default {
+export const SWITCH_THEME_API = {
   root: '',
   input: '',
   switch: '',

--- a/source/themes/API/textarea.js
+++ b/source/themes/API/textarea.js
@@ -1,5 +1,5 @@
 // @flow
-export default {
+export const TEXT_AREA_THEME_API = {
   textarea: '',
   disabled: '',
   errored: ''

--- a/source/themes/API/toggler.js
+++ b/source/themes/API/toggler.js
@@ -1,5 +1,5 @@
 // @flow
-export default {
+export const TOGGLER_THEME_API = {
   root: '',
   input: '',
   toggler: '',

--- a/source/themes/API/tooltip.js
+++ b/source/themes/API/tooltip.js
@@ -1,5 +1,5 @@
 // @flow
-export default {
+export const TOOLTIP_THEME_API = {
   root: '',
   bubble: '',
   alignRight: '',

--- a/source/themes/simple/index.js
+++ b/source/themes/simple/index.js
@@ -1,54 +1,40 @@
 // @flow
-// css modules plugin converts all imports below into plain objects
-import Autocomplete from './SimpleAutocomplete.scss';
-import Bubble from './SimpleBubble.scss';
-import Button from './SimpleButton.scss';
-import Checkbox from './SimpleCheckbox.scss';
-import FormField from './SimpleFormField.scss';
-import Input from './SimpleInput.scss';
-import Modal from './SimpleModal.scss';
-import Options from './SimpleOptions.scss';
-import Radio from './SimpleRadio.scss';
-import Select from './SimpleSelect.scss';
-import Switch from './SimpleSwitch.scss';
-import TextArea from './SimpleTextArea.scss';
-import Toggler from './SimpleToggler.scss';
-import Tooltip from './SimpleTooltip.scss';
+// import theme IDENTIFIERS constants
+import { IDENTIFIERS } from '../API';
 
-// named exports allow user to import a single theme object per component
-// instead of importing and destructuring the entire SimpleTheme obj
-export const AutocompleteTheme = Autocomplete;
-export const BubbleTheme = Bubble;
-export const ButtonTheme = Button;
-export const CheckboxTheme = Checkbox;
-export const FormFieldTheme = FormField;
-export const InputTheme = Input;
-export const ModalTheme = Modal;
-export const OptionsTheme = Options;
-export const RadioTheme = Radio;
-export const SelectTheme = Select;
-export const SwitchTheme = Switch;
-export const TextAreaTheme = TextArea;
-export const TogglerTheme = Toggler;
-export const TooltipTheme = Tooltip;
+// css modules plugin converts all imports below into plain objects
+import SimpleAutocomplete from './SimpleAutocomplete.scss';
+import SimpleBubble from './SimpleBubble.scss';
+import SimpleButton from './SimpleButton.scss';
+import SimpleCheckbox from './SimpleCheckbox.scss';
+import SimpleFormField from './SimpleFormField.scss';
+import SimpleInput from './SimpleInput.scss';
+import SimpleModal from './SimpleModal.scss';
+import SimpleOptions from './SimpleOptions.scss';
+import SimpleRadio from './SimpleRadio.scss';
+import SimpleSelect from './SimpleSelect.scss';
+import SimpleSwitch from './SimpleSwitch.scss';
+import SimpleTextArea from './SimpleTextArea.scss';
+import SimpleToggler from './SimpleToggler.scss';
+import SimpleTooltip from './SimpleTooltip.scss';
 
 // SimpleTheme is a plain object serving as the default export.
 // Each key is named after a component and each key's value
 // is the component's corresponding theme. The user can
 // pass this entire obj directly to ThemeProvider via the "theme" prop
-export default {
-  autocomplete: { ...AutocompleteTheme },
-  bubble: { ...BubbleTheme },
-  button: { ...ButtonTheme },
-  checkbox: { ...CheckboxTheme },
-  formfield: { ...FormFieldTheme },
-  input: { ...InputTheme },
-  modal: { ...ModalTheme },
-  options: { ...OptionsTheme },
-  radio: { ...RadioTheme },
-  select: { ...SelectTheme },
-  switch: { ...SwitchTheme },
-  textarea: { ...TextAreaTheme },
-  toggler: { ...TogglerTheme },
-  tooltip: { ...TooltipTheme }
+export const SimpleTheme = {
+  [IDENTIFIERS.AUTOCOMPLETE]: SimpleAutocomplete,
+  [IDENTIFIERS.BUBBLE]: SimpleBubble,
+  [IDENTIFIERS.BUTTON]: SimpleButton,
+  [IDENTIFIERS.CHECKBOX]: SimpleCheckbox,
+  [IDENTIFIERS.FORM_FIELD]: SimpleFormField,
+  [IDENTIFIERS.INPUT]: SimpleInput,
+  [IDENTIFIERS.MODAL]: SimpleModal,
+  [IDENTIFIERS.OPTIONS]: SimpleOptions,
+  [IDENTIFIERS.RADIO]: SimpleRadio,
+  [IDENTIFIERS.SELECT]: SimpleSelect,
+  [IDENTIFIERS.SWITCH]: SimpleSwitch,
+  [IDENTIFIERS.TEXT_AREA]: SimpleTextArea,
+  [IDENTIFIERS.TOGGLER]: SimpleToggler,
+  [IDENTIFIERS.TOOLTIP]: SimpleTooltip
 };

--- a/stories/Select.stories.js
+++ b/stories/Select.stories.js
@@ -14,7 +14,7 @@ import { Button } from '../source/components/Button';
 import { ButtonSkin } from '../source/skins/simple/ButtonSkin';
 
 // themes
-import SimpleTheme from '../source/themes/simple';
+import { SimpleTheme } from '../source/themes/simple';
 import CustomSelectTheme from './theme-customizations/Select.custom.scss';
 
 // custom styles

--- a/stories/ThemeProvider.stories.js
+++ b/stories/ThemeProvider.stories.js
@@ -40,7 +40,8 @@ import CustomModalTheme from './theme-customizations/Modal.custom.scss';
 import CustomButtonTheme from './theme-customizations/Button.custom.scss';
 import CustomCheckboxTheme from './theme-customizations/Checkbox.custom.scss';
 import CustomAutocompleteTheme from './theme-customizations/Autocomplete.custom.scss';
-import { BubbleTheme, FormFieldTheme } from '../source/themes/simple';
+import SimpleBubble from '../source/themes/simple/SimpleBubble.scss';
+import SimpleFormField from '../source/themes/simple/SimpleFormField.scss';
 
 const OPTIONS = [
   'home',
@@ -60,8 +61,8 @@ const CUSTOM_THEME = {
   [IDENTIFIERS.BUTTON]: CustomButtonTheme,
   [IDENTIFIERS.CHECKBOX]: CustomCheckboxTheme,
   [IDENTIFIERS.AUTOCOMPLETE]: CustomAutocompleteTheme,
-  [IDENTIFIERS.BUBBLE]: BubbleTheme,
-  [IDENTIFIERS.FORM_FIELD]: FormFieldTheme
+  [IDENTIFIERS.BUBBLE]: SimpleBubble,
+  [IDENTIFIERS.FORM_FIELD]: SimpleFormField
 };
 
 storiesOf('ThemeProvider', module)

--- a/stories/Tooltip.stories.js
+++ b/stories/Tooltip.stories.js
@@ -11,7 +11,7 @@ import { Tooltip } from '../source/components/Tooltip';
 import { TooltipSkin } from '../source/skins/simple/TooltipSkin';
 
 // themes
-import SimpleTheme from '../source/themes/simple';
+import { SimpleTheme } from '../source/themes/simple';
 import CustomBubbleTheme from './theme-customizations/Bubble.custom.scss';
 
 // custom styles & theme overrides


### PR DESCRIPTION
- This PR replaces all default exports in the theme directory with constants and exports them.

- This allows each component's theme API object to be imported as a named import. This change reduces file size and clutter within `themes/API/index.js` and `themes/simple/index.js`.

- Puts `SimpleTheme` and `ROOT_THEME_API` properties in ABC order and defines properties using `IDENTIFIERS`.

- In `HOC/ThemeContext.js` the import statements for each component's theme file are removed along with the reconstructed `SimpleTheme` object that's passed to `defaultContext`. `SimpleTheme` is now imported as a constant and passed to `defaultContext,` reducing file size and improving readability.