### PR TITLE
[DDW-367] use empty theme as default to avoid duplicated styles

### DIFF
--- a/__tests__/Autocomplete.behavior.test.js
+++ b/__tests__/Autocomplete.behavior.test.js
@@ -1,0 +1,330 @@
+import React from 'react';
+
+import { Autocomplete } from '../source/components/Autocomplete';
+import { AutocompleteSkin } from '../source/skins/simple/AutocompleteSkin';
+import { mountInSimpleTheme } from './helpers/theming';
+
+const MNEMONIC_WORDS = [
+  'home',
+  'cat',
+  'dog',
+  'fish',
+  'hide',
+  'hover',
+  'duck',
+  'category',
+  'join',
+  'paper',
+  'box',
+  'tab'
+];
+
+const ABC_SORTED_MNEMONICS = [
+  'home',
+  'cat',
+  'dog',
+  'fish',
+  'hide',
+  'hover',
+  'duck',
+  'category',
+  'join',
+  'paper',
+  'box',
+  'tab'
+].sort();
+
+describe('Autocomplete onChange simulations', () => {
+  test('Autocomplete is closed by default and when clicked is open and displays options', () => {
+    const wrapper = mountInSimpleTheme(
+      <Autocomplete
+        options={MNEMONIC_WORDS}
+        skin={AutocompleteSkin}
+      />
+    );
+    const component = wrapper.find('AutocompleteBase').instance();
+    const input = wrapper.find('input');
+    const options = wrapper.find('div.options');
+
+    // assert Autocomplete is closed by default
+    // first, via state
+    expect(component.state.isOpen).toBe(false);
+    // then, via classnames
+    expect(options.instance().className).toBe('options firstOptionHighlighted root isFloating isHidden');
+
+    // open Autocomplete
+    input.simulate('click', {});
+
+    // assert Autocomplete is open and displaying options
+    // first, via state
+    expect(component.state.isOpen).toBe(true);
+    expect(component.state.filteredOptions.length).toBe(12);
+    // then, via classnames
+    expect(options.instance().className).toBe('options isOpen firstOptionHighlighted root isFloating');
+  });
+
+  test('Autocomplete puts options in abc order and highlights first option by default when open', () => {
+    const wrapper = mountInSimpleTheme(
+      <Autocomplete
+        options={MNEMONIC_WORDS}
+        skin={AutocompleteSkin}
+      />
+    );
+    const component = wrapper.find('AutocompleteBase').instance();
+    const input = wrapper.find('input');
+
+    // open Autocomplete
+    input.simulate('click', {});
+
+    const arraysAreEqual = (array1, array2) => {
+      if (!array1 || !array2) { return false; }
+      if (!Array.isArray(array1) || !Array.isArray(array2)) { return false; }
+      if (array1.length !== array2.length) { return false; }
+
+      const unequalValues = array1.filter((value, index) => value !== array2[index]);
+      return unequalValues.length === 0;
+    };
+
+    // assert Autocomplete's filteredOptions are in ABC order
+    expect(arraysAreEqual(ABC_SORTED_MNEMONICS, component.state.filteredOptions)).toBe(true);
+
+    // set highlightedOption
+    const highlightedOption = wrapper.find('li.highlightedOption');
+
+    // assert highlighted option is the first option by default
+    expect(highlightedOption.text()).toBe(ABC_SORTED_MNEMONICS[0]);
+  });
+
+  test('Autocomplete closes if open and escape key is pressed', () => {
+    const map = {};
+    document.addEventListener = jest.fn().mockImplementation((event, cb) => {
+      map[event] = cb;
+    });
+
+    const wrapper = mountInSimpleTheme(
+      <Autocomplete
+        options={MNEMONIC_WORDS}
+        skin={AutocompleteSkin}
+      />
+    );
+    const component = wrapper.find('AutocompleteBase').instance();
+    const input = wrapper.find('input');
+    const options = wrapper.find('div.options');
+
+    // simulate click on Autocomplete's input
+    input.simulate('click', {});
+
+    // simulate escape key being pressed
+    map.keydown({ keyCode: 27 });
+    wrapper.update();
+
+    // assert Autocomplete is now closed again
+    // first, via state
+    expect(component.state.isOpen).toBe(false);
+    // then, via classnames
+    expect(options.instance().className).toBe('options firstOptionHighlighted root isFloating isHidden');
+  });
+
+  test('Autocomplete shows correct options after user input is simulated', () => {
+    const wrapper = mountInSimpleTheme(
+      <Autocomplete
+        options={MNEMONIC_WORDS}
+        skin={AutocompleteSkin}
+      />
+    );
+    const component = wrapper.find('AutocompleteBase').instance();
+    const input = wrapper.find('input');
+
+    // open Autocomplete
+    input.simulate('click', {});
+
+    // assert Autocomplete's filteredOptions has a length of 12 (all options)
+    expect(component.state.filteredOptions.length).toBe(12);
+
+    // simulate user typing 'h'
+    input.simulate('change', { target: { value: 'h' } });
+
+    // assert inputValue is now 'h' and options beginning with 'h' are shown
+    // first, via component state
+    expect(component.state.inputValue).toBe('h');
+    expect(component.state.filteredOptions.length).toBe(3); // hide, home, hover
+    // then, via classnames
+    expect(wrapper.find('li.option').length).toBe(3);
+    expect(wrapper.find('li.option').first().text()).toBe('hide');
+    expect(wrapper.find('li.highlightedOption').text()).toBe('hide');
+
+    // simulate more specific user input of 'hover'
+    input.simulate('change', { target: { value: 'hover' } });
+
+    // assert inputValue is now 'hover' and only the 'hover' option is shown
+    // first, via component state
+    expect(component.state.inputValue).toBe('hover');
+    expect(component.state.filteredOptions.length).toBe(1);
+    // then, via classnames
+    expect(wrapper.find('li.option').length).toBe(1);
+    expect(wrapper.find('li.option').first().text()).toBe('hover');
+    expect(wrapper.find('li.highlightedOption').text()).toBe('hover');
+  });
+
+  test('Autcomplete selects highlighted option when tab key is pressed', () => {
+    const map = {};
+    document.addEventListener = jest.fn().mockImplementation((event, cb) => {
+      map[event] = cb;
+    });
+
+    const wrapper = mountInSimpleTheme(
+      <Autocomplete
+        options={MNEMONIC_WORDS}
+        skin={AutocompleteSkin}
+      />
+    );
+    const component = wrapper.find('AutocompleteBase').instance();
+    const input = wrapper.find('input');
+
+    // open Autocomplete
+    input.simulate('click', {});
+
+    // simulate tab key being pressed
+    map.keydown({ keyCode: 9, preventDefault() {} });
+
+    // assert that selected options contains only 'box' (1st ABC sorted option)
+    expect(component.state.selectedOptions.length).toBe(1);
+    expect(component.state.selectedOptions[0]).toBe(ABC_SORTED_MNEMONICS[0]);
+
+    // assert Autocomplete is closed after option is selected
+    expect(component.state.isOpen).toBe(false);
+  });
+
+  test('Autcomplete selects highlighted option when enter key is pressed', () => {
+    const map = {};
+    document.addEventListener = jest.fn().mockImplementation((event, cb) => {
+      map[event] = cb;
+    });
+
+    const wrapper = mountInSimpleTheme(
+      <Autocomplete
+        options={MNEMONIC_WORDS}
+        skin={AutocompleteSkin}
+      />
+    );
+    const component = wrapper.find('AutocompleteBase').instance();
+    const input = wrapper.find('input');
+
+    // open Autocomplete
+    input.simulate('click', {});
+
+    // simulate enter key being pressed
+    map.keydown({ keyCode: 13, preventDefault() {} });
+
+    // assert that selected options contains only 'box' (1st ABC sorted option)
+    expect(component.state.selectedOptions.length).toBe(1);
+    expect(component.state.selectedOptions[0]).toBe(ABC_SORTED_MNEMONICS[0]);
+
+    // assert Autocomplete is closed after option is selected
+    expect(component.state.isOpen).toBe(false);
+  });
+
+  test('Autcomplete selects highlighted option when space key is pressed', () => {
+    const map = {};
+    document.addEventListener = jest.fn().mockImplementation((event, cb) => {
+      map[event] = cb;
+    });
+
+    const wrapper = mountInSimpleTheme(
+      <Autocomplete
+        options={MNEMONIC_WORDS}
+        skin={AutocompleteSkin}
+      />
+    );
+    const component = wrapper.find('AutocompleteBase').instance();
+    const input = wrapper.find('input');
+
+    // open Autocomplete
+    input.simulate('click', {});
+
+    // simulate space key being pressed
+    map.keydown({ keyCode: 32, preventDefault() {} });
+
+    // assert that selected options contains only 'box' (1st ABC sorted option)
+    expect(component.state.selectedOptions.length).toBe(1);
+    expect(component.state.selectedOptions[0]).toBe(ABC_SORTED_MNEMONICS[0]);
+
+    // assert Autocomplete is closed after option is selected
+    expect(component.state.isOpen).toBe(false);
+  });
+
+  test('Autcomplete updates highlighted option when down arrow key is pressed and selects it with click', () => {
+    const map = {};
+    document.addEventListener = jest.fn().mockImplementation((event, cb) => {
+      map[event] = cb;
+    });
+
+    const wrapper = mountInSimpleTheme(
+      <Autocomplete
+        options={MNEMONIC_WORDS}
+        skin={AutocompleteSkin}
+      />
+    );
+    const component = wrapper.find('AutocompleteBase').instance();
+    const input = wrapper.find('input');
+
+    // open Autocomplete
+    input.simulate('click', {});
+
+    // simulate arrow down key being pressed 3 times
+    map.keydown({ keyCode: 40, preventDefault() {} });
+    map.keydown({ keyCode: 40, preventDefault() {} });
+    map.keydown({ keyCode: 40, preventDefault() {} });
+    wrapper.update();
+
+    // assert that highlighted option is now 'dog' (4th ABC sorted options)
+    expect(wrapper.find('li.highlightedOption').text()).toBe(ABC_SORTED_MNEMONICS[3]);
+
+    // simulate click on highlighted option
+    wrapper.find('li.highlightedOption').simulate('click', {});
+
+    // assert selected options now contains only 'dog' (4th ABC sorted options)
+    // and Autocomplete is closed
+    expect(component.state.selectedOptions.length).toBe(1);
+    expect(component.state.selectedOptions[0]).toBe(ABC_SORTED_MNEMONICS[3]);
+    expect(component.state.isOpen).toBe(false);
+  });
+
+  test('Autocomplete deletes a selected option when backspace is pressed', () => {
+    const map = {};
+    document.addEventListener = jest.fn().mockImplementation((event, cb) => {
+      map[event] = cb;
+    });
+
+    const wrapper = mountInSimpleTheme(
+      <Autocomplete
+        options={MNEMONIC_WORDS}
+        skin={AutocompleteSkin}
+      />
+    );
+    const component = wrapper.find('AutocompleteBase').instance();
+    const input = wrapper.find('input');
+
+    // open Autocomplete
+    input.simulate('click', {});
+
+    // simulate user typing 'hide'
+    input.simulate('change', { target: { value: 'hide' } });
+
+    // select 'hide' via pressing enter key
+    map.keydown({ keyCode: 13, preventDefault() {} });
+
+    // assert 'hide' is now a selected option
+    expect(component.state.selectedOptions.length).toBe(1);
+    expect(component.state.selectedOptions[0]).toBe('hide');
+
+    // assert inputValue is empty before attempting to delete 'hide'
+    expect(component.state.inputValue).toBe('');
+
+    // simulate backspace to delete 'hide'
+    input.simulate('keydown', { keyCode: 8 });
+
+    // assert backspace deleted the selected option 'hide'
+    expect(component.state.selectedOptions.length).toBe(0);
+  });
+});

--- a/__tests__/Autocomplete.test.js
+++ b/__tests__/Autocomplete.test.js
@@ -1,9 +1,8 @@
 import React from 'react';
-import renderer from 'react-test-renderer';
-import { mount } from 'enzyme';
 
 import { Autocomplete } from '../source/components/Autocomplete';
 import { AutocompleteSkin } from '../source/skins/simple/AutocompleteSkin';
+import { renderInSimpleTheme } from './helpers/theming';
 
 const OPTIONS = [
   'home',
@@ -12,38 +11,8 @@ const OPTIONS = [
   'fish'
 ];
 
-const MNEMONIC_WORDS = [
-  'home',
-  'cat',
-  'dog',
-  'fish',
-  'hide',
-  'hover',
-  'duck',
-  'category',
-  'join',
-  'paper',
-  'box',
-  'tab'
-];
-
-const ABC_SORTED_MNEMONICS = [
-  'home',
-  'cat',
-  'dog',
-  'fish',
-  'hide',
-  'hover',
-  'duck',
-  'category',
-  'join',
-  'paper',
-  'box',
-  'tab'
-].sort();
-
 test('Autocomplete renders correctly', () => {
-  const component = renderer.create(
+  const component = renderInSimpleTheme(
     <Autocomplete
       options={OPTIONS}
       skin={AutocompleteSkin}
@@ -55,7 +24,7 @@ test('Autocomplete renders correctly', () => {
 });
 
 test('Autocomplete renders with label', () => {
-  const component = renderer.create(
+  const component = renderInSimpleTheme(
     <Autocomplete
       label="Enter your recovery phrase below"
       options={OPTIONS}
@@ -68,7 +37,7 @@ test('Autocomplete renders with label', () => {
 });
 
 test('Autocomplete renders with a placeholder', () => {
-  const component = renderer.create(
+  const component = renderInSimpleTheme(
     <Autocomplete
       placeholder="Enter recovery phrase"
       options={OPTIONS}
@@ -81,7 +50,7 @@ test('Autocomplete renders with a placeholder', () => {
 });
 
 test('Autocomplete renders with an error', () => {
-  const component = renderer.create(
+  const component = renderInSimpleTheme(
     <Autocomplete
       error="Your mnemonic phrase is incorrect"
       options={OPTIONS}
@@ -94,7 +63,7 @@ test('Autocomplete renders with an error', () => {
 });
 
 test('Autocomplete uses render prop - renderSelections', () => {
-  const component = renderer.create(
+  const component = renderInSimpleTheme(
     <Autocomplete
       options={OPTIONS}
       skin={AutocompleteSkin}
@@ -120,7 +89,7 @@ test('Autocomplete uses render prop - renderSelections', () => {
 });
 
 test('Autocomplete uses render prop - renderOptions', () => {
-  const component = renderer.create(
+  const component = renderInSimpleTheme(
     <Autocomplete
       options={OPTIONS}
       skin={AutocompleteSkin}
@@ -138,299 +107,4 @@ test('Autocomplete uses render prop - renderOptions', () => {
 
   const tree = component.toJSON();
   expect(tree).toMatchSnapshot();
-});
-
-describe('Autocomplete onChange simulations', () => {
-  test('Autocomplete is closed by default and when clicked is open and displays options', () => {
-    const wrapper = mount(
-      <Autocomplete
-        options={MNEMONIC_WORDS}
-        skin={AutocompleteSkin}
-      />
-    );
-    const component = wrapper.find('AutocompleteBase').instance();
-    const input = wrapper.find('input');
-    const options = wrapper.find('div.options');
-
-    // assert Autocomplete is closed by default
-    // first, via state
-    expect(component.state.isOpen).toBe(false);
-    // then, via classnames
-    expect(options.instance().className).toBe('options firstOptionHighlighted root isFloating isHidden');
-
-    // open Autocomplete
-    input.simulate('click', {});
-
-    // assert Autocomplete is open and displaying options
-    // first, via state
-    expect(component.state.isOpen).toBe(true);
-    expect(component.state.filteredOptions.length).toBe(12);
-    // then, via classnames
-    expect(options.instance().className).toBe('options isOpen firstOptionHighlighted root isFloating');
-  });
-
-  test('Autocomplete puts options in abc order and highlights first option by default when open', () => {
-    const wrapper = mount(
-      <Autocomplete
-        options={MNEMONIC_WORDS}
-        skin={AutocompleteSkin}
-      />
-    );
-    const component = wrapper.find('AutocompleteBase').instance();
-    const input = wrapper.find('input');
-
-    // open Autocomplete
-    input.simulate('click', {});
-
-    const arraysAreEqual = (array1, array2) => {
-      if (!array1 || !array2) { return false; }
-      if (!Array.isArray(array1) || !Array.isArray(array2)) { return false; }
-      if (array1.length !== array2.length) { return false; }
-
-      const unequalValues = array1.filter((value, index) => value !== array2[index]);
-      return unequalValues.length === 0;
-    };
-
-    // assert Autocomplete's filteredOptions are in ABC order
-    expect(arraysAreEqual(ABC_SORTED_MNEMONICS, component.state.filteredOptions)).toBe(true);
-
-    // set highlightedOption
-    const highlightedOption = wrapper.find('li.highlightedOption');
-
-    // assert highlighted option is the first option by default
-    expect(highlightedOption.text()).toBe(ABC_SORTED_MNEMONICS[0]);
-  });
-
-  test('Autocomplete closes if open and escape key is pressed', () => {
-    const map = {};
-    document.addEventListener = jest.fn().mockImplementation((event, cb) => {
-      map[event] = cb;
-    });
-
-    const wrapper = mount(
-      <Autocomplete
-        options={MNEMONIC_WORDS}
-        skin={AutocompleteSkin}
-      />
-    );
-    const component = wrapper.find('AutocompleteBase').instance();
-    const input = wrapper.find('input');
-    const options = wrapper.find('div.options');
-
-    // simulate click on Autocomplete's input
-    input.simulate('click', {});
-
-    // simulate escape key being pressed
-    map.keydown({ keyCode: 27 });
-    wrapper.update();
-
-    // assert Autocomplete is now closed again
-    // first, via state
-    expect(component.state.isOpen).toBe(false);
-    // then, via classnames
-    expect(options.instance().className).toBe('options firstOptionHighlighted root isFloating isHidden');
-  });
-
-  test('Autocomplete shows correct options after user input is simulated', () => {
-    const wrapper = mount(
-      <Autocomplete
-        options={MNEMONIC_WORDS}
-        skin={AutocompleteSkin}
-      />
-    );
-    const component = wrapper.find('AutocompleteBase').instance();
-    const input = wrapper.find('input');
-
-    // open Autocomplete
-    input.simulate('click', {});
-
-    // assert Autocomplete's filteredOptions has a length of 12 (all options)
-    expect(component.state.filteredOptions.length).toBe(12);
-
-    // simulate user typing 'h'
-    input.simulate('change', { target: { value: 'h' } });
-
-    // assert inputValue is now 'h' and options beginning with 'h' are shown
-    // first, via component state
-    expect(component.state.inputValue).toBe('h');
-    expect(component.state.filteredOptions.length).toBe(3); // hide, home, hover
-    // then, via classnames
-    expect(wrapper.find('li.option').length).toBe(3);
-    expect(wrapper.find('li.option').first().text()).toBe('hide');
-    expect(wrapper.find('li.highlightedOption').text()).toBe('hide');
-
-    // simulate more specific user input of 'hover'
-    input.simulate('change', { target: { value: 'hover' } });
-
-    // assert inputValue is now 'hover' and only the 'hover' option is shown
-    // first, via component state
-    expect(component.state.inputValue).toBe('hover');
-    expect(component.state.filteredOptions.length).toBe(1);
-    // then, via classnames
-    expect(wrapper.find('li.option').length).toBe(1);
-    expect(wrapper.find('li.option').first().text()).toBe('hover');
-    expect(wrapper.find('li.highlightedOption').text()).toBe('hover');
-  });
-
-  test('Autcomplete selects highlighted option when tab key is pressed', () => {
-    const map = {};
-    document.addEventListener = jest.fn().mockImplementation((event, cb) => {
-      map[event] = cb;
-    });
-
-    const wrapper = mount(
-      <Autocomplete
-        options={MNEMONIC_WORDS}
-        skin={AutocompleteSkin}
-      />
-    );
-    const component = wrapper.find('AutocompleteBase').instance();
-    const input = wrapper.find('input');
-
-    // open Autocomplete
-    input.simulate('click', {});
-
-    // simulate tab key being pressed
-    map.keydown({ keyCode: 9, preventDefault() {} });
-
-    // assert that selected options contains only 'box' (1st ABC sorted option)
-    expect(component.state.selectedOptions.length).toBe(1);
-    expect(component.state.selectedOptions[0]).toBe(ABC_SORTED_MNEMONICS[0]);
-
-    // assert Autocomplete is closed after option is selected
-    expect(component.state.isOpen).toBe(false);
-  });
-
-  test('Autcomplete selects highlighted option when enter key is pressed', () => {
-    const map = {};
-    document.addEventListener = jest.fn().mockImplementation((event, cb) => {
-      map[event] = cb;
-    });
-
-    const wrapper = mount(
-      <Autocomplete
-        options={MNEMONIC_WORDS}
-        skin={AutocompleteSkin}
-      />
-    );
-    const component = wrapper.find('AutocompleteBase').instance();
-    const input = wrapper.find('input');
-
-    // open Autocomplete
-    input.simulate('click', {});
-
-    // simulate enter key being pressed
-    map.keydown({ keyCode: 13, preventDefault() {} });
-
-    // assert that selected options contains only 'box' (1st ABC sorted option)
-    expect(component.state.selectedOptions.length).toBe(1);
-    expect(component.state.selectedOptions[0]).toBe(ABC_SORTED_MNEMONICS[0]);
-
-    // assert Autocomplete is closed after option is selected
-    expect(component.state.isOpen).toBe(false);
-  });
-
-  test('Autcomplete selects highlighted option when space key is pressed', () => {
-    const map = {};
-    document.addEventListener = jest.fn().mockImplementation((event, cb) => {
-      map[event] = cb;
-    });
-
-    const wrapper = mount(
-      <Autocomplete
-        options={MNEMONIC_WORDS}
-        skin={AutocompleteSkin}
-      />
-    );
-    const component = wrapper.find('AutocompleteBase').instance();
-    const input = wrapper.find('input');
-
-    // open Autocomplete
-    input.simulate('click', {});
-
-    // simulate space key being pressed
-    map.keydown({ keyCode: 32, preventDefault() {} });
-
-    // assert that selected options contains only 'box' (1st ABC sorted option)
-    expect(component.state.selectedOptions.length).toBe(1);
-    expect(component.state.selectedOptions[0]).toBe(ABC_SORTED_MNEMONICS[0]);
-
-    // assert Autocomplete is closed after option is selected
-    expect(component.state.isOpen).toBe(false);
-  });
-
-  test('Autcomplete updates highlighted option when down arrow key is pressed and selects it with click', () => {
-    const map = {};
-    document.addEventListener = jest.fn().mockImplementation((event, cb) => {
-      map[event] = cb;
-    });
-
-    const wrapper = mount(
-      <Autocomplete
-        options={MNEMONIC_WORDS}
-        skin={AutocompleteSkin}
-      />
-    );
-    const component = wrapper.find('AutocompleteBase').instance();
-    const input = wrapper.find('input');
-
-    // open Autocomplete
-    input.simulate('click', {});
-
-    // simulate arrow down key being pressed 3 times
-    map.keydown({ keyCode: 40, preventDefault() {} });
-    map.keydown({ keyCode: 40, preventDefault() {} });
-    map.keydown({ keyCode: 40, preventDefault() {} });
-    wrapper.update();
-
-    // assert that highlighted option is now 'dog' (4th ABC sorted options)
-    expect(wrapper.find('li.highlightedOption').text()).toBe(ABC_SORTED_MNEMONICS[3]);
-
-    // simulate click on highlighted option
-    wrapper.find('li.highlightedOption').simulate('click', {});
-
-    // assert selected options now contains only 'dog' (4th ABC sorted options)
-    // and Autocomplete is closed
-    expect(component.state.selectedOptions.length).toBe(1);
-    expect(component.state.selectedOptions[0]).toBe(ABC_SORTED_MNEMONICS[3]);
-    expect(component.state.isOpen).toBe(false);
-  });
-
-  test('Autocomplete deletes a selected option when backspace is pressed', () => {
-    const map = {};
-    document.addEventListener = jest.fn().mockImplementation((event, cb) => {
-      map[event] = cb;
-    });
-
-    const wrapper = mount(
-      <Autocomplete
-        options={MNEMONIC_WORDS}
-        skin={AutocompleteSkin}
-      />
-    );
-    const component = wrapper.find('AutocompleteBase').instance();
-    const input = wrapper.find('input');
-
-    // open Autocomplete
-    input.simulate('click', {});
-
-    // simulate user typing 'hide'
-    input.simulate('change', { target: { value: 'hide' } });
-
-    // select 'hide' via pressing enter key
-    map.keydown({ keyCode: 13, preventDefault() {} });
-
-    // assert 'hide' is now a selected option
-    expect(component.state.selectedOptions.length).toBe(1);
-    expect(component.state.selectedOptions[0]).toBe('hide');
-
-    // assert inputValue is empty before attempting to delete 'hide'
-    expect(component.state.inputValue).toBe('');
-
-    // simulate backspace to delete 'hide'
-    input.simulate('keydown', { keyCode: 8 });
-
-    // assert backspace deleted the selected option 'hide'
-    expect(component.state.selectedOptions.length).toBe(0);
-  });
 });

--- a/__tests__/Bubble.test.js
+++ b/__tests__/Bubble.test.js
@@ -1,11 +1,11 @@
 import React from 'react';
-import renderer from 'react-test-renderer';
 
 import { Bubble } from '../source/components/Bubble';
 import { BubbleSkin } from '../source/skins/simple/BubbleSkin';
+import { renderInSimpleTheme } from './helpers/theming';
 
 test('Bubble renders correctly', () => {
-  const component = renderer.create(
+  const component = renderInSimpleTheme(
     <Bubble skin={BubbleSkin} />
   );
 
@@ -14,7 +14,7 @@ test('Bubble renders correctly', () => {
 });
 
 test('Bubble renders isOpeningUpward={true}', () => {
-  const component = renderer.create(
+  const component = renderInSimpleTheme(
     <Bubble isOpeningUpward skin={BubbleSkin} />
   );
 
@@ -23,7 +23,7 @@ test('Bubble renders isOpeningUpward={true}', () => {
 });
 
 test('Bubble renders isTransparent={false}', () => {
-  const component = renderer.create(
+  const component = renderInSimpleTheme(
     <Bubble isTransparent={false} skin={BubbleSkin} />
   );
 
@@ -32,7 +32,7 @@ test('Bubble renders isTransparent={false}', () => {
 });
 
 test('Bubble renders isHidden={true}', () => {
-  const component = renderer.create(
+  const component = renderInSimpleTheme(
     <Bubble isHidden skin={BubbleSkin} />
   );
 
@@ -41,7 +41,7 @@ test('Bubble renders isHidden={true}', () => {
 });
 
 test('Bubble renders isFloating={true}', () => {
-  const component = renderer.create(
+  const component = renderInSimpleTheme(
     <Bubble isFloating skin={BubbleSkin} />
   );
 

--- a/__tests__/Button.test.js
+++ b/__tests__/Button.test.js
@@ -1,11 +1,11 @@
 import React from 'react';
-import renderer from 'react-test-renderer';
 
 import { Button } from '../source/components/Button';
 import { ButtonSkin } from '../source/skins/simple/ButtonSkin';
+import { renderInSimpleTheme } from './helpers/theming';
 
 test('Button renders correctly', () => {
-  const component = renderer.create(
+  const component = renderInSimpleTheme(
     <Button skin={ButtonSkin} />
   );
 
@@ -14,7 +14,7 @@ test('Button renders correctly', () => {
 });
 
 test('Button renders with a label', () => {
-  const component = renderer.create(
+  const component = renderInSimpleTheme(
     <Button label="send" skin={ButtonSkin} />
   );
 
@@ -23,7 +23,7 @@ test('Button renders with a label', () => {
 });
 
 test('Button is disabled', () => {
-  const component = renderer.create(
+  const component = renderInSimpleTheme(
     <Button disabled skin={ButtonSkin} />
   );
 

--- a/__tests__/Checkbox.test.js
+++ b/__tests__/Checkbox.test.js
@@ -1,11 +1,11 @@
 import React from 'react';
-import renderer from 'react-test-renderer';
 
 import { Checkbox } from '../source/components/Checkbox';
 import { CheckboxSkin } from '../source/skins/simple/CheckboxSkin';
+import { renderInSimpleTheme } from './helpers/theming';
 
 test('Checkbox renders correctly', () => {
-  const component = renderer.create(
+  const component = renderInSimpleTheme(
     <Checkbox skin={CheckboxSkin} />
   );
 
@@ -14,7 +14,7 @@ test('Checkbox renders correctly', () => {
 });
 
 test('Checkbox renders with a label', () => {
-  const component = renderer.create(
+  const component = renderInSimpleTheme(
     <Checkbox label="check here" skin={CheckboxSkin} />
   );
 
@@ -23,7 +23,7 @@ test('Checkbox renders with a label', () => {
 });
 
 test('Checkbox is disabled', () => {
-  const component = renderer.create(
+  const component = renderInSimpleTheme(
     <Checkbox disabled skin={CheckboxSkin} />
   );
 
@@ -32,7 +32,7 @@ test('Checkbox is disabled', () => {
 });
 
 test('Checkbox is checked', () => {
-  const component = renderer.create(
+  const component = renderInSimpleTheme(
     <Checkbox checked skin={CheckboxSkin} />
   );
 

--- a/__tests__/FormField.test.js
+++ b/__tests__/FormField.test.js
@@ -1,13 +1,13 @@
 import React from 'react';
-import renderer from 'react-test-renderer';
 
 import { FormField } from '../source/components/FormField';
 import { FormFieldSkin } from '../source/skins/simple/FormFieldSkin';
+import { renderInSimpleTheme } from './helpers/theming';
 
 const renderFormField = () => <div className="render-prop" />;
 
 test('FormField renders correctly', () => {
-  const component = renderer.create(
+  const component = renderInSimpleTheme(
     <FormField
       skin={FormFieldSkin}
       render={renderFormField}
@@ -19,7 +19,7 @@ test('FormField renders correctly', () => {
 });
 
 test('FormField renders with label', () => {
-  const component = renderer.create(
+  const component = renderInSimpleTheme(
     <FormField
       label="Add a Label"
       skin={FormFieldSkin}
@@ -32,7 +32,7 @@ test('FormField renders with label', () => {
 });
 
 test('FormField renders with an error', () => {
-  const component = renderer.create(
+  const component = renderInSimpleTheme(
     <FormField
       error="Add an Error"
       skin={FormFieldSkin}
@@ -45,7 +45,7 @@ test('FormField renders with an error', () => {
 });
 
 test('FormField is disabled', () => {
-  const component = renderer.create(
+  const component = renderInSimpleTheme(
     <FormField
       disabled
       skin={FormFieldSkin}
@@ -58,7 +58,7 @@ test('FormField is disabled', () => {
 });
 
 test('FormField renders an input element', () => {
-  const component = renderer.create(
+  const component = renderInSimpleTheme(
     <FormField
       skin={FormFieldSkin}
       render={() => <input className="render-prop" />}

--- a/__tests__/Input.test.js
+++ b/__tests__/Input.test.js
@@ -1,11 +1,11 @@
 import React from 'react';
-import renderer from 'react-test-renderer';
 
 import { Input } from '../source/components/Input';
 import { InputSkin } from '../source/skins/simple/InputSkin';
+import { renderInSimpleTheme } from './helpers/theming';
 
 test('Input renders correctly', () => {
-  const component = renderer.create(
+  const component = renderInSimpleTheme(
     <Input skin={InputSkin} />
   );
 
@@ -14,7 +14,7 @@ test('Input renders correctly', () => {
 });
 
 test('Input renders with placeholder', () => {
-  const component = renderer.create(
+  const component = renderInSimpleTheme(
     <Input placeholder="0.0000" skin={InputSkin} />
   );
 
@@ -23,7 +23,7 @@ test('Input renders with placeholder', () => {
 });
 
 test('Input renders with a value', () => {
-  const component = renderer.create(
+  const component = renderInSimpleTheme(
     <Input value="there is value" skin={InputSkin} />
   );
 
@@ -32,7 +32,7 @@ test('Input renders with a value', () => {
 });
 
 test('Input is readOnly', () => {
-  const component = renderer.create(
+  const component = renderInSimpleTheme(
     <Input
       readOnly
       skin={InputSkin}

--- a/__tests__/NumericInput.behavior.test.js
+++ b/__tests__/NumericInput.behavior.test.js
@@ -1,0 +1,182 @@
+import React from 'react';
+
+import { NumericInput } from '../source/components/NumericInput';
+import { InputSkin } from '../source/skins/simple/InputSkin';
+import { mountInSimpleTheme } from './helpers/theming';
+
+describe('NumericInput onChange simulations', () => {
+  test('onChange updates state with valid amount', () => {
+    const wrapper = mountInSimpleTheme(
+      <NumericInput
+        skin={InputSkin}
+      />
+    );
+
+    const component = wrapper.find('NumericInputBase').instance();
+    const input = wrapper.find('input');
+
+    // valid input value
+    input.simulate('change', { target: { value: '19.00' } });
+    expect(component.state.oldValue).toBe('19.00');
+  });
+
+  test('onChange creates error via invalid amount: value > maxValue', () => {
+    const wrapper = mountInSimpleTheme(
+      <NumericInput
+        maxValue={1000}
+        skin={InputSkin}
+      />
+    );
+
+    const component = wrapper.find('NumericInputBase').instance();
+    const input = wrapper.find('input');
+
+    // invalid input value: value > maxValue
+    // state and className should reflect error
+    input.simulate('change', { target: { value: '1001.00' } });
+    expect(component.state.error).toBeTruthy();
+    expect(input.instance().className).toBe('input errored');
+  });
+
+  test('onChange creates error via invalid amount: value < minValue', () => {
+    const wrapper = mountInSimpleTheme(
+      <NumericInput
+        minValue={500}
+        skin={InputSkin}
+      />
+    );
+
+    const component = wrapper.find('NumericInputBase').instance();
+    const input = wrapper.find('input');
+
+    // invalid input value: value < minValue
+    // state and className should reflect error
+    input.simulate('change', { target: { value: '499.99' } });
+    expect(component.state.error).toBeTruthy();
+    expect(input.instance().className).toBe('input errored');
+  });
+
+  test('onChange is passed invalid amount, maxBeforeDot is enforced correctly', () => {
+    const wrapper = mountInSimpleTheme(
+      <NumericInput
+        maxBeforeDot={3}
+        skin={InputSkin}
+      />
+    );
+
+    const component = wrapper.find('NumericInputBase').instance();
+    const input = wrapper.find('input');
+
+    // input value is valid: value has 3 integer places
+    input.simulate('change', { target: { value: '432.99' } });
+    expect(component.state.oldValue).toBe('432.99');
+
+    // input value is invalid: value has 4 integer places
+    // 6 should be dropped from the 1's place
+    input.simulate('change', { target: { value: '9876.99' } });
+    expect(component.state.oldValue).toBe('987.99');
+  });
+
+  test('onChange is passed invalid amount, maxAfterDot is enforced correctly', () => {
+    const wrapper = mountInSimpleTheme(
+      <NumericInput
+        maxAfterDot={4}
+        skin={InputSkin}
+      />
+    );
+
+    const component = wrapper.find('NumericInputBase').instance();
+    const input = wrapper.find('input');
+
+    // simulate onChange with 4 decimal places (valid)
+    input.simulate('change', { target: { value: '65.7821' } });
+    expect(component.state.oldValue).toBe('65.7821');
+
+    // simulate onChange with 5 decimal places (invalid)
+    input.simulate('change', { target: { value: '85.98543' } });
+    // 3 should be dropped from the 5th decimal place
+    expect(component.state.oldValue).toBe('85.9854');
+  });
+
+  test('onChange simulates amount exceeding maxValue, enforceMax is enforced', () => {
+    const wrapper = mountInSimpleTheme(
+      <NumericInput
+        enforceMax
+        maxValue={24999}
+        maxAfterDot={2}
+        skin={InputSkin}
+      />
+    );
+
+    const component = wrapper.find('NumericInputBase').instance();
+    const input = wrapper.find('input');
+
+    // valid input value: there should be no error in state or className
+    input.simulate('change', { target: { value: '24500.99' } });
+    expect(component.state.oldValue).toBe('24500.99');
+    expect(component.state.error).toBe('');
+    expect(input.instance().className).toBe('input');
+
+    // invalid input value: value exceeds maxValue
+    // integers should be adjusted to maxValue
+    // state and className should reflect error
+    input.simulate('change', { target: { value: '25000.00' } });
+    expect(component.state.oldValue).toBe('24999.00');
+    expect(component.state.error).toBeTruthy();
+    expect(input.instance().className).toBe('input errored');
+
+    // invalid input value: decimal value exceeds maxValue
+    // decimals should be adjusted to maxValue
+    // state and className should reflect error
+    input.simulate('change', { target: { value: '24999.99' } });
+    expect(component.state.oldValue).toBe('24999.00');
+    expect(component.state.error).toBeTruthy();
+    expect(input.instance().className).toBe('input errored');
+
+    // valid input value: should reset state and className
+    input.simulate('change', { target: { value: '50.00' } });
+    expect(component.state.error).toBe('');
+    expect(input.instance().className).toBe('input');
+  });
+
+  test('onChange simulates amount less than minValue, enforceMin is enforced', () => {
+    const wrapper = mountInSimpleTheme(
+      <NumericInput
+        enforceMin
+        minValue={99.99}
+        maxAfterDot={2}
+        skin={InputSkin}
+      />
+    );
+
+    const component = wrapper.find('NumericInputBase').instance();
+    const input = wrapper.find('input');
+
+    // simulate onChange with valid amount
+    // should be no error in state or className
+    input.simulate('change', { target: { value: '100.00' } });
+    expect(component.state.oldValue).toBe('100.00');
+    expect(component.state.error).toBe('');
+
+    // input value is invalid: value < minValue
+    // integers should be adjusted to minValue
+    // state and className should reflect error
+    input.simulate('change', { target: { value: '85.99' } });
+    expect(component.state.oldValue).toBe('99.99');
+    expect(component.state.error).toBeTruthy();
+    expect(input.instance().className).toBe('input errored');
+
+    // input value is invalid: decimal value is less than minValue
+    // decimals should be adjusted to minValue
+    // state and className should reflect error
+    input.simulate('change', { target: { value: '99.98' } });
+    expect(component.state.oldValue).toBe('99.99');
+    expect(component.state.error).toBeTruthy();
+    expect(input.instance().className).toBe('input errored');
+
+    // valid input value: should reset error in state and className
+    input.simulate('change', { target: { value: '150.00' } });
+    expect(component.state.error).toBe('');
+    expect(input.instance().className).toBe('input');
+  });
+});

--- a/__tests__/NumericInput.test.js
+++ b/__tests__/NumericInput.test.js
@@ -1,12 +1,11 @@
 import React from 'react';
-import renderer from 'react-test-renderer';
-import { mount } from 'enzyme';
 
 import { NumericInput } from '../source/components/NumericInput';
 import { InputSkin } from '../source/skins/simple/InputSkin';
+import { renderInSimpleTheme } from './helpers/theming';
 
 test('NumericInput renders correctly', () => {
-  const component = renderer.create(
+  const component = renderInSimpleTheme(
     <NumericInput
       skin={InputSkin}
     />
@@ -17,7 +16,7 @@ test('NumericInput renders correctly', () => {
 });
 
 test('NumericInput renders with placeholder', () => {
-  const component = renderer.create(
+  const component = renderInSimpleTheme(
     <NumericInput
       placeholder="0.0000"
       skin={InputSkin}
@@ -29,7 +28,7 @@ test('NumericInput renders with placeholder', () => {
 });
 
 test('NumericInput is disabled', () => {
-  const component = renderer.create(
+  const component = renderInSimpleTheme(
     <NumericInput
       disabled
       skin={InputSkin}
@@ -41,7 +40,7 @@ test('NumericInput is disabled', () => {
 });
 
 test('NumericInput is readOnly', () => {
-  const component = renderer.create(
+  const component = renderInSimpleTheme(
     <NumericInput
       readOnly
       skin={InputSkin}
@@ -53,7 +52,7 @@ test('NumericInput is readOnly', () => {
 });
 
 test('NumericInput renders with an error', () => {
-  const component = renderer.create(
+  const component = renderInSimpleTheme(
     <NumericInput
       error="Invalid Amount"
       skin={InputSkin}
@@ -65,7 +64,7 @@ test('NumericInput renders with an error', () => {
 });
 
 test('NumericInput renders with a value', () => {
-  const component = renderer.create(
+  const component = renderInSimpleTheme(
     <NumericInput
       value="555.333"
       skin={InputSkin}
@@ -74,181 +73,4 @@ test('NumericInput renders with a value', () => {
 
   const tree = component.toJSON();
   expect(tree).toMatchSnapshot();
-});
-
-describe('NumericInput onChange simulations', () => {
-  test('onChange updates state with valid amount', () => {
-    const wrapper = mount(
-      <NumericInput
-        skin={InputSkin}
-      />
-    );
-
-    const component = wrapper.find('NumericInputBase').instance();
-    const input = wrapper.find('input');
-
-    // valid input value
-    input.simulate('change', { target: { value: '19.00' } });
-    expect(component.state.oldValue).toBe('19.00');
-  });
-
-  test('onChange creates error via invalid amount: value > maxValue', () => {
-    const wrapper = mount(
-      <NumericInput
-        maxValue={1000}
-        skin={InputSkin}
-      />
-    );
-
-    const component = wrapper.find('NumericInputBase').instance();
-    const input = wrapper.find('input');
-
-    // invalid input value: value > maxValue
-    // state and className should reflect error
-    input.simulate('change', { target: { value: '1001.00' } });
-    expect(component.state.error).toBeTruthy();
-    expect(input.instance().className).toBe('input errored');
-  });
-
-  test('onChange creates error via invalid amount: value < minValue', () => {
-    const wrapper = mount(
-      <NumericInput
-        minValue={500}
-        skin={InputSkin}
-      />
-    );
-
-    const component = wrapper.find('NumericInputBase').instance();
-    const input = wrapper.find('input');
-
-    // invalid input value: value < minValue
-    // state and className should reflect error
-    input.simulate('change', { target: { value: '499.99' } });
-    expect(component.state.error).toBeTruthy();
-    expect(input.instance().className).toBe('input errored');
-  });
-
-  test('onChange is passed invalid amount, maxBeforeDot is enforced correctly', () => {
-    const wrapper = mount(
-      <NumericInput
-        maxBeforeDot={3}
-        skin={InputSkin}
-      />
-    );
-
-    const component = wrapper.find('NumericInputBase').instance();
-    const input = wrapper.find('input');
-
-    // input value is valid: value has 3 integer places
-    input.simulate('change', { target: { value: '432.99' } });
-    expect(component.state.oldValue).toBe('432.99');
-
-    // input value is invalid: value has 4 integer places
-    // 6 should be dropped from the 1's place
-    input.simulate('change', { target: { value: '9876.99' } });
-    expect(component.state.oldValue).toBe('987.99');
-  });
-
-  test('onChange is passed invalid amount, maxAfterDot is enforced correctly', () => {
-    const wrapper = mount(
-      <NumericInput
-        maxAfterDot={4}
-        skin={InputSkin}
-      />
-    );
-
-    const component = wrapper.find('NumericInputBase').instance();
-    const input = wrapper.find('input');
-
-    // simulate onChange with 4 decimal places (valid)
-    input.simulate('change', { target: { value: '65.7821' } });
-    expect(component.state.oldValue).toBe('65.7821');
-
-    // simulate onChange with 5 decimal places (invalid)
-    input.simulate('change', { target: { value: '85.98543' } });
-    // 3 should be dropped from the 5th decimal place
-    expect(component.state.oldValue).toBe('85.9854');
-  });
-
-  test('onChange simulates amount exceeding maxValue, enforceMax is enforced', () => {
-    const wrapper = mount(
-      <NumericInput
-        enforceMax
-        maxValue={24999}
-        maxAfterDot={2}
-        skin={InputSkin}
-      />
-    );
-
-    const component = wrapper.find('NumericInputBase').instance();
-    const input = wrapper.find('input');
-
-    // valid input value: there should be no error in state or className
-    input.simulate('change', { target: { value: '24500.99' } });
-    expect(component.state.oldValue).toBe('24500.99');
-    expect(component.state.error).toBe('');
-    expect(input.instance().className).toBe('input');
-
-    // invalid input value: value exceeds maxValue
-    // integers should be adjusted to maxValue
-    // state and className should reflect error
-    input.simulate('change', { target: { value: '25000.00' } });
-    expect(component.state.oldValue).toBe('24999.00');
-    expect(component.state.error).toBeTruthy();
-    expect(input.instance().className).toBe('input errored');
-
-    // invalid input value: decimal value exceeds maxValue
-    // decimals should be adjusted to maxValue
-    // state and className should reflect error
-    input.simulate('change', { target: { value: '24999.99' } });
-    expect(component.state.oldValue).toBe('24999.00');
-    expect(component.state.error).toBeTruthy();
-    expect(input.instance().className).toBe('input errored');
-
-    // valid input value: should reset state and className
-    input.simulate('change', { target: { value: '50.00' } });
-    expect(component.state.error).toBe('');
-    expect(input.instance().className).toBe('input');
-  });
-
-  test('onChange simulates amount less than minValue, enforceMin is enforced', () => {
-    const wrapper = mount(
-      <NumericInput
-        enforceMin
-        minValue={99.99}
-        maxAfterDot={2}
-        skin={InputSkin}
-      />
-    );
-
-    const component = wrapper.find('NumericInputBase').instance();
-    const input = wrapper.find('input');
-
-    // simulate onChange with valid amount
-    // should be no error in state or className
-    input.simulate('change', { target: { value: '100.00' } });
-    expect(component.state.oldValue).toBe('100.00');
-    expect(component.state.error).toBe('');
-
-    // input value is invalid: value < minValue
-    // integers should be adjusted to minValue
-    // state and className should reflect error
-    input.simulate('change', { target: { value: '85.99' } });
-    expect(component.state.oldValue).toBe('99.99');
-    expect(component.state.error).toBeTruthy();
-    expect(input.instance().className).toBe('input errored');
-
-    // input value is invalid: decimal value is less than minValue
-    // decimals should be adjusted to minValue
-    // state and className should reflect error
-    input.simulate('change', { target: { value: '99.98' } });
-    expect(component.state.oldValue).toBe('99.99');
-    expect(component.state.error).toBeTruthy();
-    expect(input.instance().className).toBe('input errored');
-
-    // valid input value: should reset error in state and className
-    input.simulate('change', { target: { value: '150.00' } });
-    expect(component.state.error).toBe('');
-    expect(input.instance().className).toBe('input');
-  });
 });

--- a/__tests__/Options.test.js
+++ b/__tests__/Options.test.js
@@ -1,8 +1,8 @@
 import React from 'react';
-import renderer from 'react-test-renderer';
 
 import { Options } from '../source/components/Options';
 import { OptionsSkin } from '../source/skins/simple/OptionsSkin';
+import { renderInSimpleTheme } from './helpers/theming';
 
 const MNEMONIC_WORDS = [
   'home',
@@ -28,7 +28,7 @@ const COUNTRIES_OPTIONS = [
 ];
 
 test('Options renders correctly', () => {
-  const component = renderer.create(
+  const component = renderInSimpleTheme(
     <Options
       options={MNEMONIC_WORDS}
       skin={OptionsSkin}
@@ -40,7 +40,7 @@ test('Options renders correctly', () => {
 });
 
 test('Options uses render prop - render', () => {
-  const component = renderer.create(
+  const component = renderInSimpleTheme(
     <Options
       options={MNEMONIC_WORDS}
       skin={OptionsSkin}
@@ -60,7 +60,7 @@ test('Options uses render prop - render', () => {
 });
 
 test('Options uses render prop - optionRenderer', () => {
-  const component = renderer.create(
+  const component = renderInSimpleTheme(
     <Options
       options={COUNTRIES_OPTIONS}
       skin={OptionsSkin}

--- a/__tests__/Radio.test.js
+++ b/__tests__/Radio.test.js
@@ -3,9 +3,10 @@ import renderer from 'react-test-renderer';
 
 import { Radio } from '../source/components/Radio';
 import { RadioSkin } from '../source/skins/simple/RadioSkin';
+import { renderInSimpleTheme } from './helpers/theming';
 
 test('Radio renders correctly', () => {
-  const component = renderer.create(
+  const component = renderInSimpleTheme(
     <Radio skin={RadioSkin} />
   );
 
@@ -14,7 +15,7 @@ test('Radio renders correctly', () => {
 });
 
 test('Radio renders with a label', () => {
-  const component = renderer.create(
+  const component = renderInSimpleTheme(
     <Radio label="click here" skin={RadioSkin} />
   );
 
@@ -23,7 +24,7 @@ test('Radio renders with a label', () => {
 });
 
 test('Radio is disabled', () => {
-  const component = renderer.create(
+  const component = renderInSimpleTheme(
     <Radio disabled skin={RadioSkin} />
   );
 
@@ -32,7 +33,7 @@ test('Radio is disabled', () => {
 });
 
 test('Radio is selected', () => {
-  const component = renderer.create(
+  const component = renderInSimpleTheme(
     <Radio selected skin={RadioSkin} />
   );
 

--- a/__tests__/Select.test.js
+++ b/__tests__/Select.test.js
@@ -3,6 +3,7 @@ import renderer from 'react-test-renderer';
 
 import { Select } from '../source/components/Select';
 import { SelectSkin } from '../source/skins/simple/SelectSkin';
+import { renderInSimpleTheme } from './helpers/theming';
 
 const COUNTRIES = [
   { label: 'Frankreich', value: 'France' },
@@ -20,7 +21,7 @@ const COUNTRIES_DISABLED_OPTIONS = [
 ];
 
 test('Select renders correctly', () => {
-  const component = renderer.create(
+  const component = renderInSimpleTheme(
     <Select
       options={COUNTRIES}
       skin={SelectSkin}
@@ -32,7 +33,7 @@ test('Select renders correctly', () => {
 });
 
 test('Select renders with placeholder', () => {
-  const component = renderer.create(
+  const component = renderInSimpleTheme(
     <Select
       placeholder="Select your country …"
       options={COUNTRIES}
@@ -45,7 +46,7 @@ test('Select renders with placeholder', () => {
 });
 
 test('Select renders with an error', () => {
-  const component = renderer.create(
+  const component = renderInSimpleTheme(
     <Select
       error="Please select a different option"
       options={COUNTRIES}
@@ -58,7 +59,7 @@ test('Select renders with an error', () => {
 });
 
 test('Select renders with disabled options', () => {
-  const component = renderer.create(
+  const component = renderInSimpleTheme(
     <Select
       options={COUNTRIES_DISABLED_OPTIONS}
       skin={SelectSkin}
@@ -70,7 +71,7 @@ test('Select renders with disabled options', () => {
 });
 
 test('Select isOpeningUpward={true}', () => {
-  const component = renderer.create(
+  const component = renderInSimpleTheme(
     <Select
       isOpeningUpward
       options={COUNTRIES}
@@ -83,7 +84,7 @@ test('Select isOpeningUpward={true}', () => {
 });
 
 test('Select isOpen={true}', () => {
-  const component = renderer.create(
+  const component = renderInSimpleTheme(
     <Select
       isOpen
       options={COUNTRIES}
@@ -96,7 +97,7 @@ test('Select isOpen={true}', () => {
 });
 
 test('Select uses render prop - optionRenderer', () => {
-  const component = renderer.create(
+  const component = renderInSimpleTheme(
     <Select
       options={COUNTRIES}
       skin={SelectSkin}

--- a/__tests__/Switch.test.js
+++ b/__tests__/Switch.test.js
@@ -4,9 +4,10 @@ import renderer from 'react-test-renderer';
 import { Checkbox } from '../source/components/Checkbox';
 import { SwitchSkin } from '../source/skins/simple/SwitchSkin';
 import { IDENTIFIERS } from '../source/themes/API';
+import { renderInSimpleTheme } from './helpers/theming';
 
 test('Switch renders correctly', () => {
-  const component = renderer.create(
+  const component = renderInSimpleTheme(
     <Checkbox
       themeId={IDENTIFIERS.SWITCH}
       skin={SwitchSkin}
@@ -18,7 +19,7 @@ test('Switch renders correctly', () => {
 });
 
 test('Switch renders with label', () => {
-  const component = renderer.create(
+  const component = renderInSimpleTheme(
     <Checkbox
       themeId={IDENTIFIERS.SWITCH}
       label="click here"
@@ -31,7 +32,7 @@ test('Switch renders with label', () => {
 });
 
 test('Switch is disabled', () => {
-  const component = renderer.create(
+  const component = renderInSimpleTheme(
     <Checkbox
       themeId={IDENTIFIERS.SWITCH}
       disabled
@@ -44,7 +45,7 @@ test('Switch is disabled', () => {
 });
 
 test('Switch is disabled and renders a label', () => {
-  const component = renderer.create(
+  const component = renderInSimpleTheme(
     <Checkbox
       themeId={IDENTIFIERS.SWITCH}
       disabled
@@ -58,7 +59,7 @@ test('Switch is disabled and renders a label', () => {
 });
 
 test('Switch is checked', () => {
-  const component = renderer.create(
+  const component = renderInSimpleTheme(
     <Checkbox
       themeId={IDENTIFIERS.SWITCH}
       checked

--- a/__tests__/TextArea.test.js
+++ b/__tests__/TextArea.test.js
@@ -3,9 +3,10 @@ import renderer from 'react-test-renderer';
 
 import { TextArea } from '../source/components/TextArea';
 import { TextAreaSkin } from '../source/skins/simple/TextAreaSkin';
+import { renderInSimpleTheme } from './helpers/theming';
 
 test('TextArea renders correctly', () => {
-  const component = renderer.create(
+  const component = renderInSimpleTheme(
     <TextArea skin={TextAreaSkin} />
   );
 
@@ -14,7 +15,7 @@ test('TextArea renders correctly', () => {
 });
 
 test('TextArea renders with placeholder', () => {
-  const component = renderer.create(
+  const component = renderInSimpleTheme(
     <TextArea
       placeholder="0.0000"
       skin={TextAreaSkin}
@@ -26,7 +27,7 @@ test('TextArea renders with placeholder', () => {
 });
 
 test('TextArea renders with an error', () => {
-  const component = renderer.create(
+  const component = renderInSimpleTheme(
     <TextArea
       error="Please enter valid input"
       skin={TextAreaSkin}
@@ -38,7 +39,7 @@ test('TextArea renders with an error', () => {
 });
 
 test('TextArea renders with a value', () => {
-  const component = renderer.create(
+  const component = renderInSimpleTheme(
     <TextArea
       value="this one has a value"
       skin={TextAreaSkin}
@@ -50,7 +51,7 @@ test('TextArea renders with a value', () => {
 });
 
 test('TextArea renders with 5 rows', () => {
-  const component = renderer.create(
+  const component = renderInSimpleTheme(
     <TextArea
       rows={5}
       skin={TextAreaSkin}

--- a/__tests__/Toggler.test.js
+++ b/__tests__/Toggler.test.js
@@ -4,9 +4,10 @@ import renderer from 'react-test-renderer';
 import { Checkbox } from '../source/components/Checkbox';
 import { TogglerSkin } from '../source/skins/simple/TogglerSkin';
 import { IDENTIFIERS } from '../source/themes/API';
+import { renderInSimpleTheme } from './helpers/theming';
 
 test('Toggler renders correctly', () => {
-  const component = renderer.create(
+  const component = renderInSimpleTheme(
     <Checkbox
       labelLeft="Included"
       labelRight="Excluded"
@@ -20,7 +21,7 @@ test('Toggler renders correctly', () => {
 });
 
 test('Toggler renders within text', () => {
-  const component = renderer.create(
+  const component = renderInSimpleTheme(
     <div>
       <span>Fees&nbsp;</span>
       <Checkbox
@@ -38,7 +39,7 @@ test('Toggler renders within text', () => {
 });
 
 test('Toggler is disabled', () => {
-  const component = renderer.create(
+  const component = renderInSimpleTheme(
     <Checkbox
       disabled
       labelLeft="Included"
@@ -53,7 +54,7 @@ test('Toggler is disabled', () => {
 });
 
 test('Toggler is checked', () => {
-  const component = renderer.create(
+  const component = renderInSimpleTheme(
     <Checkbox
       checked
       labelLeft="Included"

--- a/__tests__/helpers/theming.js
+++ b/__tests__/helpers/theming.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import { mount } from 'enzyme';
+
+import { SimpleTheme } from '../../source/themes/simple';
+import { ThemeProvider } from '../../source/components/ThemeProvider';
+
+export const renderInSimpleTheme = (children) => (
+  renderer.create(
+    <ThemeProvider theme={SimpleTheme}>
+      {children}
+    </ThemeProvider>
+  )
+);
+
+export const mountInSimpleTheme = (children) => (
+  mount(
+    <ThemeProvider theme={SimpleTheme}>
+      {children}
+    </ThemeProvider>
+  )
+);

--- a/source/components/HOC/ThemeContext.js
+++ b/source/components/HOC/ThemeContext.js
@@ -2,7 +2,6 @@
 import React from 'react';
 import createReactContext, { type Context } from 'create-react-context';
 import { ROOT_THEME_API } from '../../themes/API';
-import { SimpleTheme } from '../../themes/simple/';
 
 // components that are NOT directly nested within a ThemeProvider
 // can access simple theme as "this.props.context.theme",
@@ -25,6 +24,6 @@ type Theme = {
   ROOT_THEME_API: Object
 };
 
-const defaultContext = { theme: SimpleTheme, ROOT_THEME_API };
+const defaultContext = { theme: ROOT_THEME_API, ROOT_THEME_API };
 
 export const ThemeContext: Context<Theme> = createContext(defaultContext);


### PR DESCRIPTION
This PR removes the reference to `SimpleTheme` as default and uses an empty theme object by default now. This caused the tests to fail since they are written with the assumption of having a theme applied.

That's why i introduced some simple test helpers (`renderInSimpleTheme` and `mountInSimpleTheme`) that render/mount the test markup wrapped in `ThemeProvider` configured with the `SimpleTheme`.

(@MarcusHurney in case you wonder why i split up the Autocomplete and NumericInput tests into two separate files [one for snapshots and one for behavior tests] … it's because of this issue i ran into: https://github.com/facebook/react/issues/13150)

Since that separation kind of makes sense anyway (those test files became too large already) … i thought it's an easy solution for now, until that fix is included in some future React version.