### PR TITLE
[DDW-197] create header component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,17 @@
 
 ## Features
 
+- Adds Header component, Header skin, and adds SimpleHeader to SimpleTheme.
+  [PR 84](https://github.com/input-output-hk/react-polymorph/pull/84)
+
 - Adds ProgressBar component to library with stories.
   [PR 78](https://github.com/input-output-hk/react-polymorph/pull/78)
 
-- Adds LoadingSpinner component, LoadingSpinnerSkin, and SimpleLoadingSpinner theme. Adds reusable 
+- Adds LoadingSpinner component, LoadingSpinnerSkin, and SimpleLoadingSpinner theme. Adds reusable
   loading-spinner mixin to themes. Adds 5 LoadingSpinner stories.
   [PR 75](https://github.com/input-output-hk/react-polymorph/pull/75)
 
-- Adds ButtonSpinnerSkin to simple skins to show LoadingSpinner within the Button component when 
+- Adds ButtonSpinnerSkin to simple skins to show LoadingSpinner within the Button component when
   page data is loading. Adds new button story to exemplify this skin and functionality.
   [PR 76](https://github.com/input-output-hk/react-polymorph/pull/76)
 
@@ -19,41 +22,41 @@
 
 ### Fixes
 
-- Fixed wrong border color for errored & focused textareas 
+- Fixed wrong border color for errored & focused textareas
   [PR 73](https://github.com/input-output-hk/react-polymorph/pull/73)
 
-- De-nests the class definitions in SimpleInput.scss. Ensures the border color of both Input and 
-  NumericInput remain the correct color when in an errored state. Improves composability when theme 
-  overrides is used with both Input components. Updates stories to reflect fixes. 
+- De-nests the class definitions in SimpleInput.scss. Ensures the border color of both Input and
+  NumericInput remain the correct color when in an errored state. Improves composability when theme
+  overrides is used with both Input components. Updates stories to reflect fixes.
   [PR 71](https://github.com/input-output-hk/react-polymorph/pull/71)
 
-- Adds a new HOC GlobalListeners which is used in Select and Autocomplete that attaches document and 
-  window listeners for closing the window. Fixes bubble and arrow positioning when Bubble is rendered 
-  via Select and Autocomplete. NumericInput does not execute the user's onChange prop unless the value 
-  changes internally after being processed. Removes index.js in components and skins directories to 
+- Adds a new HOC GlobalListeners which is used in Select and Autocomplete that attaches document and
+  window listeners for closing the window. Fixes bubble and arrow positioning when Bubble is rendered
+  via Select and Autocomplete. NumericInput does not execute the user's onChange prop unless the value
+  changes internally after being processed. Removes index.js in components and skins directories to
   reduce size of library. [PR 69](https://github.com/input-output-hk/react-polymorph/pull/69)
 
-- Wraps TextAreaSkin's render method in FormField so labels and errors are rendered the same as in Input 
-  and NumericInput. Fixes Input, NumericInput, and TextArea components so they pass a prop called inputRef 
-  or textareaRef to FormField in their skins. This properly makes use of React v16.3.1+'s ref API instead 
-  of using the onRef callback. Adds autoFocus, onBlur, and onFocus props to NumericInput and TextArea. 
+- Wraps TextAreaSkin's render method in FormField so labels and errors are rendered the same as in Input
+  and NumericInput. Fixes Input, NumericInput, and TextArea components so they pass a prop called inputRef
+  or textareaRef to FormField in their skins. This properly makes use of React v16.3.1+'s ref API instead
+  of using the onRef callback. Adds autoFocus, onBlur, and onFocus props to NumericInput and TextArea.
   [PR 67](https://github.com/input-output-hk/react-polymorph/pull/67)
 
-- Fixed wrong positioning of select options when opening upward 
+- Fixed wrong positioning of select options when opening upward
   [PR 68](https://github.com/input-output-hk/react-polymorph/pull/68)
 
-- Fixed vertical positioning of select arrow when opened 
+- Fixed vertical positioning of select arrow when opened
   [PR 68](https://github.com/input-output-hk/react-polymorph/pull/68)
 
 ### Chores
 
-- Replaces all default exports in the theme directory with constants and exports them. Additionally, 
-  all import statements previously importing a default export are replaced with an appropriate named 
-  import. Defines all properties of the SimpleTheme and ROOT_THEME_API objects using IDENTIFIERS and 
+- Replaces all default exports in the theme directory with constants and exports them. Additionally,
+  all import statements previously importing a default export are replaced with an appropriate named
+  import. Defines all properties of the SimpleTheme and ROOT_THEME_API objects using IDENTIFIERS and
   arranges their properties in ABC order for better readability.
   [77](https://github.com/input-output-hk/react-polymorph/pull/77)
 
-- Adds support for React v15 - v16.4.1. Upgrades devDependencies to latest versions of react, jest, and 
+- Adds support for React v15 - v16.4.1. Upgrades devDependencies to latest versions of react, jest, and
   enzyme related libraries. Adds Autocomplete simulation test for deleting a selected option via backspace key.
   [PR 65](https://github.com/input-output-hk/react-polymorph/pull/65)
 
@@ -73,15 +76,15 @@
 
 ### Chores
 
-- Adds keydown and click simulation tests for Autocomplete using jest and enzyme. Removes helper skins from 
-  test directory and refactors the way in which components are wrapped in a ThemeContext Consumer HOC before 
+- Adds keydown and click simulation tests for Autocomplete using jest and enzyme. Removes helper skins from
+  test directory and refactors the way in which components are wrapped in a ThemeContext Consumer HOC before
   they're exported in order to handle a test environment.
   [PR 63](https://github.com/input-output-hk/react-polymorph/pull/63)
 
-- Adds polyfills for React's new context API and ref API released in v16.3.0. Drops support for React versions 
+- Adds polyfills for React's new context API and ref API released in v16.3.0. Drops support for React versions
   less than v16.[PR 61](https://github.com/input-output-hk/react-polymorph/pull/61)
 
-- Add snapshot test coverage from using jest and enzyme. Add event simulation tests for NumericInput. Adds 
+- Add snapshot test coverage from using jest and enzyme. Add event simulation tests for NumericInput. Adds
 story for ThemeProvider. [PR 60](https://github.com/input-output-hk/react-polymorph/pull/60)
 
 ### Features
@@ -105,9 +108,9 @@ Major breaking changes due to large refactoring of component architecture:
   - Removes skin parts
   - Manages refs by passing them from parent to child
   - Removes inheritance architecture
-  - Adds ESLint config from Daedalus and integrates flow library & static type declarations. Refactors 
-  - components to declare refs using createRef from React v16.3^. Removes propTypes from all components 
-  and removes prop-types lib from dependencies. 
+  - Adds ESLint config from Daedalus and integrates flow library & static type declarations. Refactors
+  - components to declare refs using createRef from React v16.3^. Removes propTypes from all components
+  and removes prop-types lib from dependencies.
 
 ## Features
 
@@ -125,33 +128,33 @@ Major breaking changes due to large refactoring of component architecture:
 
 - Add Autocomplete clear feature [PR 49](https://github.com/input-output-hk/react-polymorph/pull/49)
 
-- Implements a theme API for each component. This is a plain object which exposes the shape of a component's theme. 
-  Each property on the theme API object corresponds with a class name assigned to an element within the component's 
+- Implements a theme API for each component. This is a plain object which exposes the shape of a component's theme.
+  Each property on the theme API object corresponds with a class name assigned to an element within the component's
   skin and a class definition within the component's theme.
 
-- Adds ThemeProvider HOC for applying a theme to all its nested react-polymorph children. ThemeProvider 
-  exonerates the user from explicitly declaring theme as a prop on every instantiated component. A complete 
-  theme, an object containing full theme definitions for every component in the library, may also be passed 
-  to ThemeProvider. The complete theme object may be deconstructed to contain only the necessary theme 
-  definitions used by the components nested within a particular instance of ThemeProvider, yet deconstruction 
+- Adds ThemeProvider HOC for applying a theme to all its nested react-polymorph children. ThemeProvider
+  exonerates the user from explicitly declaring theme as a prop on every instantiated component. A complete
+  theme, an object containing full theme definitions for every component in the library, may also be passed
+  to ThemeProvider. The complete theme object may be deconstructed to contain only the necessary theme
+  definitions used by the components nested within a particular instance of ThemeProvider, yet deconstruction
   is not required.
 
-- Adds themeOverrides as an optional prop on ThemeProvider and on all components within the library. 
-  themeOverrides composes the user's custom css/scss with the component's base theme. This automatic 
-  composition saves the user from the tedium of manually piecing together custom styles with those of 
-  the component's theme that the user wishes to retain, yet themeOverrides is flexible enough to restyle 
-  a component's theme in a nontrivial way. themeOverrides may be passed directly to one instance of 
-  a component or passed to all instances nested within ThemeProvider via context. This composition of 
+- Adds themeOverrides as an optional prop on ThemeProvider and on all components within the library.
+  themeOverrides composes the user's custom css/scss with the component's base theme. This automatic
+  composition saves the user from the tedium of manually piecing together custom styles with those of
+  the component's theme that the user wishes to retain, yet themeOverrides is flexible enough to restyle
+  a component's theme in a nontrivial way. themeOverrides may be passed directly to one instance of
+  a component or passed to all instances nested within ThemeProvider via context. This composition of
   styles relies on css-modules.
 
-- Adds a composed theme story to most component stories to exemplify the relationship between ThemeProvider 
+- Adds a composed theme story to most component stories to exemplify the relationship between ThemeProvider
   and themeOverrides.
 
 - Adds autofocus prop to all applicable input based components.
 
-- Adds index file to source/utils, source/themes/API, source/themes/simple, source/skins/simple, and 
-  source/components for the use of named and default exports. Makes it easier for the user to import a 
-  full theme object for ThemeProvider, or simply one component's theme. Also makes it easier to import 
+- Adds index file to source/utils, source/themes/API, source/themes/simple, source/skins/simple, and
+  source/components for the use of named and default exports. Makes it easier for the user to import a
+  full theme object for ThemeProvider, or simply one component's theme. Also makes it easier to import
   multiple skins and components on one line.
 
 ## 0.6.4

--- a/source/components/Header.js
+++ b/source/components/Header.js
@@ -1,0 +1,138 @@
+// @flow
+import React, { Component } from 'react';
+import type { ComponentType, Element } from 'react';
+import { pickBy, isEmpty } from 'lodash';
+
+// components
+import { withTheme } from './HOC/withTheme';
+
+// utility functions
+import { composeTheme, addThemeId } from '../utils/themes';
+
+// constants
+import { IDENTIFIERS } from '../themes/API';
+
+type Props = {
+  bold: boolean,
+  center: boolean,
+  children: Element<*>,
+  className: string,
+  context: {
+    theme: Object,
+    ROOT_THEME_API: Object
+  },
+  h1: boolean,
+  h2: boolean,
+  h3: boolean,
+  h4: boolean,
+  light: boolean,
+  lowerCase: boolean,
+  medium: boolean,
+  regular: boolean,
+  right: boolean,
+  left: boolean,
+  skin: ComponentType<any>,
+  theme: Object,
+  themeId: string,
+  themeOverrides: Object,
+  thin: boolean,
+  upperCase: boolean
+};
+
+type State = { composedTheme: Object };
+
+class HeaderBase extends Component <Props, State> {
+  // define static properties
+  static displayName = 'Header';
+  static defaultProps = {
+    theme: null,
+    themeId: IDENTIFIERS.HEADER,
+    themeOverrides: {}
+  };
+
+  constructor(props: Props) {
+    super(props);
+
+    const { context, themeId, theme, themeOverrides } = props;
+
+    this.state = {
+      composedTheme: composeTheme(
+        addThemeId(theme || context.theme, themeId),
+        addThemeId(themeOverrides, themeId),
+        context.ROOT_THEME_API
+      )
+    };
+  }
+
+  _assembleInlineStyles = ({ center, lowerCase, left, right, upperCase }) => {
+    const inlineStyles = {};
+    const textAlign = pickBy({ center, left, right });
+    const textTransform = pickBy({ lowerCase, upperCase });
+
+    if (!isEmpty(textAlign)) {
+      inlineStyles.textAlign = Object.keys(textAlign)[0];
+    }
+
+    if (!isEmpty(textTransform)) {
+      inlineStyles.textTransform = Object.keys(textTransform)[0];
+    }
+
+    return inlineStyles;
+  };
+
+  _assembleHeaderTheme = (styleProps: Object) => {
+    const activeClasses = this._getActiveClasses(styleProps);
+    const theme = this.state.composedTheme[this.props.themeId];
+
+    return activeClasses.reduce((reducedTheme, activeClass) => {
+      if (Object.hasOwnProperty.call(theme, activeClass)) {
+        reducedTheme.activeClass = theme.activeClass;
+      }
+      return reducedTheme;
+    }, {});
+  }
+
+  _getActiveFont = ({ light, medium, regular, thin, bold }) => {
+    const fontProps = pickBy({ light, medium, regular, thin, bold });
+    if (isEmpty(fontProps)) { return; }
+    // returns the first active font if more than 1 is passed
+    return Object.keys(fontProps)[0];
+  };
+
+  _getActiveTheme = ({ h1, h2, h3, h4 }) => {
+    const themeProps = pickBy({ h1, h2, h3, h4 });
+    if (isEmpty(themeProps)) { return; }
+    // returns the first active theme if more than 1 is passed
+    return Object.keys(themeProps)[0];
+  };
+
+  _getActiveClasses = (styleProps: Object) => {
+    const activeClasses = ['header'];
+    const activeTheme = this._getActiveTheme(styleProps);
+    const activeFont = this._getActiveFont(styleProps);
+
+    if (activeTheme) { return [...activeClasses, activeTheme]; }
+    if (activeFont) { return [...activeClasses, activeFont]; }
+
+    return [...activeClasses, activeTheme, activeFont].filter(val => val);
+  }
+
+  render() {
+    const { children, className, skin: HeaderSkin, ...styleProps } = this.props;
+
+    const reducedTheme = this._assembleHeaderTheme(styleProps);
+    const inlineStyles = this._assembleInlineStyles(styleProps);
+
+    return (
+      <HeaderSkin
+        className={className}
+        inlineStyles={inlineStyles}
+        theme={reducedTheme}
+      >
+        {children}
+      </HeaderSkin>
+    );
+  }
+}
+
+export const Header = withTheme(HeaderBase);

--- a/source/components/Header.js
+++ b/source/components/Header.js
@@ -85,12 +85,12 @@ class HeaderBase extends Component <Props, State> {
     const theme = this.state.composedTheme[this.props.themeId];
 
     return activeClasses.reduce((reducedTheme, activeClass) => {
-      if (Object.hasOwnProperty.call(theme, activeClass)) {
+      if (activeClass && Object.hasOwnProperty.call(theme, activeClass)) {
         reducedTheme[activeClass] = theme[activeClass];
       }
       return reducedTheme;
     }, {});
-  }
+  };
 
   _getActiveFont = ({ light, medium, regular, thin, bold }) => {
     const fontProps = pickBy({ light, medium, regular, thin, bold });
@@ -115,7 +115,7 @@ class HeaderBase extends Component <Props, State> {
     if (activeFont) { return [...activeClasses, activeFont]; }
 
     return [...activeClasses, activeTheme, activeFont].filter(val => val);
-  }
+  };
 
   render() {
     const { children, className, skin: HeaderSkin, ...styleProps } = this.props;

--- a/source/components/Header.js
+++ b/source/components/Header.js
@@ -86,7 +86,7 @@ class HeaderBase extends Component <Props, State> {
 
     return activeClasses.reduce((reducedTheme, activeClass) => {
       if (Object.hasOwnProperty.call(theme, activeClass)) {
-        reducedTheme.activeClass = theme.activeClass;
+        reducedTheme[activeClass] = theme[activeClass];
       }
       return reducedTheme;
     }, {});

--- a/source/skins/simple/HeaderSkin.js
+++ b/source/skins/simple/HeaderSkin.js
@@ -1,0 +1,22 @@
+// @flow
+import React from 'react';
+import type { Element } from 'react';
+import classnames from 'classnames';
+
+type Props = {
+  children: Element<*>,
+  className: string,
+  inlineStyles: Object,
+  theme: Object
+};
+
+export const HeaderSkin = (props: Props) => {
+  const { children, className, inlineStyles, theme } = props;
+  const themeClasses = Object.values(theme);
+
+  return (
+    <header className={classnames([className, ...themeClasses])} style={inlineStyles}>
+      {children}
+    </header>
+  );
+};

--- a/source/themes/API/header.js
+++ b/source/themes/API/header.js
@@ -1,0 +1,13 @@
+// @flow
+export const HEADER_THEME_API = {
+  header: '',
+  h1: '',
+  h2: '',
+  h3: '',
+  h4: '',
+  thin: '',
+  light: '',
+  regular: '',
+  medium: '',
+  bold: ''
+};

--- a/source/themes/API/index.js
+++ b/source/themes/API/index.js
@@ -4,6 +4,7 @@ import { BUBBLE_THEME_API } from './bubble';
 import { BUTTON_THEME_API } from './button';
 import { CHECKBOX_THEME_API } from './checkbox';
 import { FORM_FIELD_THEME_API } from './formfield';
+import { HEADER_THEME_API } from './header';
 import { INPUT_THEME_API } from './input';
 import { LOADING_SPINNER_API } from './loadingspinner';
 import { MODAL_THEME_API } from './modal';
@@ -22,6 +23,7 @@ export const IDENTIFIERS = {
   BUTTON: 'button',
   CHECKBOX: 'checkbox',
   FORM_FIELD: 'formfield',
+  HEADER: 'header',
   INPUT: 'input',
   LOADING_SPINNER: 'loadingspinner',
   MODAL: 'modal',
@@ -41,6 +43,7 @@ export const ROOT_THEME_API = {
   [IDENTIFIERS.BUTTON]: BUTTON_THEME_API,
   [IDENTIFIERS.CHECKBOX]: CHECKBOX_THEME_API,
   [IDENTIFIERS.FORM_FIELD]: FORM_FIELD_THEME_API,
+  [IDENTIFIERS.HEADER]: HEADER_THEME_API,
   [IDENTIFIERS.INPUT]: INPUT_THEME_API,
   [IDENTIFIERS.LOADING_SPINNER]: LOADING_SPINNER_API,
   [IDENTIFIERS.MODAL]: MODAL_THEME_API,

--- a/source/themes/simple/SimpleHeader.scss
+++ b/source/themes/simple/SimpleHeader.scss
@@ -1,0 +1,63 @@
+@import "theme";
+
+.header {
+  // styles shared between all variations
+  // useful when themeOverrides is passed to ThemeProvider
+}
+
+.h1 {
+  font-family: $theme-font-bold;
+  font-size: 21px;
+  line-height: 1.39;
+  letter-spacing: 1px;
+  text-align: center;
+  text-transform: uppercase;
+  color: #5e6066;
+}
+
+.h2 {
+  font-family: $theme-font-medium;
+  font-size: 18px;
+  line-height: 1.39;
+  letter-spacing: 1px;
+  text-align: center;
+  color: #5e6066;
+}
+
+.h3 {
+  font-family: $theme-font-regular;
+  font-size: 16px;
+  line-height: 1.39;
+  letter-spacing: 1px;
+  text-align: center;
+  color: #5e6066;
+}
+
+.h4 {
+  font-family: $theme-font-light;
+  font-size: 14px;
+  line-height: 1.39;
+  letter-spacing: 1px;
+  text-align: center;
+  color: #5e6066;
+}
+
+.thin {
+  font-family: $theme-font-thin;
+}
+
+.light {
+  font-family: $theme-font-light;
+}
+
+.regular {
+  font-family: $theme-font-regular;
+}
+
+.medium {
+  font-family: $theme-font-medium;
+}
+
+.bold {
+  font-family: $theme-font-bold;
+}

--- a/source/themes/simple/index.js
+++ b/source/themes/simple/index.js
@@ -8,6 +8,7 @@ import SimpleBubble from './SimpleBubble.scss';
 import SimpleButton from './SimpleButton.scss';
 import SimpleCheckbox from './SimpleCheckbox.scss';
 import SimpleFormField from './SimpleFormField.scss';
+import SimpleHeader from './SimpleHeader.scss';
 import SimpleInput from './SimpleInput.scss';
 import SimpleLoadingSpinner from './SimpleLoadingSpinner.scss';
 import SimpleModal from './SimpleModal.scss';
@@ -30,6 +31,7 @@ export const SimpleTheme = {
   [IDENTIFIERS.BUTTON]: SimpleButton,
   [IDENTIFIERS.CHECKBOX]: SimpleCheckbox,
   [IDENTIFIERS.FORM_FIELD]: SimpleFormField,
+  [IDENTIFIERS.HEADER]: SimpleHeader,
   [IDENTIFIERS.INPUT]: SimpleInput,
   [IDENTIFIERS.LOADING_SPINNER]: SimpleLoadingSpinner,
   [IDENTIFIERS.MODAL]: SimpleModal,

--- a/stories/Header.stories.js
+++ b/stories/Header.stories.js
@@ -1,0 +1,162 @@
+// @flow
+import React from 'react';
+
+// storybook
+import { storiesOf } from '@storybook/react';
+
+// components
+import { Header } from '../source/components/Header';
+
+// skins
+import { HeaderSkin } from '../source/skins/simple/HeaderSkin';
+
+// themes
+import CustomTheme from './theme-customizations/Header.custom.scss';
+
+// custom styles & theme overrides
+import styles from './Header.stories.scss';
+import custom from './theme-overrides/customHeader.scss';
+import { decorateWithSimpleTheme } from './helpers/theming';
+
+storiesOf('Header', module)
+
+  .addDecorator(decorateWithSimpleTheme)
+
+  // ====== Header Stories ======
+
+  .add('positioning', () => (
+    <div className={styles.wrapper}>
+      <Header left skin={HeaderSkin}>
+        Wallet Name - left
+      </Header>
+
+      <Header center skin={HeaderSkin}>
+        Wallet Name - center
+      </Header>
+
+      <Header right skin={HeaderSkin}>
+        Wallet Name - right
+      </Header>
+    </div>
+  ))
+
+  .add('font', () => (
+    <div className={styles.wrapper}>
+      <Header thin themeOverrides={custom} skin={HeaderSkin}>
+        Wallet Name - thin
+      </Header>
+
+      <Header light themeOverrides={custom} skin={HeaderSkin}>
+        Wallet Name - light
+      </Header>
+
+      <Header regular themeOverrides={custom} skin={HeaderSkin}>
+        Wallet Name - regular
+      </Header>
+
+      <Header medium themeOverrides={custom} skin={HeaderSkin}>
+        Wallet Name - medium
+      </Header>
+
+      <Header bold themeOverrides={custom} skin={HeaderSkin}>
+        Wallet Name - bold
+      </Header>
+    </div>
+  ))
+
+  .add('text', () => (
+    <div className={styles.wrapper}>
+      <Header lowerCase skin={HeaderSkin}>
+        Wallet Name - lowerCase
+      </Header>
+
+      <Header upperCase skin={HeaderSkin}>
+        Wallet Name - upperCase
+      </Header>
+    </div>
+  ))
+
+  .add('simple theme', () => (
+    <div className={styles.wrapper}>
+      <Header h1 skin={HeaderSkin}>
+        Wallet Name - h1
+      </Header>
+
+      <Header h2 skin={HeaderSkin}>
+        Wallet Name - h2
+      </Header>
+
+      <Header h3 skin={HeaderSkin}>
+        Wallet Name - h3
+      </Header>
+
+      <Header h4 skin={HeaderSkin}>
+        Wallet Name - h4
+      </Header>
+    </div>
+  ))
+
+  .add('override theme - props', () => (
+    <div className={styles.wrapper}>
+      <Header h1 lowerCase skin={HeaderSkin}>
+        Wallet Name - h1 lowerCase
+      </Header>
+
+      <Header h2 left skin={HeaderSkin}>
+        Wallet Name - h2 left
+      </Header>
+
+      <Header h3 right skin={HeaderSkin}>
+        Wallet Name - h3 right
+      </Header>
+
+      <Header h4 upperCase skin={HeaderSkin}>
+        Wallet Name - h4 upperCase
+      </Header>
+    </div>
+  ))
+
+  .add('override theme - themeOverrides', () => (
+    <div className={styles.wrapper}>
+      <Header h1 themeOverrides={custom} skin={HeaderSkin}>
+        Wallet Name - h1
+      </Header>
+
+      <Header h2 themeOverrides={custom} skin={HeaderSkin}>
+        Wallet Name - h2
+      </Header>
+
+      <Header h3 themeOverrides={custom} skin={HeaderSkin}>
+        Wallet Name - h3
+      </Header>
+
+      <Header h4 themeOverrides={custom} skin={HeaderSkin}>
+        Wallet Name - h4
+      </Header>
+    </div>
+  ))
+
+  .add('override combo - props & themeOverrides', () => (
+    <div className={styles.wrapper}>
+      <Header h3 upperCase left themeOverrides={custom} skin={HeaderSkin}>
+        Wallet Name - h3
+      </Header>
+      <Header h3 upperCase right themeOverrides={custom} skin={HeaderSkin}>
+        Wallet Name - h3
+      </Header>
+      <Header h3 lowerCase center themeOverrides={custom} skin={HeaderSkin}>
+        Wallet Name - h3
+      </Header>
+    </div>
+  ))
+
+  .add('custom theme', () => (
+    <div className={styles.wrapper}>
+      <Header h1 theme={CustomTheme} skin={HeaderSkin}>
+        My Custom Theme
+      </Header>
+      <Header h1 center upperCase theme={CustomTheme} skin={HeaderSkin}>
+        My Custom Theme with Prop Overrides
+      </Header>
+    </div>
+  ));

--- a/stories/Header.stories.scss
+++ b/stories/Header.stories.scss
@@ -1,6 +1,10 @@
 .wrapper {
+  position: absolute;
+  top: 10px;
+  left: 10px;
   height: 300px;
   width: 400px;
+  border: 1px solid #eee;
 
   header {
     margin: 10px;

--- a/stories/Header.stories.scss
+++ b/stories/Header.stories.scss
@@ -1,0 +1,8 @@
+.wrapper {
+  height: 300px;
+  width: 400px;
+
+  header {
+    margin: 10px;
+  }
+}

--- a/stories/index.js
+++ b/stories/index.js
@@ -4,6 +4,7 @@ import './Autocomplete.stories';
 import './Bubble.stories';
 import './Button.stories';
 import './Checkbox.stories';
+import './Header.stories';
 import './Input.stories';
 import './LoadingSpinner.stories';
 import './Modal.stories';

--- a/stories/theme-customizations/Header.custom.scss
+++ b/stories/theme-customizations/Header.custom.scss
@@ -1,0 +1,11 @@
+.header {
+  &.h1 {
+    color: #356166;
+    font-size: 14px;
+    font-family: serif;
+    font-weight: bold;
+    letter-spacing: 2px;
+    border-radius: 10px;
+    padding: 14px 20px;
+  }
+}

--- a/stories/theme-overrides/customHeader.scss
+++ b/stories/theme-overrides/customHeader.scss
@@ -1,0 +1,41 @@
+.header {
+  font-family: 'Lato', sans-serif;
+
+  &.h1 {
+    color: rgba(10, 145, 48, 0.8);
+  }
+
+  &.h2 {
+    color: #5dcdfc;
+  }
+
+  &.h3 {
+    color: #1e4a2e;
+    border: 1px solid #1e4a2e;
+    padding: 10px;
+  }
+
+  &.h4 {
+    letter-spacing: 5px;
+  }
+
+  &.thin {
+    font-weight: 100;
+  }
+
+  &.light {
+    font-weight: 300;
+  }
+
+  &.regular {
+    font-weight: 400;
+  }
+
+  &.medium {
+    font-weight: 600;
+  }
+
+  &.bold {
+    font-weight: 700;
+  }
+}


### PR DESCRIPTION
This PR adds a Header component for creating 4 unique instances of a themed Header and makes them available in context as part of SimpleTheme. Theme variation and manipulation of specific styles can be accessed via props passed to Header as booleans. Combining and composing variations of these props with a theme makes the visual rendering of Header flexible and convenient.