### PR TITLE
[DDW-197] create flex layout component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,17 @@
 
 ## Features
 
+- Adds Flex and FlexItem components to layout components.
+  [PR 85](https://github.com/input-output-hk/react-polymorph/pull/85)
+
 - Adds ProgressBar component to library with stories.
   [PR 78](https://github.com/input-output-hk/react-polymorph/pull/78)
 
-- Adds LoadingSpinner component, LoadingSpinnerSkin, and SimpleLoadingSpinner theme. Adds reusable 
+- Adds LoadingSpinner component, LoadingSpinnerSkin, and SimpleLoadingSpinner theme. Adds reusable
   loading-spinner mixin to themes. Adds 5 LoadingSpinner stories.
   [PR 75](https://github.com/input-output-hk/react-polymorph/pull/75)
 
-- Adds ButtonSpinnerSkin to simple skins to show LoadingSpinner within the Button component when 
+- Adds ButtonSpinnerSkin to simple skins to show LoadingSpinner within the Button component when
   page data is loading. Adds new button story to exemplify this skin and functionality.
   [PR 76](https://github.com/input-output-hk/react-polymorph/pull/76)
 
@@ -19,41 +22,41 @@
 
 ### Fixes
 
-- Fixed wrong border color for errored & focused textareas 
+- Fixed wrong border color for errored & focused textareas
   [PR 73](https://github.com/input-output-hk/react-polymorph/pull/73)
 
-- De-nests the class definitions in SimpleInput.scss. Ensures the border color of both Input and 
-  NumericInput remain the correct color when in an errored state. Improves composability when theme 
-  overrides is used with both Input components. Updates stories to reflect fixes. 
+- De-nests the class definitions in SimpleInput.scss. Ensures the border color of both Input and
+  NumericInput remain the correct color when in an errored state. Improves composability when theme
+  overrides is used with both Input components. Updates stories to reflect fixes.
   [PR 71](https://github.com/input-output-hk/react-polymorph/pull/71)
 
-- Adds a new HOC GlobalListeners which is used in Select and Autocomplete that attaches document and 
-  window listeners for closing the window. Fixes bubble and arrow positioning when Bubble is rendered 
-  via Select and Autocomplete. NumericInput does not execute the user's onChange prop unless the value 
-  changes internally after being processed. Removes index.js in components and skins directories to 
+- Adds a new HOC GlobalListeners which is used in Select and Autocomplete that attaches document and
+  window listeners for closing the window. Fixes bubble and arrow positioning when Bubble is rendered
+  via Select and Autocomplete. NumericInput does not execute the user's onChange prop unless the value
+  changes internally after being processed. Removes index.js in components and skins directories to
   reduce size of library. [PR 69](https://github.com/input-output-hk/react-polymorph/pull/69)
 
-- Wraps TextAreaSkin's render method in FormField so labels and errors are rendered the same as in Input 
-  and NumericInput. Fixes Input, NumericInput, and TextArea components so they pass a prop called inputRef 
-  or textareaRef to FormField in their skins. This properly makes use of React v16.3.1+'s ref API instead 
-  of using the onRef callback. Adds autoFocus, onBlur, and onFocus props to NumericInput and TextArea. 
+- Wraps TextAreaSkin's render method in FormField so labels and errors are rendered the same as in Input
+  and NumericInput. Fixes Input, NumericInput, and TextArea components so they pass a prop called inputRef
+  or textareaRef to FormField in their skins. This properly makes use of React v16.3.1+'s ref API instead
+  of using the onRef callback. Adds autoFocus, onBlur, and onFocus props to NumericInput and TextArea.
   [PR 67](https://github.com/input-output-hk/react-polymorph/pull/67)
 
-- Fixed wrong positioning of select options when opening upward 
+- Fixed wrong positioning of select options when opening upward
   [PR 68](https://github.com/input-output-hk/react-polymorph/pull/68)
 
-- Fixed vertical positioning of select arrow when opened 
+- Fixed vertical positioning of select arrow when opened
   [PR 68](https://github.com/input-output-hk/react-polymorph/pull/68)
 
 ### Chores
 
-- Replaces all default exports in the theme directory with constants and exports them. Additionally, 
-  all import statements previously importing a default export are replaced with an appropriate named 
-  import. Defines all properties of the SimpleTheme and ROOT_THEME_API objects using IDENTIFIERS and 
+- Replaces all default exports in the theme directory with constants and exports them. Additionally,
+  all import statements previously importing a default export are replaced with an appropriate named
+  import. Defines all properties of the SimpleTheme and ROOT_THEME_API objects using IDENTIFIERS and
   arranges their properties in ABC order for better readability.
   [77](https://github.com/input-output-hk/react-polymorph/pull/77)
 
-- Adds support for React v15 - v16.4.1. Upgrades devDependencies to latest versions of react, jest, and 
+- Adds support for React v15 - v16.4.1. Upgrades devDependencies to latest versions of react, jest, and
   enzyme related libraries. Adds Autocomplete simulation test for deleting a selected option via backspace key.
   [PR 65](https://github.com/input-output-hk/react-polymorph/pull/65)
 
@@ -73,15 +76,15 @@
 
 ### Chores
 
-- Adds keydown and click simulation tests for Autocomplete using jest and enzyme. Removes helper skins from 
-  test directory and refactors the way in which components are wrapped in a ThemeContext Consumer HOC before 
+- Adds keydown and click simulation tests for Autocomplete using jest and enzyme. Removes helper skins from
+  test directory and refactors the way in which components are wrapped in a ThemeContext Consumer HOC before
   they're exported in order to handle a test environment.
   [PR 63](https://github.com/input-output-hk/react-polymorph/pull/63)
 
-- Adds polyfills for React's new context API and ref API released in v16.3.0. Drops support for React versions 
+- Adds polyfills for React's new context API and ref API released in v16.3.0. Drops support for React versions
   less than v16.[PR 61](https://github.com/input-output-hk/react-polymorph/pull/61)
 
-- Add snapshot test coverage from using jest and enzyme. Add event simulation tests for NumericInput. Adds 
+- Add snapshot test coverage from using jest and enzyme. Add event simulation tests for NumericInput. Adds
 story for ThemeProvider. [PR 60](https://github.com/input-output-hk/react-polymorph/pull/60)
 
 ### Features
@@ -105,9 +108,9 @@ Major breaking changes due to large refactoring of component architecture:
   - Removes skin parts
   - Manages refs by passing them from parent to child
   - Removes inheritance architecture
-  - Adds ESLint config from Daedalus and integrates flow library & static type declarations. Refactors 
-  - components to declare refs using createRef from React v16.3^. Removes propTypes from all components 
-  and removes prop-types lib from dependencies. 
+  - Adds ESLint config from Daedalus and integrates flow library & static type declarations. Refactors
+  - components to declare refs using createRef from React v16.3^. Removes propTypes from all components
+  and removes prop-types lib from dependencies.
 
 ## Features
 
@@ -125,33 +128,33 @@ Major breaking changes due to large refactoring of component architecture:
 
 - Add Autocomplete clear feature [PR 49](https://github.com/input-output-hk/react-polymorph/pull/49)
 
-- Implements a theme API for each component. This is a plain object which exposes the shape of a component's theme. 
-  Each property on the theme API object corresponds with a class name assigned to an element within the component's 
+- Implements a theme API for each component. This is a plain object which exposes the shape of a component's theme.
+  Each property on the theme API object corresponds with a class name assigned to an element within the component's
   skin and a class definition within the component's theme.
 
-- Adds ThemeProvider HOC for applying a theme to all its nested react-polymorph children. ThemeProvider 
-  exonerates the user from explicitly declaring theme as a prop on every instantiated component. A complete 
-  theme, an object containing full theme definitions for every component in the library, may also be passed 
-  to ThemeProvider. The complete theme object may be deconstructed to contain only the necessary theme 
-  definitions used by the components nested within a particular instance of ThemeProvider, yet deconstruction 
+- Adds ThemeProvider HOC for applying a theme to all its nested react-polymorph children. ThemeProvider
+  exonerates the user from explicitly declaring theme as a prop on every instantiated component. A complete
+  theme, an object containing full theme definitions for every component in the library, may also be passed
+  to ThemeProvider. The complete theme object may be deconstructed to contain only the necessary theme
+  definitions used by the components nested within a particular instance of ThemeProvider, yet deconstruction
   is not required.
 
-- Adds themeOverrides as an optional prop on ThemeProvider and on all components within the library. 
-  themeOverrides composes the user's custom css/scss with the component's base theme. This automatic 
-  composition saves the user from the tedium of manually piecing together custom styles with those of 
-  the component's theme that the user wishes to retain, yet themeOverrides is flexible enough to restyle 
-  a component's theme in a nontrivial way. themeOverrides may be passed directly to one instance of 
-  a component or passed to all instances nested within ThemeProvider via context. This composition of 
+- Adds themeOverrides as an optional prop on ThemeProvider and on all components within the library.
+  themeOverrides composes the user's custom css/scss with the component's base theme. This automatic
+  composition saves the user from the tedium of manually piecing together custom styles with those of
+  the component's theme that the user wishes to retain, yet themeOverrides is flexible enough to restyle
+  a component's theme in a nontrivial way. themeOverrides may be passed directly to one instance of
+  a component or passed to all instances nested within ThemeProvider via context. This composition of
   styles relies on css-modules.
 
-- Adds a composed theme story to most component stories to exemplify the relationship between ThemeProvider 
+- Adds a composed theme story to most component stories to exemplify the relationship between ThemeProvider
   and themeOverrides.
 
 - Adds autofocus prop to all applicable input based components.
 
-- Adds index file to source/utils, source/themes/API, source/themes/simple, source/skins/simple, and 
-  source/components for the use of named and default exports. Makes it easier for the user to import a 
-  full theme object for ThemeProvider, or simply one component's theme. Also makes it easier to import 
+- Adds index file to source/utils, source/themes/API, source/themes/simple, source/skins/simple, and
+  source/components for the use of named and default exports. Makes it easier for the user to import a
+  full theme object for ThemeProvider, or simply one component's theme. Also makes it easier to import
   multiple skins and components on one line.
 
 ## 0.6.4

--- a/source/components/Header.js
+++ b/source/components/Header.js
@@ -85,7 +85,7 @@ class HeaderBase extends Component <Props, State> {
     const theme = this.state.composedTheme[this.props.themeId];
 
     return activeClasses.reduce((reducedTheme, activeClass) => {
-      if (Object.hasOwnProperty.call(theme, activeClass)) {
+      if (activeClass && Object.hasOwnProperty.call(theme, activeClass)) {
         reducedTheme[activeClass] = theme[activeClass];
       }
       return reducedTheme;

--- a/source/components/layout/Base.js
+++ b/source/components/layout/Base.js
@@ -1,6 +1,6 @@
 // @flow
 import React, { Component } from 'react';
-import type { Element } from 'react';
+import type { Node } from 'react';
 import classnames from 'classnames';
 
 // styles
@@ -11,8 +11,8 @@ import { composeBaseStyles } from '../../utils/layout';
 
 type Props = {
   activeClasses: Array<*>,
-  children: Element<*> | Array<*>,
-  className: string,
+  children: Node,
+  className?: string,
   inlineStyles: Object,
   stylesToAdd?: Object
 };

--- a/source/components/layout/Base.js
+++ b/source/components/layout/Base.js
@@ -11,10 +11,10 @@ import { composeBaseStyles } from '../../utils/layout';
 
 type Props = {
   activeClasses: Array<*>,
-  children: Element<*>,
+  children: Element<*> | Array<*>,
   className: string,
   inlineStyles: Object,
-  stylesToAdd: Object
+  stylesToAdd?: Object
 };
 
 type State = {
@@ -24,6 +24,7 @@ type State = {
 export class Base extends Component<Props, State> {
   // define static properties
   static displayName = 'Base';
+  static defaultProps = { stylesToAdd: {} };
 
   constructor(props: Props) {
     super(props);

--- a/source/components/layout/Flex.js
+++ b/source/components/layout/Flex.js
@@ -1,6 +1,6 @@
 // @flow
 import React, { Component } from 'react';
-import type { Element, ComponentType, ChildrenArray } from 'react';
+import type { ChildrenArray } from 'react';
 import { pickBy } from 'lodash';
 
 // components
@@ -38,7 +38,6 @@ type State = { composedTheme: Object };
 class FlexBase extends Component<Props, State> {
   // define static properties
   static displayName = 'Flex';
-  static Item: ComponentType<*> = FlexItem;
   static defaultProps = {
     theme: null,
     themeId: IDENTIFIERS.FLEX,
@@ -107,3 +106,4 @@ class FlexBase extends Component<Props, State> {
 }
 
 export const Flex = withTheme(FlexBase);
+Flex.Item = FlexItem;

--- a/source/components/layout/Flex.js
+++ b/source/components/layout/Flex.js
@@ -1,5 +1,6 @@
 // @flow
 import React, { Component } from 'react';
+import type { Element, ComponentType, ChildrenArray } from 'react';
 import { pickBy } from 'lodash';
 
 // components
@@ -17,6 +18,7 @@ type Props = {
   alignItems: string,
   className: string,
   center: boolean,
+  children: ChildrenArray<*>,
   column: boolean,
   columnReverse: boolean,
   context: {
@@ -36,6 +38,7 @@ type State = { composedTheme: Object };
 class FlexBase extends Component<Props, State> {
   // define static properties
   static displayName = 'Flex';
+  static Item: ComponentType<*> = FlexItem;
   static defaultProps = {
     theme: null,
     themeId: IDENTIFIERS.FLEX,
@@ -62,7 +65,7 @@ class FlexBase extends Component<Props, State> {
     return [...activeClasses, ...Object.keys(activeProps)].filter(val => val);
   }
 
-  _assembleFlexTheme = (activeClasses: ['']) => {
+  _assembleFlexTheme = (activeClasses: Array<string>) => {
     const theme = this.state.composedTheme[this.props.themeId];
 
     return activeClasses.reduce((reducedTheme, activeClass) => {
@@ -102,5 +105,5 @@ class FlexBase extends Component<Props, State> {
     );
   }
 }
+
 export const Flex = withTheme(FlexBase);
-Flex.Item = FlexItem;

--- a/source/components/layout/Flex.js
+++ b/source/components/layout/Flex.js
@@ -4,7 +4,7 @@ import { pickBy } from 'lodash';
 
 // components
 import { Base } from './Base';
-// import { FlexItem } from './FlexItem';
+import { FlexItem } from './FlexItem';
 import { withTheme } from '../HOC/withTheme';
 
 // utilities
@@ -103,4 +103,4 @@ class FlexBase extends Component<Props, State> {
   }
 }
 export const Flex = withTheme(FlexBase);
-// Flex.Item = FlexItem;
+Flex.Item = FlexItem;

--- a/source/components/layout/Flex.js
+++ b/source/components/layout/Flex.js
@@ -1,0 +1,106 @@
+// @flow
+import React, { Component } from 'react';
+import { pickBy } from 'lodash';
+
+// components
+import { Base } from './Base';
+// import { FlexItem } from './FlexItem';
+import { withTheme } from '../HOC/withTheme';
+
+// utilities
+import { composeTheme, addThemeId } from '../../utils/themes';
+
+// constants
+import { IDENTIFIERS } from '../../themes/API';
+
+type Props = {
+  alignItems: string,
+  className: string,
+  center: boolean,
+  column: boolean,
+  columnReverse: boolean,
+  context: {
+    theme: Object,
+    ROOT_THEME_API: Object
+  },
+  justifyContent: string,
+  row: boolean,
+  rowReverse: boolean,
+  theme: Object,
+  themeId: string,
+  themeOverrides: Object
+};
+
+type State = { composedTheme: Object };
+
+class FlexBase extends Component<Props, State> {
+  // define static properties
+  static displayName = 'Flex';
+  static defaultProps = {
+    theme: null,
+    themeId: IDENTIFIERS.FLEX,
+    themeOverrides: {}
+  };
+
+  constructor(props: Props) {
+    super(props);
+
+    const { context, themeId, theme, themeOverrides } = props;
+
+    this.state = {
+      composedTheme: composeTheme(
+        addThemeId(theme || context.theme, themeId),
+        addThemeId(themeOverrides, themeId),
+        context.ROOT_THEME_API
+      )
+    };
+  }
+
+  _getActiveClasses = ({ center, column, columnReverse, row, rowReverse }) => {
+    const activeClasses = ['container'];
+    const activeProps = pickBy({ center, column, columnReverse, row, rowReverse });
+    return [...activeClasses, ...Object.keys(activeProps)].filter(val => val);
+  }
+
+  _assembleFlexTheme = (activeClasses: ['']) => {
+    const theme = this.state.composedTheme[this.props.themeId];
+
+    return activeClasses.reduce((reducedTheme, activeClass) => {
+      if (Object.hasOwnProperty.call(theme, activeClass)) {
+        reducedTheme[activeClass] = theme[activeClass];
+      }
+      return reducedTheme;
+    }, {});
+  }
+
+  renderChildren(theme: Object) {
+    return React.Children.map(this.props.children, child => {
+      if (child.type.displayName === 'FlexItem') {
+        return React.cloneElement(child, { theme });
+      }
+      return child;
+    });
+  }
+
+  render() {
+    const { alignItems, className, justifyContent, themeId, ...directionProps } = this.props;
+
+    const inlineStyles = pickBy({ alignItems, justifyContent });
+    const activeClasses = this._getActiveClasses(directionProps);
+    const flexTheme = this._assembleFlexTheme(activeClasses);
+    const fullTheme = this.state.composedTheme[themeId];
+
+    return (
+      <Base
+        activeClasses={activeClasses}
+        className={className}
+        inlineStyles={inlineStyles}
+        stylesToAdd={flexTheme}
+      >
+        {this.renderChildren(fullTheme)}
+      </Base>
+    );
+  }
+}
+export const Flex = withTheme(FlexBase);
+// Flex.Item = FlexItem;

--- a/source/components/layout/Flex.js
+++ b/source/components/layout/Flex.js
@@ -5,7 +5,6 @@ import { pickBy } from 'lodash';
 
 // components
 import { Base } from './Base';
-import { FlexItem } from './FlexItem';
 import { withTheme } from '../HOC/withTheme';
 
 // utilities
@@ -36,7 +35,7 @@ type Props = {
 type State = { composedTheme: Object };
 
 class FlexBase extends Component<Props, State> {
-  // define static properties
+
   static displayName = 'Flex';
   static defaultProps = {
     theme: null,
@@ -62,7 +61,7 @@ class FlexBase extends Component<Props, State> {
     const activeClasses = ['container'];
     const activeProps = pickBy({ center, column, columnReverse, row, rowReverse });
     return [...activeClasses, ...Object.keys(activeProps)].filter(val => val);
-  }
+  };
 
   _assembleFlexTheme = (activeClasses: Array<string>) => {
     const theme = this.state.composedTheme[this.props.themeId];
@@ -73,7 +72,7 @@ class FlexBase extends Component<Props, State> {
       }
       return reducedTheme;
     }, {});
-  }
+  };
 
   renderChildren(theme: Object) {
     return React.Children.map(this.props.children, child => {
@@ -106,4 +105,3 @@ class FlexBase extends Component<Props, State> {
 }
 
 export const Flex = withTheme(FlexBase);
-Flex.Item = FlexItem;

--- a/source/components/layout/FlexItem.js
+++ b/source/components/layout/FlexItem.js
@@ -1,11 +1,13 @@
 // @flow
 import React from 'react';
+import type { Element } from 'react';
 
 // components
 import { Base } from './Base';
 
 type Props = {
   alignSelf: string,
+  children: Element<*>,
   className: string,
   flex: number,
   order: number,

--- a/source/components/layout/FlexItem.js
+++ b/source/components/layout/FlexItem.js
@@ -1,0 +1,30 @@
+// @flow
+import React from 'react';
+
+// components
+import { Base } from './Base';
+
+type Props = {
+  alignSelf: string,
+  className: string,
+  flex: number,
+  order: number,
+  theme?: Object
+};
+
+export const FlexItem = (props: Props) => {
+  const { children, className, alignSelf, flex, order, theme } = props;
+  return (
+    <Base
+      activeClasses={['item']}
+      className={className}
+      inlineStyles={{ order, alignSelf, flex }}
+      stylesToAdd={theme}
+    >
+      {children}
+    </Base>
+  );
+};
+// define static properties
+FlexItem.displayName = 'FlexItem';
+FlexItem.defaultProps = { theme: {} };

--- a/source/components/layout/FlexItem.js
+++ b/source/components/layout/FlexItem.js
@@ -1,32 +1,36 @@
 // @flow
-import React from 'react';
-import type { Element } from 'react';
+import React, { Component } from 'react';
+import type { Node } from 'react';
 
 // components
 import { Base } from './Base';
 
 type Props = {
-  alignSelf: string,
-  children: Element<*>,
-  className: string,
-  flex: number,
-  order: number,
+  alignSelf?: string,
+  children: Node,
+  className?: string,
+  flex?: number,
+  order?: number,
   theme?: Object
 };
 
-export const FlexItem = (props: Props) => {
-  const { children, className, alignSelf, flex, order, theme } = props;
-  return (
-    <Base
-      activeClasses={['item']}
-      className={className}
-      inlineStyles={{ order, alignSelf, flex }}
-      stylesToAdd={theme}
-    >
-      {children}
-    </Base>
-  );
-};
-// define static properties
-FlexItem.displayName = 'FlexItem';
-FlexItem.defaultProps = { theme: {} };
+export class FlexItem extends Component<Props> {
+
+  static displayName = 'FlexItem';
+  static defaultProps = { theme: {} };
+
+  render() {
+    const { children, className, alignSelf, flex, order, theme } = this.props;
+    return (
+      <Base
+        activeClasses={['item']}
+        className={className}
+        inlineStyles={{ order, alignSelf, flex }}
+        stylesToAdd={theme}
+      >
+        {children}
+      </Base>
+    );
+  }
+}
+

--- a/source/themes/API/flex.js
+++ b/source/themes/API/flex.js
@@ -1,0 +1,5 @@
+// @flow
+export const FLEX_THEME_API = {
+  container: '',
+  item: ''
+};

--- a/source/themes/API/index.js
+++ b/source/themes/API/index.js
@@ -3,6 +3,7 @@ import { AUTOCOMPLETE_THEME_API } from './autocomplete';
 import { BUBBLE_THEME_API } from './bubble';
 import { BUTTON_THEME_API } from './button';
 import { CHECKBOX_THEME_API } from './checkbox';
+import { FLEX_THEME_API } from './flex';
 import { FORM_FIELD_THEME_API } from './formfield';
 import { HEADER_THEME_API } from './header';
 import { INPUT_THEME_API } from './input';
@@ -22,6 +23,7 @@ export const IDENTIFIERS = {
   BUBBLE: 'bubble',
   BUTTON: 'button',
   CHECKBOX: 'checkbox',
+  FLEX: 'flex',
   FORM_FIELD: 'formfield',
   HEADER: 'header',
   INPUT: 'input',
@@ -42,6 +44,7 @@ export const ROOT_THEME_API = {
   [IDENTIFIERS.BUBBLE]: BUBBLE_THEME_API,
   [IDENTIFIERS.BUTTON]: BUTTON_THEME_API,
   [IDENTIFIERS.CHECKBOX]: CHECKBOX_THEME_API,
+  [IDENTIFIERS.FLEX]: FLEX_THEME_API,
   [IDENTIFIERS.FORM_FIELD]: FORM_FIELD_THEME_API,
   [IDENTIFIERS.HEADER]: HEADER_THEME_API,
   [IDENTIFIERS.INPUT]: INPUT_THEME_API,

--- a/source/themes/simple/SimpleFlex.scss
+++ b/source/themes/simple/SimpleFlex.scss
@@ -1,0 +1,30 @@
+@import "theme";
+
+.container {
+  display: flex;
+
+  &.column {
+    flex-direction: column;
+  }
+
+  &.row {
+    flex-direction: row;
+  }
+
+  &.rowReverse {
+    flex-direction: row-reverse;
+  }
+
+  &.columnReverse {
+    flex-direction: column-reverse;
+  }
+
+  &.center {
+    justify-content: center;
+    align-items: center;
+  }
+}
+
+.item {
+  flex: none;
+}

--- a/source/themes/simple/index.js
+++ b/source/themes/simple/index.js
@@ -7,6 +7,7 @@ import SimpleAutocomplete from './SimpleAutocomplete.scss';
 import SimpleBubble from './SimpleBubble.scss';
 import SimpleButton from './SimpleButton.scss';
 import SimpleCheckbox from './SimpleCheckbox.scss';
+import SimpleFlex from './SimpleFlex.scss';
 import SimpleFormField from './SimpleFormField.scss';
 import SimpleHeader from './SimpleHeader.scss';
 import SimpleInput from './SimpleInput.scss';
@@ -30,6 +31,7 @@ export const SimpleTheme = {
   [IDENTIFIERS.BUBBLE]: SimpleBubble,
   [IDENTIFIERS.BUTTON]: SimpleButton,
   [IDENTIFIERS.CHECKBOX]: SimpleCheckbox,
+  [IDENTIFIERS.FLEX]: SimpleFlex,
   [IDENTIFIERS.FORM_FIELD]: SimpleFormField,
   [IDENTIFIERS.HEADER]: SimpleHeader,
   [IDENTIFIERS.INPUT]: SimpleInput,

--- a/source/utils/layout.js
+++ b/source/utils/layout.js
@@ -5,7 +5,7 @@
 // that should be added to baseStyles
 export const composeBaseStyles = (
   baseStyles: Object,
-  stylesToAdd: Object,
+  stylesToAdd: Object = {},
   activeClasses: Array<string>
 ) => {
   if (!activeClasses || !activeClasses.length) { return baseStyles; }

--- a/stories/Layout.stories.js
+++ b/stories/Layout.stories.js
@@ -6,6 +6,7 @@ import { storiesOf } from '@storybook/react';
 
 // components
 import { Flex } from '../source/components/layout/Flex';
+import { FlexItem } from '../source/components/layout/FlexItem';
 
 // styles && themeOverrides
 import styles from './Layout.stories.scss';
@@ -23,33 +24,33 @@ storiesOf('Layout', module)
 
   .add('Flex - column center', () => (
     <Flex column center className={wrapper}>
-      <Flex.Item>FlexItem 1</Flex.Item>
-      <Flex.Item>FlexItem 2</Flex.Item>
-      <Flex.Item>FlexItem 3</Flex.Item>
+      <FlexItem>FlexItem 1</FlexItem>
+      <FlexItem>FlexItem 2</FlexItem>
+      <FlexItem>FlexItem 3</FlexItem>
     </Flex>
   ))
 
   .add('Flex - row center', () => (
     <Flex row center className={wrapper}>
-      <Flex.Item>FlexItem 1</Flex.Item>
-      <Flex.Item>FlexItem 2</Flex.Item>
-      <Flex.Item>FlexItem 3</Flex.Item>
+      <FlexItem>FlexItem 1</FlexItem>
+      <FlexItem>FlexItem 2</FlexItem>
+      <FlexItem>FlexItem 3</FlexItem>
     </Flex>
   ))
 
   .add('Flex - columnReverse', () => (
     <Flex columnReverse center className={wrapper}>
-      <Flex.Item>FlexItem 1</Flex.Item>
-      <Flex.Item>FlexItem 2</Flex.Item>
-      <Flex.Item>FlexItem 3</Flex.Item>
+      <FlexItem>FlexItem 1</FlexItem>
+      <FlexItem>FlexItem 2</FlexItem>
+      <FlexItem>FlexItem 3</FlexItem>
     </Flex>
   ))
 
   .add('Flex - rowReverse', () => (
     <Flex rowReverse center className={wrapper}>
-      <Flex.Item>FlexItem 1</Flex.Item>
-      <Flex.Item>FlexItem 2</Flex.Item>
-      <Flex.Item>FlexItem 3</Flex.Item>
+      <FlexItem>FlexItem 1</FlexItem>
+      <FlexItem>FlexItem 2</FlexItem>
+      <FlexItem>FlexItem 3</FlexItem>
     </Flex>
   ))
 
@@ -60,9 +61,9 @@ storiesOf('Layout', module)
       alignItems="center"
       className={wrapper}
     >
-      <Flex.Item>FlexItem 1</Flex.Item>
-      <Flex.Item>FlexItem 2</Flex.Item>
-      <Flex.Item>FlexItem 3</Flex.Item>
+      <FlexItem>FlexItem 1</FlexItem>
+      <FlexItem>FlexItem 2</FlexItem>
+      <FlexItem>FlexItem 3</FlexItem>
     </Flex>
   ))
 
@@ -73,9 +74,9 @@ storiesOf('Layout', module)
       alignItems="center"
       className={wrapper}
     >
-      <Flex.Item>FlexItem 1</Flex.Item>
-      <Flex.Item>FlexItem 2</Flex.Item>
-      <Flex.Item>FlexItem 3</Flex.Item>
+      <FlexItem>FlexItem 1</FlexItem>
+      <FlexItem>FlexItem 2</FlexItem>
+      <FlexItem>FlexItem 3</FlexItem>
     </Flex>
   ))
 
@@ -86,44 +87,44 @@ storiesOf('Layout', module)
       alignItems="center"
       themeOverrides={customFlex}
     >
-      <Flex.Item>FlexItem 1</Flex.Item>
-      <Flex.Item>FlexItem 2</Flex.Item>
-      <Flex.Item>FlexItem 3</Flex.Item>
+      <FlexItem>FlexItem 1</FlexItem>
+      <FlexItem>FlexItem 2</FlexItem>
+      <FlexItem>FlexItem 3</FlexItem>
     </Flex>
   ))
 
-  .add('Flex.Item - alignSelf="flex-start"', () => (
+  .add('FlexItem - alignSelf="flex-start / end"', () => (
     <Flex row center className={wrapper}>
-      <Flex.Item alignSelf="flex-start">FlexItem 1</Flex.Item>
-      <Flex.Item alignSelf="flex-end">FlexItem 2</Flex.Item>
-      <Flex.Item alignSelf="flex-start">FlexItem 3</Flex.Item>
+      <FlexItem alignSelf="flex-start">flex-start</FlexItem>
+      <FlexItem alignSelf="flex-end">flex-end</FlexItem>
+      <FlexItem alignSelf="flex-start">flex-start</FlexItem>
     </Flex>
   ))
 
-  .add('Flex.Item - alignSelf="stretch"', () => (
+  .add('FlexItem - alignSelf="stretch"', () => (
     <Flex row center className={wrapper}>
-      <Flex.Item>FlexItem 1</Flex.Item>
-      <Flex.Item alignSelf="stretch">FlexItem 2</Flex.Item>
-      <Flex.Item>FlexItem 3</Flex.Item>
+      <FlexItem>FlexItem 1</FlexItem>
+      <FlexItem alignSelf="stretch">stretch</FlexItem>
+      <FlexItem>FlexItem 3</FlexItem>
     </Flex>
   ))
 
-  .add('Flex.Item - order', () => (
+  .add('FlexItem - order', () => (
     <Flex row center className={wrapper}>
-      <Flex.Item order={2}>FlexItem 1</Flex.Item>
-      <Flex.Item order={3}>FlexItem 2</Flex.Item>
-      <Flex.Item order={1}>FlexItem 3</Flex.Item>
-      <Flex.Item order={5}>FlexItem 4</Flex.Item>
-      <Flex.Item order={4}>FlexItem 5</Flex.Item>
+      <FlexItem order={2}>FlexItem 1</FlexItem>
+      <FlexItem order={3}>FlexItem 2</FlexItem>
+      <FlexItem order={1}>FlexItem 3</FlexItem>
+      <FlexItem order={5}>FlexItem 4</FlexItem>
+      <FlexItem order={4}>FlexItem 5</FlexItem>
     </Flex>
   ))
 
-  .add('Flex.Item - flex', () => (
+  .add('FlexItem - flex', () => (
     <Flex row center className={wrapper}>
-      <Flex.Item flex={1}>flex = 1</Flex.Item>
-      <Flex.Item flex={2}>flex = 2</Flex.Item>
-      <Flex.Item flex={3}>flex = 3</Flex.Item>
-      <Flex.Item flex={4}>flex = 4</Flex.Item>
-      <Flex.Item flex={5}>flex = 5</Flex.Item>
+      <FlexItem flex={1}>flex = 1</FlexItem>
+      <FlexItem flex={2}>flex = 2</FlexItem>
+      <FlexItem flex={3}>flex = 3</FlexItem>
+      <FlexItem flex={4}>flex = 4</FlexItem>
+      <FlexItem flex={5}>flex = 5</FlexItem>
     </Flex>
   ));

--- a/stories/Layout.stories.js
+++ b/stories/Layout.stories.js
@@ -1,0 +1,129 @@
+// @flow
+import React from 'react';
+
+// storybook
+import { storiesOf } from '@storybook/react';
+
+// components
+import { Flex } from '../source/components/layout/Flex';
+
+// styles && themeOverrides
+import styles from './Layout.stories.scss';
+import customFlex from './theme-overrides/customFlex.scss';
+
+// decorator
+import { decorateWithSimpleTheme } from './helpers/theming';
+
+const { wrapper } = styles;
+
+storiesOf('Layout', module)
+
+  // wraps all stories in ThemeProvider, passes theme via context
+  .addDecorator(decorateWithSimpleTheme)
+
+  .add('Flex - column center', () => (
+    <Flex column center className={wrapper}>
+      <Flex.Item>FlexItem 1</Flex.Item>
+      <Flex.Item>FlexItem 2</Flex.Item>
+      <Flex.Item>FlexItem 3</Flex.Item>
+    </Flex>
+  ))
+
+  .add('Flex - row center', () => (
+    <Flex row center className={wrapper}>
+      <Flex.Item>FlexItem 1</Flex.Item>
+      <Flex.Item>FlexItem 2</Flex.Item>
+      <Flex.Item>FlexItem 3</Flex.Item>
+    </Flex>
+  ))
+
+  .add('Flex - columnReverse', () => (
+    <Flex columnReverse center className={wrapper}>
+      <Flex.Item>FlexItem 1</Flex.Item>
+      <Flex.Item>FlexItem 2</Flex.Item>
+      <Flex.Item>FlexItem 3</Flex.Item>
+    </Flex>
+  ))
+
+  .add('Flex - rowReverse', () => (
+    <Flex rowReverse center className={wrapper}>
+      <Flex.Item>FlexItem 1</Flex.Item>
+      <Flex.Item>FlexItem 2</Flex.Item>
+      <Flex.Item>FlexItem 3</Flex.Item>
+    </Flex>
+  ))
+
+  .add('Flex - justifyContent="space-around"', () => (
+    <Flex
+      row
+      justifyContent="space-around"
+      alignItems="center"
+      className={wrapper}
+    >
+      <Flex.Item>FlexItem 1</Flex.Item>
+      <Flex.Item>FlexItem 2</Flex.Item>
+      <Flex.Item>FlexItem 3</Flex.Item>
+    </Flex>
+  ))
+
+  .add('Flex - justifyContent="space-between"', () => (
+    <Flex
+      row
+      justifyContent="space-between"
+      alignItems="center"
+      className={wrapper}
+    >
+      <Flex.Item>FlexItem 1</Flex.Item>
+      <Flex.Item>FlexItem 2</Flex.Item>
+      <Flex.Item>FlexItem 3</Flex.Item>
+    </Flex>
+  ))
+
+  .add('Flex - themeOverrides', () => (
+    <Flex
+      row
+      justifyContent="space-between"
+      alignItems="center"
+      themeOverrides={customFlex}
+    >
+      <Flex.Item>FlexItem 1</Flex.Item>
+      <Flex.Item>FlexItem 2</Flex.Item>
+      <Flex.Item>FlexItem 3</Flex.Item>
+    </Flex>
+  ))
+
+  .add('Flex.Item - alignSelf="flex-start"', () => (
+    <Flex row center className={wrapper}>
+      <Flex.Item alignSelf="flex-start">FlexItem 1</Flex.Item>
+      <Flex.Item alignSelf="flex-end">FlexItem 2</Flex.Item>
+      <Flex.Item alignSelf="flex-start">FlexItem 3</Flex.Item>
+    </Flex>
+  ))
+
+  .add('Flex.Item - alignSelf="stretch"', () => (
+    <Flex row center className={wrapper}>
+      <Flex.Item>FlexItem 1</Flex.Item>
+      <Flex.Item alignSelf="stretch">FlexItem 2</Flex.Item>
+      <Flex.Item>FlexItem 3</Flex.Item>
+    </Flex>
+  ))
+
+  .add('Flex.Item - order', () => (
+    <Flex row center className={wrapper}>
+      <Flex.Item order={2}>FlexItem 1</Flex.Item>
+      <Flex.Item order={3}>FlexItem 2</Flex.Item>
+      <Flex.Item order={1}>FlexItem 3</Flex.Item>
+      <Flex.Item order={5}>FlexItem 4</Flex.Item>
+      <Flex.Item order={4}>FlexItem 5</Flex.Item>
+    </Flex>
+  ))
+
+  .add('Flex.Item - flex', () => (
+    <Flex row center className={wrapper}>
+      <Flex.Item flex={1}>flex = 1</Flex.Item>
+      <Flex.Item flex={2}>flex = 2</Flex.Item>
+      <Flex.Item flex={3}>flex = 3</Flex.Item>
+      <Flex.Item flex={4}>flex = 4</Flex.Item>
+      <Flex.Item flex={5}>flex = 5</Flex.Item>
+    </Flex>
+  ));

--- a/stories/Layout.stories.scss
+++ b/stories/Layout.stories.scss
@@ -1,0 +1,21 @@
+.wrapper {
+  padding: 5px;
+  margin: 20px;
+  height: 500px;
+  width: auto;
+  border: 1px solid #BEBEBE;
+
+  div {
+    background: tomato;
+    font-family: 'apercu-pro', sans-serif;
+    padding: 5px;
+    width: 100px;
+    margin: 5px;
+    border-radius: 5px;
+    line-height: 100px;
+    color: white;
+    font-size: 15px;
+    text-align: center;
+    box-shadow: 3px 3px 5px rgba(0, 0, 0, 0.5);
+  }
+}

--- a/stories/index.js
+++ b/stories/index.js
@@ -6,6 +6,7 @@ import './Button.stories';
 import './Checkbox.stories';
 import './Header.stories';
 import './Input.stories';
+import './Layout.stories';
 import './LoadingSpinner.stories';
 import './Modal.stories';
 import './NumericInput.stories';

--- a/stories/theme-overrides/customFlex.scss
+++ b/stories/theme-overrides/customFlex.scss
@@ -1,0 +1,21 @@
+.container {
+  padding: 5px;
+  margin: 20px;
+  height: 500px;
+  width: auto;
+  border: 1px solid #BEBEBE;
+
+  .item {
+    font-family: 'apercu-pro', sans-serif;
+    color: #fff;
+    background-color: rgba(66, 244, 226, 0.6);
+    box-shadow: 3px 3px 5px rgba(0, 0, 0, 0.5);
+    padding: 5px;
+    width: 100px;
+    margin: 5px;
+    border-radius: 5px;
+    line-height: 100px;
+    font-size: 15px;
+    text-align: center;
+  }
+}


### PR DESCRIPTION
This PR adds layout components Flex and FlexItem. This abstracts layout into composable, compound components that facilitate a more uniform and reusable layout solution. Enables third party developers using react-polymorph to craft applications with uniformity of layout specs and style more easily with most of the Flexbox API.