### PR TITLE
[DDW-446] Add display name to components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ## Features
 
+- Adds displayName static property to all components
+  [PR 89](https://github.com/input-output-hk/react-polymorph/pull/89)
+
 - Adds Flex and FlexItem components to layout components.
   [PR 85](https://github.com/input-output-hk/react-polymorph/pull/85)
 

--- a/source/components/Autocomplete.js
+++ b/source/components/Autocomplete.js
@@ -53,11 +53,14 @@ type State = {
 };
 
 class AutocompleteBase extends Component<Props, State> {
+  // declare ref types
   rootElement: ?Element<any>;
   inputElement: ?Element<'input'>;
   suggestionsElement: ?Element<any>;
   optionsElement: ?Element<any>;
 
+  // define static properties
+  static displayName = 'Autocomplete';
   static defaultProps = {
     error: null,
     invalidCharsRegex: /[^a-zA-Z0-9]/g, // only allow letters and numbers by default

--- a/source/components/Bubble.js
+++ b/source/components/Bubble.js
@@ -36,9 +36,11 @@ type State = {
 };
 
 class BubbleBase extends Component<Props, State> {
-
+  // declare ref types
   rootElement: ?Element<any>;
 
+  // define static properties
+  static displayName = 'Bubble';
   static defaultProps = {
     isHidden: false,
     isFloating: false,

--- a/source/components/Button.js
+++ b/source/components/Button.js
@@ -32,6 +32,8 @@ type State = {
 };
 
 class ButtonBase extends Component<Props, State> {
+  // define static properties
+  static displayName = 'Button';
   static defaultProps = {
     disabled: false,
     loading: false,

--- a/source/components/Checkbox.js
+++ b/source/components/Checkbox.js
@@ -36,6 +36,8 @@ type State = {
 };
 
 class CheckboxBase extends Component<Props, State> {
+  // define static properties
+  static displayName = 'Checkbox';
   static defaultProps = {
     checked: false,
     disabled: false,

--- a/source/components/FormField.js
+++ b/source/components/FormField.js
@@ -34,6 +34,8 @@ type State = {
 };
 
 class FormFieldBase extends Component<Props, State> {
+  // define static properties
+  static displayName = 'FormField';
   static defaultProps = {
     disabled: false,
     theme: null,

--- a/source/components/HOC/GlobalListeners.js
+++ b/source/components/HOC/GlobalListeners.js
@@ -20,6 +20,8 @@ type Props = {
 };
 
 export class GlobalListeners extends Component<Props> {
+  // define static properties
+  static displayName = 'GlobalListeners';
   static defaultProps = {
     optionsIsOpen: false
   };

--- a/source/components/HOC/withTheme.js
+++ b/source/components/HOC/withTheme.js
@@ -3,6 +3,7 @@ import React from 'react';
 import type { ComponentType, Ref } from 'react';
 import forwardRef from 'create-react-ref/lib/forwardRef';
 import { ThemeContext } from './ThemeContext';
+import { getDisplayName } from '../../utils/props';
 
 // withTheme is a HOC that takes a Component as a parameter
 // and returns that Component wrapped within ThemeContext.Consumer.
@@ -26,5 +27,7 @@ export const withTheme = (Component: ComponentType<any>) => {
     ));
   }
 
+  // create a new displayName for the wrapped component
+  WrappedComponent.displayName = `withTheme(${getDisplayName(Component)})`;
   return WrappedComponent;
 };

--- a/source/components/HOC/withTheme.js
+++ b/source/components/HOC/withTheme.js
@@ -2,7 +2,12 @@
 import React from 'react';
 import type { ComponentType, Ref } from 'react';
 import forwardRef from 'create-react-ref/lib/forwardRef';
+
+// internal components
 import { ThemeContext } from './ThemeContext';
+
+// utility functions
+import { getDisplayName } from '../../utils/props';
 
 // withTheme is a HOC that takes a Component as a parameter
 // and returns that Component wrapped within ThemeContext.Consumer.
@@ -25,6 +30,7 @@ export const withTheme = (Component: ComponentType<any>) => {
       </ThemeContext.Consumer>
     ));
   }
-
+  // create a new displayName for the wrapped component
+  WrappedComponent.displayName = `withTheme(${getDisplayName(Component)})`;
   return WrappedComponent;
 };

--- a/source/components/Input.js
+++ b/source/components/Input.js
@@ -48,9 +48,11 @@ type State = {
 };
 
 class InputBase extends Component<Props, State> {
-
+  // declare ref types
   inputElement: Element<'input'>;
 
+  // define static properties
+  static displayName = 'Input';
   static defaultProps = {
     autoFocus: false,
     error: '',

--- a/source/components/LoadingSpinner.js
+++ b/source/components/LoadingSpinner.js
@@ -30,6 +30,8 @@ type State = {
 };
 
 class LoadingSpinnerBase extends Component<Props, State> {
+  // define static properties
+  static displayName = 'LoadingSpinner';
   static defaultProps = {
     big: false,
     theme: null,

--- a/source/components/Modal.js
+++ b/source/components/Modal.js
@@ -31,6 +31,8 @@ type State = {
 };
 
 class ModalBase extends Component<Props, State> {
+  // define static properties
+  static displayName = 'Modal';
   static defaultProps = {
     contentLabel: 'Modal Dialog',
     isOpen: false,

--- a/source/components/NumericInput.js
+++ b/source/components/NumericInput.js
@@ -54,8 +54,11 @@ type State = {
 };
 
 class NumericInputBase extends Component<Props, State> {
+  // declare ref types
   inputElement: Element<'input'>;
 
+  // define static properties
+  static displayName = 'NumericInput';
   static defaultProps = {
     disabled: false,
     error: '',

--- a/source/components/Options.js
+++ b/source/components/Options.js
@@ -55,9 +55,11 @@ type State = {
 };
 
 class OptionsBase extends Component<Props, State> {
+  // declare ref types
+  optionsElement: ?Element<any>; // TODO: Does this get used? Don't think so.
 
-  optionsElement: ?Element<any>;
-
+  // define static properties
+  static displayName = 'Options';
   static defaultProps = {
     isOpen: false,
     isOpeningUpward: false,

--- a/source/components/ProgressBar.js
+++ b/source/components/ProgressBar.js
@@ -30,6 +30,8 @@ type State = {
 };
 
 class ProgressBarBase extends Component<Props, State> {
+  // define static properties
+  static displayName = 'ProgressBar';
   static defaultProps = {
     progress: 100,
     theme: null,

--- a/source/components/Radio.js
+++ b/source/components/Radio.js
@@ -33,6 +33,8 @@ type State = {
 };
 
 class RadioBase extends Component<Props, State> {
+  // define static properties
+  static displayName = 'Radio';
   static defaultProps = {
     disabled: false,
     selected: false,

--- a/source/components/Select.js
+++ b/source/components/Select.js
@@ -46,11 +46,13 @@ type State = {
 };
 
 class SelectBase extends Component<Props, State> {
-
+  // declare ref types
   rootElement: ?Element<*>;
   inputElement: Element<'input'>;
   optionsElement: ?Element<*>;
 
+  // define static properties
+  static displayName = 'Select';
   static defaultProps = {
     allowBlank: true,
     autoFocus: false,

--- a/source/components/TextArea.js
+++ b/source/components/TextArea.js
@@ -46,8 +46,11 @@ type State = {
 };
 
 class TextAreaBase extends Component<Props, State> {
+  // declare ref types
   textareaElement: Element<'textarea'>;
 
+  // define static properties
+  static displayName = 'TextArea';
   static defaultProps = {
     autoFocus: false,
     autoResize: true,

--- a/source/components/ThemeProvider.js
+++ b/source/components/ThemeProvider.js
@@ -26,6 +26,8 @@ type State = {
 };
 
 export class ThemeProvider extends Component<Props, State> {
+  // define static properties
+  static displayName = 'ThemeProvider';
   static defaultProps = {
     themeOverrides: {}
   };

--- a/source/components/Tooltip.js
+++ b/source/components/Tooltip.js
@@ -33,6 +33,8 @@ type State = {
 };
 
 class TooltipBase extends Component<Props, State> {
+  // define static properties
+  static displayName = 'Tooltip';
   static defaultProps = {
     isOpeningUpward: true,
     isTransparent: true,

--- a/source/components/layout/Flex.js
+++ b/source/components/layout/Flex.js
@@ -35,7 +35,7 @@ type Props = {
 type State = { composedTheme: Object };
 
 class FlexBase extends Component<Props, State> {
-
+  // define static properties
   static displayName = 'Flex';
   static defaultProps = {
     theme: null,

--- a/source/components/layout/FlexItem.js
+++ b/source/components/layout/FlexItem.js
@@ -15,7 +15,7 @@ type Props = {
 };
 
 export class FlexItem extends Component<Props> {
-
+  // define static properties
   static displayName = 'FlexItem';
   static defaultProps = { theme: {} };
 
@@ -33,4 +33,3 @@ export class FlexItem extends Component<Props> {
     );
   }
 }
-

--- a/source/utils/props.js
+++ b/source/utils/props.js
@@ -13,3 +13,6 @@ export const numberToPx = (val: string | number) =>
 
 export const hasProperty = (obj: Object, property: ?string) =>
   Object.prototype.hasOwnProperty.call(obj, property);
+
+export const getDisplayName = (Component: ComponentType<*>) =>
+  (Component.displayName || Component.name);

--- a/source/utils/props.js
+++ b/source/utils/props.js
@@ -7,3 +7,6 @@ export const pickDOMProps = filterReactDomProps;
 
 export const composeFunctions = (...fns: [Function, Function]) => (...args: [any, any]) =>
   fns.forEach(fn => fn && fn(...args));
+
+export const getDisplayName = (Component: ComponentType<*>) =>
+  (Component.displayName || Component.name);


### PR DESCRIPTION
This PR adds a `displayName` static property to all components for semantic convenience when using react developer tools and for targeting a component by its `displayName` in tests.