### PR TITLE
[DDW-381] Fix themeOverrides in react polymorph ThemeProvider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## vNext
 
+## Fixes
+
+- Fixes a bug where ThemeProvider failed to compose its theme prop with the user's custom styles passed as a themeOverrides prop. Adds a themeOverrides story to ThemeProvider's stories to show intended functionality of theme composition. [PR 90](https://github.com/input-output-hk/react-polymorph/pull/90)
+
 ## Features
 
 - Adds InfiniteScroll component, InfiniteScrollSkin to simple skins, and SimpleInfiniteScroll to SimpleTheme.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## Fixes
 
-- Fixes a bug where ThemeProvider failed to compose its theme prop with the user's custom styles passed as a themeOverrides prop. Adds a themeOverrides story to ThemeProvider's stories to show intended functionality of theme composition. [PR 90](https://github.com/input-output-hk/react-polymorph/pull/90)
+- Fixes a bug where ThemeProvider failed to compose its theme prop with the user's custom styles passed as the themeOverrides prop. Adds a check to all components using context for when themeOverrides or theme changes in context. If there is a change, the component's theme and themeOverrides will be composed again and local state will update. Adds a themeOverrides story to ThemeProvider's stories to show intended functionality of theme composition and dynamic theme switching. [PR 90](https://github.com/input-output-hk/react-polymorph/pull/90)
 
 ## Features
 

--- a/source/components/Autocomplete.js
+++ b/source/components/Autocomplete.js
@@ -12,7 +12,7 @@ import { GlobalListeners } from './HOC/GlobalListeners';
 import { withTheme } from './HOC/withTheme';
 
 // internal utility functions
-import { composeTheme, addThemeId } from '../utils/themes';
+import { composeTheme, addThemeId, didThemePropsChange } from '../utils/themes';
 import { composeFunctions } from '../utils/props';
 
 import { IDENTIFIERS } from '../themes/API';
@@ -106,28 +106,7 @@ class AutocompleteBase extends Component<Props, State> {
   }
 
   componentWillReceiveProps(nextProps: Props) {
-    const { context, themeId, theme, themeOverrides } = this.props;
-    const {
-      context: nextContext,
-      themeId: nextThemeId,
-      theme: nextTheme,
-      themeOverrides: nextOverrides
-    } = nextProps;
-
-    if (
-      !_.isEqual(context, nextContext) ||
-      !_.isEqual(themeId, nextThemeId) ||
-      !_.isEqual(theme, nextTheme) ||
-      !_.isEqual(themeOverrides, nextOverrides)
-    ) {
-      this.setState(() => ({
-        composedTheme: composeTheme(
-          addThemeId(nextTheme || nextContext.theme, nextThemeId),
-          addThemeId(nextOverrides, nextThemeId),
-          nextContext.ROOT_THEME_API
-        )
-      }));
-    }
+    didThemePropsChange(this.props, nextProps, this.setState.bind(this));
   }
 
   clear = () => this._removeOptions();

--- a/source/components/Autocomplete.js
+++ b/source/components/Autocomplete.js
@@ -105,6 +105,31 @@ class AutocompleteBase extends Component<Props, State> {
     };
   }
 
+  componentWillReceiveProps(nextProps: Props) {
+    const { context, themeId, theme, themeOverrides } = this.props;
+    const {
+      context: nextContext,
+      themeId: nextThemeId,
+      theme: nextTheme,
+      themeOverrides: nextOverrides
+    } = nextProps;
+
+    if (
+      !_.isEqual(context, nextContext) ||
+      !_.isEqual(themeId, nextThemeId) ||
+      !_.isEqual(theme, nextTheme) ||
+      !_.isEqual(themeOverrides, nextOverrides)
+    ) {
+      this.setState(() => ({
+        composedTheme: composeTheme(
+          addThemeId(nextTheme || nextContext.theme, nextThemeId),
+          addThemeId(nextOverrides, nextThemeId),
+          nextContext.ROOT_THEME_API
+        )
+      }));
+    }
+  }
+
   clear = () => this._removeOptions();
 
   focus = () => this.handleAutocompleteClick();

--- a/source/components/Bubble.js
+++ b/source/components/Bubble.js
@@ -2,13 +2,12 @@
 import React, { Component } from 'react';
 import type { ComponentType, Element, ElementRef, Ref } from 'react';
 import createRef from 'create-react-ref/lib/createRef';
-import { isEqual } from 'lodash';
 
 // internal components
 import { withTheme } from './HOC/withTheme';
 
 // internal utility functions
-import { composeTheme, addThemeId } from '../utils/themes';
+import { composeTheme, addThemeId, didThemePropsChange } from '../utils/themes';
 import { addDocumentListeners, removeDocumentListeners } from '../utils/events';
 
 // import constants
@@ -77,28 +76,7 @@ class BubbleBase extends Component<Props, State> {
   }
 
   componentWillReceiveProps(nextProps: Props) {
-    const { context, themeId, theme, themeOverrides } = this.props;
-    const {
-      context: nextContext,
-      themeId: nextThemeId,
-      theme: nextTheme,
-      themeOverrides: nextOverrides
-    } = nextProps;
-
-    if (
-      !isEqual(context, nextContext) ||
-      !isEqual(themeId, nextThemeId) ||
-      !isEqual(theme, nextTheme) ||
-      !isEqual(themeOverrides, nextOverrides)
-    ) {
-      this.setState(() => ({
-        composedTheme: composeTheme(
-          addThemeId(nextTheme || nextContext.theme, nextThemeId),
-          addThemeId(nextOverrides, nextThemeId),
-          nextContext.ROOT_THEME_API
-        )
-      }));
-    }
+    didThemePropsChange(this.props, nextProps, this.setState.bind(this));
   }
 
   componentWillUpdate(nextProps) {

--- a/source/components/Bubble.js
+++ b/source/components/Bubble.js
@@ -2,6 +2,7 @@
 import React, { Component } from 'react';
 import type { ComponentType, Element, ElementRef, Ref } from 'react';
 import createRef from 'create-react-ref/lib/createRef';
+import { isEqual } from 'lodash';
 
 // internal components
 import { withTheme } from './HOC/withTheme';
@@ -73,6 +74,31 @@ class BubbleBase extends Component<Props, State> {
     setTimeout(() => {
       if (this.props.isFloating) this._updatePosition();
     }, 0);
+  }
+
+  componentWillReceiveProps(nextProps: Props) {
+    const { context, themeId, theme, themeOverrides } = this.props;
+    const {
+      context: nextContext,
+      themeId: nextThemeId,
+      theme: nextTheme,
+      themeOverrides: nextOverrides
+    } = nextProps;
+
+    if (
+      !isEqual(context, nextContext) ||
+      !isEqual(themeId, nextThemeId) ||
+      !isEqual(theme, nextTheme) ||
+      !isEqual(themeOverrides, nextOverrides)
+    ) {
+      this.setState(() => ({
+        composedTheme: composeTheme(
+          addThemeId(nextTheme || nextContext.theme, nextThemeId),
+          addThemeId(nextOverrides, nextThemeId),
+          nextContext.ROOT_THEME_API
+        )
+      }));
+    }
   }
 
   componentWillUpdate(nextProps) {

--- a/source/components/Button.js
+++ b/source/components/Button.js
@@ -1,6 +1,7 @@
 // @flow
 import React, { Component } from 'react';
 import type { ComponentType, Element } from 'react';
+import { isEqual } from 'lodash';
 
 // internal components
 import { withTheme } from './HOC/withTheme';
@@ -52,6 +53,31 @@ class ButtonBase extends Component<Props, State> {
         context.ROOT_THEME_API
       )
     };
+  }
+
+  componentWillReceiveProps(nextProps: Props) {
+    const { context, themeId, theme, themeOverrides } = this.props;
+    const {
+      context: nextContext,
+      themeId: nextThemeId,
+      theme: nextTheme,
+      themeOverrides: nextOverrides
+    } = nextProps;
+
+    if (
+      !isEqual(context, nextContext) ||
+      !isEqual(themeId, nextThemeId) ||
+      !isEqual(theme, nextTheme) ||
+      !isEqual(themeOverrides, nextOverrides)
+    ) {
+      this.setState(() => ({
+        composedTheme: composeTheme(
+          addThemeId(nextTheme || nextContext.theme, nextThemeId),
+          addThemeId(nextOverrides, nextThemeId),
+          nextContext.ROOT_THEME_API
+        )
+      }));
+    }
   }
 
   render() {

--- a/source/components/Button.js
+++ b/source/components/Button.js
@@ -1,13 +1,12 @@
 // @flow
 import React, { Component } from 'react';
 import type { ComponentType, Element } from 'react';
-import { isEqual } from 'lodash';
 
 // internal components
 import { withTheme } from './HOC/withTheme';
 
 // internal utility functions
-import { composeTheme, addThemeId } from '../utils/themes';
+import { composeTheme, addThemeId, didThemePropsChange } from '../utils/themes';
 
 // import constants
 import { IDENTIFIERS } from '../themes/API';
@@ -56,28 +55,7 @@ class ButtonBase extends Component<Props, State> {
   }
 
   componentWillReceiveProps(nextProps: Props) {
-    const { context, themeId, theme, themeOverrides } = this.props;
-    const {
-      context: nextContext,
-      themeId: nextThemeId,
-      theme: nextTheme,
-      themeOverrides: nextOverrides
-    } = nextProps;
-
-    if (
-      !isEqual(context, nextContext) ||
-      !isEqual(themeId, nextThemeId) ||
-      !isEqual(theme, nextTheme) ||
-      !isEqual(themeOverrides, nextOverrides)
-    ) {
-      this.setState(() => ({
-        composedTheme: composeTheme(
-          addThemeId(nextTheme || nextContext.theme, nextThemeId),
-          addThemeId(nextOverrides, nextThemeId),
-          nextContext.ROOT_THEME_API
-        )
-      }));
-    }
+    didThemePropsChange(this.props, nextProps, this.setState.bind(this));
   }
 
   render() {

--- a/source/components/Checkbox.js
+++ b/source/components/Checkbox.js
@@ -1,13 +1,12 @@
 // @flow
 import React, { Component } from 'react';
 import type { ComponentType, Element } from 'react';
-import { isEqual } from 'lodash';
 
 // internal components
 import { withTheme } from './HOC/withTheme';
 
 // internal utility functions
-import { composeTheme, addThemeId } from '../utils/themes';
+import { composeTheme, addThemeId, didThemePropsChange } from '../utils/themes';
 
 // import constants
 import { IDENTIFIERS } from '../themes/API';
@@ -60,28 +59,7 @@ class CheckboxBase extends Component<Props, State> {
   }
 
   componentWillReceiveProps(nextProps: Props) {
-    const { context, themeId, theme, themeOverrides } = this.props;
-    const {
-      context: nextContext,
-      themeId: nextThemeId,
-      theme: nextTheme,
-      themeOverrides: nextOverrides
-    } = nextProps;
-
-    if (
-      !isEqual(context, nextContext) ||
-      !isEqual(themeId, nextThemeId) ||
-      !isEqual(theme, nextTheme) ||
-      !isEqual(themeOverrides, nextOverrides)
-    ) {
-      this.setState(() => ({
-        composedTheme: composeTheme(
-          addThemeId(nextTheme || nextContext.theme, nextThemeId),
-          addThemeId(nextOverrides, nextThemeId),
-          nextContext.ROOT_THEME_API
-        )
-      }));
-    }
+    didThemePropsChange(this.props, nextProps, this.setState.bind(this));
   }
 
   render() {

--- a/source/components/Checkbox.js
+++ b/source/components/Checkbox.js
@@ -1,6 +1,7 @@
 // @flow
 import React, { Component } from 'react';
 import type { ComponentType, Element } from 'react';
+import { isEqual } from 'lodash';
 
 // internal components
 import { withTheme } from './HOC/withTheme';
@@ -56,6 +57,31 @@ class CheckboxBase extends Component<Props, State> {
         context.ROOT_THEME_API
       )
     };
+  }
+
+  componentWillReceiveProps(nextProps: Props) {
+    const { context, themeId, theme, themeOverrides } = this.props;
+    const {
+      context: nextContext,
+      themeId: nextThemeId,
+      theme: nextTheme,
+      themeOverrides: nextOverrides
+    } = nextProps;
+
+    if (
+      !isEqual(context, nextContext) ||
+      !isEqual(themeId, nextThemeId) ||
+      !isEqual(theme, nextTheme) ||
+      !isEqual(themeOverrides, nextOverrides)
+    ) {
+      this.setState(() => ({
+        composedTheme: composeTheme(
+          addThemeId(nextTheme || nextContext.theme, nextThemeId),
+          addThemeId(nextOverrides, nextThemeId),
+          nextContext.ROOT_THEME_API
+        )
+      }));
+    }
   }
 
   render() {

--- a/source/components/FormField.js
+++ b/source/components/FormField.js
@@ -1,13 +1,12 @@
 // @flow
 import React, { Component } from 'react';
 import type { ComponentType, Element } from 'react';
-import { isEqual } from 'lodash';
 
 // internal components
 import { withTheme } from './HOC/withTheme';
 
 // internal utility functions
-import { composeTheme, addThemeId } from '../utils/themes';
+import { composeTheme, addThemeId, didThemePropsChange } from '../utils/themes';
 
 // import constants
 import { IDENTIFIERS } from '../themes/API';
@@ -58,28 +57,7 @@ class FormFieldBase extends Component<Props, State> {
   }
 
   componentWillReceiveProps(nextProps: Props) {
-    const { context, themeId, theme, themeOverrides } = this.props;
-    const {
-      context: nextContext,
-      themeId: nextThemeId,
-      theme: nextTheme,
-      themeOverrides: nextOverrides
-    } = nextProps;
-
-    if (
-      !isEqual(context, nextContext) ||
-      !isEqual(themeId, nextThemeId) ||
-      !isEqual(theme, nextTheme) ||
-      !isEqual(themeOverrides, nextOverrides)
-    ) {
-      this.setState(() => ({
-        composedTheme: composeTheme(
-          addThemeId(nextTheme || nextContext.theme, nextThemeId),
-          addThemeId(nextOverrides, nextThemeId),
-          nextContext.ROOT_THEME_API
-        )
-      }));
-    }
+    didThemePropsChange(this.props, nextProps, this.setState.bind(this));
   }
 
   setError = (error: string) => this.setState({ error });

--- a/source/components/FormField.js
+++ b/source/components/FormField.js
@@ -1,6 +1,7 @@
 // @flow
 import React, { Component } from 'react';
 import type { ComponentType, Element } from 'react';
+import { isEqual } from 'lodash';
 
 // internal components
 import { withTheme } from './HOC/withTheme';
@@ -54,6 +55,31 @@ class FormFieldBase extends Component<Props, State> {
         context.ROOT_THEME_API
       )
     };
+  }
+
+  componentWillReceiveProps(nextProps: Props) {
+    const { context, themeId, theme, themeOverrides } = this.props;
+    const {
+      context: nextContext,
+      themeId: nextThemeId,
+      theme: nextTheme,
+      themeOverrides: nextOverrides
+    } = nextProps;
+
+    if (
+      !isEqual(context, nextContext) ||
+      !isEqual(themeId, nextThemeId) ||
+      !isEqual(theme, nextTheme) ||
+      !isEqual(themeOverrides, nextOverrides)
+    ) {
+      this.setState(() => ({
+        composedTheme: composeTheme(
+          addThemeId(nextTheme || nextContext.theme, nextThemeId),
+          addThemeId(nextOverrides, nextThemeId),
+          nextContext.ROOT_THEME_API
+        )
+      }));
+    }
   }
 
   setError = (error: string) => this.setState({ error });

--- a/source/components/Header.js
+++ b/source/components/Header.js
@@ -1,7 +1,7 @@
 // @flow
 import React, { Component } from 'react';
 import type { ComponentType, Element } from 'react';
-import { pickBy, isEmpty } from 'lodash';
+import { pickBy, isEmpty, isEqual } from 'lodash';
 
 // components
 import { withTheme } from './HOC/withTheme';
@@ -62,6 +62,31 @@ class HeaderBase extends Component <Props, State> {
         context.ROOT_THEME_API
       )
     };
+  }
+
+  componentWillReceiveProps(nextProps: Props) {
+    const { context, themeId, theme, themeOverrides } = this.props;
+    const {
+      context: nextContext,
+      themeId: nextThemeId,
+      theme: nextTheme,
+      themeOverrides: nextOverrides
+    } = nextProps;
+
+    if (
+      !isEqual(context, nextContext) ||
+      !isEqual(themeId, nextThemeId) ||
+      !isEqual(theme, nextTheme) ||
+      !isEqual(themeOverrides, nextOverrides)
+    ) {
+      this.setState(() => ({
+        composedTheme: composeTheme(
+          addThemeId(nextTheme || nextContext.theme, nextThemeId),
+          addThemeId(nextOverrides, nextThemeId),
+          nextContext.ROOT_THEME_API
+        )
+      }));
+    }
   }
 
   _assembleInlineStyles = ({ center, lowerCase, left, right, upperCase }) => {

--- a/source/components/Header.js
+++ b/source/components/Header.js
@@ -1,13 +1,13 @@
 // @flow
 import React, { Component } from 'react';
 import type { ComponentType, Element } from 'react';
-import { pickBy, isEmpty, isEqual } from 'lodash';
+import { pickBy, isEmpty } from 'lodash';
 
 // components
 import { withTheme } from './HOC/withTheme';
 
 // utility functions
-import { composeTheme, addThemeId } from '../utils/themes';
+import { composeTheme, addThemeId, didThemePropsChange } from '../utils/themes';
 
 // constants
 import { IDENTIFIERS } from '../themes/API';
@@ -65,28 +65,7 @@ class HeaderBase extends Component <Props, State> {
   }
 
   componentWillReceiveProps(nextProps: Props) {
-    const { context, themeId, theme, themeOverrides } = this.props;
-    const {
-      context: nextContext,
-      themeId: nextThemeId,
-      theme: nextTheme,
-      themeOverrides: nextOverrides
-    } = nextProps;
-
-    if (
-      !isEqual(context, nextContext) ||
-      !isEqual(themeId, nextThemeId) ||
-      !isEqual(theme, nextTheme) ||
-      !isEqual(themeOverrides, nextOverrides)
-    ) {
-      this.setState(() => ({
-        composedTheme: composeTheme(
-          addThemeId(nextTheme || nextContext.theme, nextThemeId),
-          addThemeId(nextOverrides, nextThemeId),
-          nextContext.ROOT_THEME_API
-        )
-      }));
-    }
+    didThemePropsChange(this.props, nextProps, this.setState.bind(this));
   }
 
   _assembleInlineStyles = ({ center, lowerCase, left, right, upperCase }) => {

--- a/source/components/InfiniteScroll.js
+++ b/source/components/InfiniteScroll.js
@@ -3,6 +3,7 @@ import React, { Component } from 'react';
 import type { ComponentType, Node } from 'react';
 // $FlowFixMe
 import createRef from 'create-react-ref/lib/createRef';
+import { isEqual } from 'lodash';
 
 import type { ReactElementRef } from '../utils/types.js';
 
@@ -80,6 +81,31 @@ class InfiniteScrollBase extends Component<Props, State> {
     const { scrollContainer } = this;
     if (!scrollContainer.current) return;
     scrollContainer.current.addEventListener('scroll', this._handleScroll);
+  }
+
+  componentWillReceiveProps(nextProps: Props) {
+    const { context, themeId, theme, themeOverrides } = this.props;
+    const {
+      context: nextContext,
+      themeId: nextThemeId,
+      theme: nextTheme,
+      themeOverrides: nextOverrides
+    } = nextProps;
+
+    if (
+      !isEqual(context, nextContext) ||
+      !isEqual(themeId, nextThemeId) ||
+      !isEqual(theme, nextTheme) ||
+      !isEqual(themeOverrides, nextOverrides)
+    ) {
+      this.setState(() => ({
+        composedTheme: composeTheme(
+          addThemeId(nextTheme || nextContext.theme, nextThemeId),
+          addThemeId(nextOverrides, nextThemeId),
+          nextContext.ROOT_THEME_API
+        )
+      }));
+    }
   }
 
   // calls user's fetchData function from props

--- a/source/components/InfiniteScroll.js
+++ b/source/components/InfiniteScroll.js
@@ -3,7 +3,6 @@ import React, { Component } from 'react';
 import type { ComponentType, Node } from 'react';
 // $FlowFixMe
 import createRef from 'create-react-ref/lib/createRef';
-import { isEqual } from 'lodash';
 
 import type { ReactElementRef } from '../utils/types.js';
 
@@ -11,7 +10,7 @@ import type { ReactElementRef } from '../utils/types.js';
 import { withTheme } from './HOC/withTheme';
 
 // utilities
-import { composeTheme, addThemeId } from '../utils/themes';
+import { composeTheme, addThemeId, didThemePropsChange } from '../utils/themes';
 
 // constants
 import { IDENTIFIERS } from '../themes/API';
@@ -84,28 +83,7 @@ class InfiniteScrollBase extends Component<Props, State> {
   }
 
   componentWillReceiveProps(nextProps: Props) {
-    const { context, themeId, theme, themeOverrides } = this.props;
-    const {
-      context: nextContext,
-      themeId: nextThemeId,
-      theme: nextTheme,
-      themeOverrides: nextOverrides
-    } = nextProps;
-
-    if (
-      !isEqual(context, nextContext) ||
-      !isEqual(themeId, nextThemeId) ||
-      !isEqual(theme, nextTheme) ||
-      !isEqual(themeOverrides, nextOverrides)
-    ) {
-      this.setState(() => ({
-        composedTheme: composeTheme(
-          addThemeId(nextTheme || nextContext.theme, nextThemeId),
-          addThemeId(nextOverrides, nextThemeId),
-          nextContext.ROOT_THEME_API
-        )
-      }));
-    }
+    didThemePropsChange(this.props, nextProps, this.setState.bind(this));
   }
 
   // calls user's fetchData function from props

--- a/source/components/Input.js
+++ b/source/components/Input.js
@@ -5,7 +5,7 @@ import type { ComponentType, Element, SyntheticInputEvent } from 'react';
 
 // external libraries
 import createRef from 'create-react-ref/lib/createRef';
-import { isString, flow } from 'lodash';
+import { isString, flow, isEqual } from 'lodash';
 
 // internal components
 import { withTheme } from './HOC/withTheme';
@@ -81,6 +81,31 @@ class InputBase extends Component<Props, State> {
 
   componentDidMount() {
     if (this.props.autoFocus) this.focus();
+  }
+
+  componentWillReceiveProps(nextProps: Props) {
+    const { context, themeId, theme, themeOverrides } = this.props;
+    const {
+      context: nextContext,
+      themeId: nextThemeId,
+      theme: nextTheme,
+      themeOverrides: nextOverrides
+    } = nextProps;
+
+    if (
+      !isEqual(context, nextContext) ||
+      !isEqual(themeId, nextThemeId) ||
+      !isEqual(theme, nextTheme) ||
+      !isEqual(themeOverrides, nextOverrides)
+    ) {
+      this.setState(() => ({
+        composedTheme: composeTheme(
+          addThemeId(nextTheme || nextContext.theme, nextThemeId),
+          addThemeId(nextOverrides, nextThemeId),
+          nextContext.ROOT_THEME_API
+        )
+      }));
+    }
   }
 
   onChange = (event: SyntheticInputEvent<Element<'input'>>) => {

--- a/source/components/Input.js
+++ b/source/components/Input.js
@@ -5,13 +5,13 @@ import type { ComponentType, Element, SyntheticInputEvent } from 'react';
 
 // external libraries
 import createRef from 'create-react-ref/lib/createRef';
-import { isString, flow, isEqual } from 'lodash';
+import { isString, flow } from 'lodash';
 
 // internal components
 import { withTheme } from './HOC/withTheme';
 
 // internal utility functions
-import { composeTheme, addThemeId } from '../utils/themes';
+import { composeTheme, addThemeId, didThemePropsChange } from '../utils/themes';
 
 // import constants
 import { IDENTIFIERS } from '../themes/API';
@@ -84,28 +84,7 @@ class InputBase extends Component<Props, State> {
   }
 
   componentWillReceiveProps(nextProps: Props) {
-    const { context, themeId, theme, themeOverrides } = this.props;
-    const {
-      context: nextContext,
-      themeId: nextThemeId,
-      theme: nextTheme,
-      themeOverrides: nextOverrides
-    } = nextProps;
-
-    if (
-      !isEqual(context, nextContext) ||
-      !isEqual(themeId, nextThemeId) ||
-      !isEqual(theme, nextTheme) ||
-      !isEqual(themeOverrides, nextOverrides)
-    ) {
-      this.setState(() => ({
-        composedTheme: composeTheme(
-          addThemeId(nextTheme || nextContext.theme, nextThemeId),
-          addThemeId(nextOverrides, nextThemeId),
-          nextContext.ROOT_THEME_API
-        )
-      }));
-    }
+    didThemePropsChange(this.props, nextProps, this.setState.bind(this));
   }
 
   onChange = (event: SyntheticInputEvent<Element<'input'>>) => {

--- a/source/components/LoadingSpinner.js
+++ b/source/components/LoadingSpinner.js
@@ -1,13 +1,12 @@
 // @flow
 import React, { Component } from 'react';
 import type { ComponentType } from 'react';
-import { isEqual } from 'lodash';
 
 // internal components
 import { withTheme } from './HOC/withTheme';
 
 // internal utility functions
-import { composeTheme, addThemeId } from '../utils/themes';
+import { composeTheme, addThemeId, didThemePropsChange } from '../utils/themes';
 
 // import constants
 import { IDENTIFIERS } from '../themes/API';
@@ -54,28 +53,7 @@ class LoadingSpinnerBase extends Component<Props, State> {
   }
 
   componentWillReceiveProps(nextProps: Props) {
-    const { context, themeId, theme, themeOverrides } = this.props;
-    const {
-      context: nextContext,
-      themeId: nextThemeId,
-      theme: nextTheme,
-      themeOverrides: nextOverrides
-    } = nextProps;
-
-    if (
-      !isEqual(context, nextContext) ||
-      !isEqual(themeId, nextThemeId) ||
-      !isEqual(theme, nextTheme) ||
-      !isEqual(themeOverrides, nextOverrides)
-    ) {
-      this.setState(() => ({
-        composedTheme: composeTheme(
-          addThemeId(nextTheme || nextContext.theme, nextThemeId),
-          addThemeId(nextOverrides, nextThemeId),
-          nextContext.ROOT_THEME_API
-        )
-      }));
-    }
+    didThemePropsChange(this.props, nextProps, this.setState.bind(this));
   }
 
   render() {

--- a/source/components/LoadingSpinner.js
+++ b/source/components/LoadingSpinner.js
@@ -1,6 +1,7 @@
 // @flow
 import React, { Component } from 'react';
 import type { ComponentType } from 'react';
+import { isEqual } from 'lodash';
 
 // internal components
 import { withTheme } from './HOC/withTheme';
@@ -50,6 +51,31 @@ class LoadingSpinnerBase extends Component<Props, State> {
         context.ROOT_THEME_API
       )
     };
+  }
+
+  componentWillReceiveProps(nextProps: Props) {
+    const { context, themeId, theme, themeOverrides } = this.props;
+    const {
+      context: nextContext,
+      themeId: nextThemeId,
+      theme: nextTheme,
+      themeOverrides: nextOverrides
+    } = nextProps;
+
+    if (
+      !isEqual(context, nextContext) ||
+      !isEqual(themeId, nextThemeId) ||
+      !isEqual(theme, nextTheme) ||
+      !isEqual(themeOverrides, nextOverrides)
+    ) {
+      this.setState(() => ({
+        composedTheme: composeTheme(
+          addThemeId(nextTheme || nextContext.theme, nextThemeId),
+          addThemeId(nextOverrides, nextThemeId),
+          nextContext.ROOT_THEME_API
+        )
+      }));
+    }
   }
 
   render() {

--- a/source/components/Modal.js
+++ b/source/components/Modal.js
@@ -1,13 +1,12 @@
 // @flow
 import React, { Component } from 'react';
 import type { ComponentType, Element } from 'react';
-import { isEqual } from 'lodash';
 
 // internal components
 import { withTheme } from './HOC/withTheme';
 
 // internal utility functions
-import { composeTheme, addThemeId } from '../utils/themes';
+import { composeTheme, addThemeId, didThemePropsChange } from '../utils/themes';
 
 // import constants
 import { IDENTIFIERS } from '../themes/API';
@@ -56,28 +55,7 @@ class ModalBase extends Component<Props, State> {
   }
 
   componentWillReceiveProps(nextProps: Props) {
-    const { context, themeId, theme, themeOverrides } = this.props;
-    const {
-      context: nextContext,
-      themeId: nextThemeId,
-      theme: nextTheme,
-      themeOverrides: nextOverrides
-    } = nextProps;
-
-    if (
-      !isEqual(context, nextContext) ||
-      !isEqual(themeId, nextThemeId) ||
-      !isEqual(theme, nextTheme) ||
-      !isEqual(themeOverrides, nextOverrides)
-    ) {
-      this.setState(() => ({
-        composedTheme: composeTheme(
-          addThemeId(nextTheme || nextContext.theme, nextThemeId),
-          addThemeId(nextOverrides, nextThemeId),
-          nextContext.ROOT_THEME_API
-        )
-      }));
-    }
+    didThemePropsChange(this.props, nextProps, this.setState.bind(this));
   }
 
   render() {

--- a/source/components/Modal.js
+++ b/source/components/Modal.js
@@ -1,6 +1,7 @@
 // @flow
 import React, { Component } from 'react';
 import type { ComponentType, Element } from 'react';
+import { isEqual } from 'lodash';
 
 // internal components
 import { withTheme } from './HOC/withTheme';
@@ -52,6 +53,31 @@ class ModalBase extends Component<Props, State> {
         context.ROOT_THEME_API
       )
     };
+  }
+
+  componentWillReceiveProps(nextProps: Props) {
+    const { context, themeId, theme, themeOverrides } = this.props;
+    const {
+      context: nextContext,
+      themeId: nextThemeId,
+      theme: nextTheme,
+      themeOverrides: nextOverrides
+    } = nextProps;
+
+    if (
+      !isEqual(context, nextContext) ||
+      !isEqual(themeId, nextThemeId) ||
+      !isEqual(theme, nextTheme) ||
+      !isEqual(themeOverrides, nextOverrides)
+    ) {
+      this.setState(() => ({
+        composedTheme: composeTheme(
+          addThemeId(nextTheme || nextContext.theme, nextThemeId),
+          addThemeId(nextOverrides, nextThemeId),
+          nextContext.ROOT_THEME_API
+        )
+      }));
+    }
   }
 
   render() {

--- a/source/components/NumericInput.js
+++ b/source/components/NumericInput.js
@@ -5,13 +5,13 @@ import type { ComponentType, SyntheticInputEvent, Element } from 'react';
 
 // external libraries
 import createRef from 'create-react-ref/lib/createRef';
-import { flow, isEqual } from 'lodash';
+import { flow } from 'lodash';
 
 // internal components
 import { withTheme } from './HOC/withTheme';
 
 // internal utility functions
-import { composeTheme, addThemeId } from '../utils/themes';
+import { composeTheme, addThemeId, didThemePropsChange } from '../utils/themes';
 
 // import constants
 import { IDENTIFIERS } from '../themes/API';
@@ -107,28 +107,7 @@ class NumericInputBase extends Component<Props, State> {
   }
 
   componentWillReceiveProps(nextProps: Props) {
-    const { context, themeId, theme, themeOverrides } = this.props;
-    const {
-      context: nextContext,
-      themeId: nextThemeId,
-      theme: nextTheme,
-      themeOverrides: nextOverrides
-    } = nextProps;
-
-    if (
-      !isEqual(context, nextContext) ||
-      !isEqual(themeId, nextThemeId) ||
-      !isEqual(theme, nextTheme) ||
-      !isEqual(themeOverrides, nextOverrides)
-    ) {
-      this.setState(() => ({
-        composedTheme: composeTheme(
-          addThemeId(nextTheme || nextContext.theme, nextThemeId),
-          addThemeId(nextOverrides, nextThemeId),
-          nextContext.ROOT_THEME_API
-        )
-      }));
-    }
+    didThemePropsChange(this.props, nextProps, this.setState.bind(this));
   }
 
   componentDidUpdate(prevProps: Props, prevState: State) {

--- a/source/components/NumericInput.js
+++ b/source/components/NumericInput.js
@@ -5,7 +5,7 @@ import type { ComponentType, SyntheticInputEvent, Element } from 'react';
 
 // external libraries
 import createRef from 'create-react-ref/lib/createRef';
-import { flow } from 'lodash';
+import { flow, isEqual } from 'lodash';
 
 // internal components
 import { withTheme } from './HOC/withTheme';
@@ -103,6 +103,31 @@ class NumericInputBase extends Component<Props, State> {
     // Set last input caret position on updates
     if (inputElement && inputElement.current) {
       this.setState({ caretPosition: inputElement.current.selectionStart });
+    }
+  }
+
+  componentWillReceiveProps(nextProps: Props) {
+    const { context, themeId, theme, themeOverrides } = this.props;
+    const {
+      context: nextContext,
+      themeId: nextThemeId,
+      theme: nextTheme,
+      themeOverrides: nextOverrides
+    } = nextProps;
+
+    if (
+      !isEqual(context, nextContext) ||
+      !isEqual(themeId, nextThemeId) ||
+      !isEqual(theme, nextTheme) ||
+      !isEqual(themeOverrides, nextOverrides)
+    ) {
+      this.setState(() => ({
+        composedTheme: composeTheme(
+          addThemeId(nextTheme || nextContext.theme, nextThemeId),
+          addThemeId(nextOverrides, nextThemeId),
+          nextContext.ROOT_THEME_API
+        )
+      }));
     }
   }
 

--- a/source/components/Options.js
+++ b/source/components/Options.js
@@ -11,6 +11,7 @@ import type {
   Element,
   Ref
 } from 'react';
+import { isEqual } from 'lodash';
 
 // internal components
 import { withTheme } from './HOC/withTheme';
@@ -91,10 +92,32 @@ class OptionsBase extends Component<Props, State> {
   }
 
   componentWillReceiveProps(nextProps: Props) {
+    const { context, themeId, theme, themeOverrides } = this.props;
+    const {
+      context: nextContext,
+      themeId: nextThemeId,
+      theme: nextTheme,
+      themeOverrides: nextOverrides
+    } = nextProps;
+
     if (!this.props.isOpen && nextProps.isOpen) {
       document.addEventListener('keydown', this._handleKeyDown, false);
     } else if (this.props.isOpen && !nextProps.isOpen) {
       document.removeEventListener('keydown', this._handleKeyDown, false);
+    }
+    if (
+      !isEqual(context, nextContext) ||
+      !isEqual(themeId, nextThemeId) ||
+      !isEqual(theme, nextTheme) ||
+      !isEqual(themeOverrides, nextOverrides)
+    ) {
+      this.setState(() => ({
+        composedTheme: composeTheme(
+          addThemeId(nextTheme || nextContext.theme, nextThemeId),
+          addThemeId(nextOverrides, nextThemeId),
+          nextContext.ROOT_THEME_API
+        )
+      }));
     }
   }
 

--- a/source/components/Options.js
+++ b/source/components/Options.js
@@ -11,13 +11,12 @@ import type {
   Element,
   Ref
 } from 'react';
-import { isEqual } from 'lodash';
 
 // internal components
 import { withTheme } from './HOC/withTheme';
 
 // internal utility functions
-import { composeTheme, addThemeId } from '../utils/themes';
+import { composeTheme, addThemeId, didThemePropsChange } from '../utils/themes';
 import { composeFunctions } from '../utils/props';
 
 // import constants
@@ -92,33 +91,12 @@ class OptionsBase extends Component<Props, State> {
   }
 
   componentWillReceiveProps(nextProps: Props) {
-    const { context, themeId, theme, themeOverrides } = this.props;
-    const {
-      context: nextContext,
-      themeId: nextThemeId,
-      theme: nextTheme,
-      themeOverrides: nextOverrides
-    } = nextProps;
-
     if (!this.props.isOpen && nextProps.isOpen) {
       document.addEventListener('keydown', this._handleKeyDown, false);
     } else if (this.props.isOpen && !nextProps.isOpen) {
       document.removeEventListener('keydown', this._handleKeyDown, false);
     }
-    if (
-      !isEqual(context, nextContext) ||
-      !isEqual(themeId, nextThemeId) ||
-      !isEqual(theme, nextTheme) ||
-      !isEqual(themeOverrides, nextOverrides)
-    ) {
-      this.setState(() => ({
-        composedTheme: composeTheme(
-          addThemeId(nextTheme || nextContext.theme, nextThemeId),
-          addThemeId(nextOverrides, nextThemeId),
-          nextContext.ROOT_THEME_API
-        )
-      }));
-    }
+    didThemePropsChange(this.props, nextProps, this.setState.bind(this));
   }
 
   componentWillUnmount() {

--- a/source/components/ProgressBar.js
+++ b/source/components/ProgressBar.js
@@ -1,6 +1,7 @@
 // @flow
 import React, { Component } from 'react';
 import type { ComponentType } from 'react';
+import { isEqual } from 'lodash';
 
 // internal components
 import { withTheme } from './HOC/withTheme';
@@ -49,6 +50,31 @@ class ProgressBarBase extends Component<Props, State> {
         context.ROOT_THEME_API
       )
     };
+  }
+
+  componentWillReceiveProps(nextProps: Props) {
+    const { context, themeId, theme, themeOverrides } = this.props;
+    const {
+      context: nextContext,
+      themeId: nextThemeId,
+      theme: nextTheme,
+      themeOverrides: nextOverrides
+    } = nextProps;
+
+    if (
+      !isEqual(context, nextContext) ||
+      !isEqual(themeId, nextThemeId) ||
+      !isEqual(theme, nextTheme) ||
+      !isEqual(themeOverrides, nextOverrides)
+    ) {
+      this.setState(() => ({
+        composedTheme: composeTheme(
+          addThemeId(nextTheme || nextContext.theme, nextThemeId),
+          addThemeId(nextOverrides, nextThemeId),
+          nextContext.ROOT_THEME_API
+        )
+      }));
+    }
   }
 
   render() {

--- a/source/components/ProgressBar.js
+++ b/source/components/ProgressBar.js
@@ -1,13 +1,12 @@
 // @flow
 import React, { Component } from 'react';
 import type { ComponentType } from 'react';
-import { isEqual } from 'lodash';
 
 // internal components
 import { withTheme } from './HOC/withTheme';
 
 // internal utility functions
-import { composeTheme, addThemeId } from '../utils/themes';
+import { composeTheme, addThemeId, didThemePropsChange } from '../utils/themes';
 
 // import constants
 import { IDENTIFIERS } from '../themes/API';
@@ -53,28 +52,7 @@ class ProgressBarBase extends Component<Props, State> {
   }
 
   componentWillReceiveProps(nextProps: Props) {
-    const { context, themeId, theme, themeOverrides } = this.props;
-    const {
-      context: nextContext,
-      themeId: nextThemeId,
-      theme: nextTheme,
-      themeOverrides: nextOverrides
-    } = nextProps;
-
-    if (
-      !isEqual(context, nextContext) ||
-      !isEqual(themeId, nextThemeId) ||
-      !isEqual(theme, nextTheme) ||
-      !isEqual(themeOverrides, nextOverrides)
-    ) {
-      this.setState(() => ({
-        composedTheme: composeTheme(
-          addThemeId(nextTheme || nextContext.theme, nextThemeId),
-          addThemeId(nextOverrides, nextThemeId),
-          nextContext.ROOT_THEME_API
-        )
-      }));
-    }
+    didThemePropsChange(this.props, nextProps, this.setState.bind(this));
   }
 
   render() {

--- a/source/components/Radio.js
+++ b/source/components/Radio.js
@@ -1,13 +1,12 @@
 // @flow
 import React, { Component } from 'react';
 import type { ComponentType, Element } from 'react';
-import { isEqual } from 'lodash';
 
 // internal components
 import { withTheme } from './HOC/withTheme';
 
 // internal utility functions
-import { composeTheme, addThemeId } from '../utils/themes';
+import { composeTheme, addThemeId, didThemePropsChange } from '../utils/themes';
 
 // import constants
 import { IDENTIFIERS } from '../themes/API';
@@ -57,28 +56,7 @@ class RadioBase extends Component<Props, State> {
   }
 
   componentWillReceiveProps(nextProps: Props) {
-    const { context, themeId, theme, themeOverrides } = this.props;
-    const {
-      context: nextContext,
-      themeId: nextThemeId,
-      theme: nextTheme,
-      themeOverrides: nextOverrides
-    } = nextProps;
-
-    if (
-      !isEqual(context, nextContext) ||
-      !isEqual(themeId, nextThemeId) ||
-      !isEqual(theme, nextTheme) ||
-      !isEqual(themeOverrides, nextOverrides)
-    ) {
-      this.setState(() => ({
-        composedTheme: composeTheme(
-          addThemeId(nextTheme || nextContext.theme, nextThemeId),
-          addThemeId(nextOverrides, nextThemeId),
-          nextContext.ROOT_THEME_API
-        )
-      }));
-    }
+    didThemePropsChange(this.props, nextProps, this.setState.bind(this));
   }
 
   render() {

--- a/source/components/Radio.js
+++ b/source/components/Radio.js
@@ -1,6 +1,7 @@
 // @flow
 import React, { Component } from 'react';
 import type { ComponentType, Element } from 'react';
+import { isEqual } from 'lodash';
 
 // internal components
 import { withTheme } from './HOC/withTheme';
@@ -53,6 +54,31 @@ class RadioBase extends Component<Props, State> {
         context.ROOT_THEME_API
       )
     };
+  }
+
+  componentWillReceiveProps(nextProps: Props) {
+    const { context, themeId, theme, themeOverrides } = this.props;
+    const {
+      context: nextContext,
+      themeId: nextThemeId,
+      theme: nextTheme,
+      themeOverrides: nextOverrides
+    } = nextProps;
+
+    if (
+      !isEqual(context, nextContext) ||
+      !isEqual(themeId, nextThemeId) ||
+      !isEqual(theme, nextTheme) ||
+      !isEqual(themeOverrides, nextOverrides)
+    ) {
+      this.setState(() => ({
+        composedTheme: composeTheme(
+          addThemeId(nextTheme || nextContext.theme, nextThemeId),
+          addThemeId(nextOverrides, nextThemeId),
+          nextContext.ROOT_THEME_API
+        )
+      }));
+    }
   }
 
   render() {

--- a/source/components/Select.js
+++ b/source/components/Select.js
@@ -2,14 +2,13 @@
 import React, { Component } from 'react';
 import type { ComponentType, Element } from 'react';
 import createRef from 'create-react-ref/lib/createRef';
-import { isEqual } from 'lodash';
 
 // internal components
 import { GlobalListeners } from './HOC/GlobalListeners';
 import { withTheme } from './HOC/withTheme';
 
 // internal utility functions
-import { composeTheme, addThemeId } from '../utils/themes';
+import { composeTheme, addThemeId, didThemePropsChange } from '../utils/themes';
 
 // import constants
 import { IDENTIFIERS } from '../themes/API';
@@ -90,28 +89,7 @@ class SelectBase extends Component<Props, State> {
   }
 
   componentWillReceiveProps(nextProps: Props) {
-    const { context, themeId, theme, themeOverrides } = this.props;
-    const {
-      context: nextContext,
-      themeId: nextThemeId,
-      theme: nextTheme,
-      themeOverrides: nextOverrides
-    } = nextProps;
-
-    if (
-      !isEqual(context, nextContext) ||
-      !isEqual(themeId, nextThemeId) ||
-      !isEqual(theme, nextTheme) ||
-      !isEqual(themeOverrides, nextOverrides)
-    ) {
-      this.setState(() => ({
-        composedTheme: composeTheme(
-          addThemeId(nextTheme || nextContext.theme, nextThemeId),
-          addThemeId(nextOverrides, nextThemeId),
-          nextContext.ROOT_THEME_API
-        )
-      }));
-    }
+    didThemePropsChange(this.props, nextProps, this.setState.bind(this));
   }
 
   // ========= PUBLIC SKIN API =========

--- a/source/components/Select.js
+++ b/source/components/Select.js
@@ -2,6 +2,7 @@
 import React, { Component } from 'react';
 import type { ComponentType, Element } from 'react';
 import createRef from 'create-react-ref/lib/createRef';
+import { isEqual } from 'lodash';
 
 // internal components
 import { GlobalListeners } from './HOC/GlobalListeners';
@@ -85,6 +86,31 @@ class SelectBase extends Component<Props, State> {
     // check for autoFocus of input element
     if (this.props.autoFocus) {
       return this.focus();
+    }
+  }
+
+  componentWillReceiveProps(nextProps: Props) {
+    const { context, themeId, theme, themeOverrides } = this.props;
+    const {
+      context: nextContext,
+      themeId: nextThemeId,
+      theme: nextTheme,
+      themeOverrides: nextOverrides
+    } = nextProps;
+
+    if (
+      !isEqual(context, nextContext) ||
+      !isEqual(themeId, nextThemeId) ||
+      !isEqual(theme, nextTheme) ||
+      !isEqual(themeOverrides, nextOverrides)
+    ) {
+      this.setState(() => ({
+        composedTheme: composeTheme(
+          addThemeId(nextTheme || nextContext.theme, nextThemeId),
+          addThemeId(nextOverrides, nextThemeId),
+          nextContext.ROOT_THEME_API
+        )
+      }));
     }
   }
 

--- a/source/components/TextArea.js
+++ b/source/components/TextArea.js
@@ -4,7 +4,7 @@ import type { ComponentType, Node, Element } from 'react';
 
 // external libraries
 import createRef from 'create-react-ref/lib/createRef';
-import { isString, flow } from 'lodash';
+import { isString, flow, isEqual } from 'lodash';
 
 // internal components
 import { withTheme } from './HOC/withTheme';
@@ -86,11 +86,33 @@ class TextAreaBase extends Component<Props, State> {
     if (autoFocus) { this.focus(); }
   }
 
-  componentWillReceiveProps(nextProps) {
+  componentWillReceiveProps(nextProps: Props) {
+    const { context, themeId, theme, themeOverrides } = this.props;
+    const {
+      context: nextContext,
+      themeId: nextThemeId,
+      theme: nextTheme,
+      themeOverrides: nextOverrides
+    } = nextProps;
+
     if (!this.props.autoResize && nextProps.autoResize) {
       window.addEventListener('resize', this._handleAutoresize);
     } else if (this.props.autoResize && !nextProps.autoResize) {
       window.removeEventListener('resize', this._handleAutoresize);
+    }
+    if (
+      !isEqual(context, nextContext) ||
+      !isEqual(themeId, nextThemeId) ||
+      !isEqual(theme, nextTheme) ||
+      !isEqual(themeOverrides, nextOverrides)
+    ) {
+      this.setState(() => ({
+        composedTheme: composeTheme(
+          addThemeId(nextTheme || nextContext.theme, nextThemeId),
+          addThemeId(nextOverrides, nextThemeId),
+          nextContext.ROOT_THEME_API
+        )
+      }));
     }
   }
 

--- a/source/components/TextArea.js
+++ b/source/components/TextArea.js
@@ -4,13 +4,13 @@ import type { ComponentType, Node, Element } from 'react';
 
 // external libraries
 import createRef from 'create-react-ref/lib/createRef';
-import { isString, flow, isEqual } from 'lodash';
+import { isString, flow } from 'lodash';
 
 // internal components
 import { withTheme } from './HOC/withTheme';
 
 // internal utility functions
-import { composeTheme, addThemeId } from '../utils/themes';
+import { composeTheme, addThemeId, didThemePropsChange } from '../utils/themes';
 
 // import constants
 import { IDENTIFIERS } from '../themes/API';
@@ -87,33 +87,13 @@ class TextAreaBase extends Component<Props, State> {
   }
 
   componentWillReceiveProps(nextProps: Props) {
-    const { context, themeId, theme, themeOverrides } = this.props;
-    const {
-      context: nextContext,
-      themeId: nextThemeId,
-      theme: nextTheme,
-      themeOverrides: nextOverrides
-    } = nextProps;
-
     if (!this.props.autoResize && nextProps.autoResize) {
       window.addEventListener('resize', this._handleAutoresize);
     } else if (this.props.autoResize && !nextProps.autoResize) {
       window.removeEventListener('resize', this._handleAutoresize);
     }
-    if (
-      !isEqual(context, nextContext) ||
-      !isEqual(themeId, nextThemeId) ||
-      !isEqual(theme, nextTheme) ||
-      !isEqual(themeOverrides, nextOverrides)
-    ) {
-      this.setState(() => ({
-        composedTheme: composeTheme(
-          addThemeId(nextTheme || nextContext.theme, nextThemeId),
-          addThemeId(nextOverrides, nextThemeId),
-          nextContext.ROOT_THEME_API
-        )
-      }));
-    }
+
+    didThemePropsChange(this.props, nextProps, this.setState.bind(this));
   }
 
   componentDidUpdate() {

--- a/source/components/ThemeProvider.js
+++ b/source/components/ThemeProvider.js
@@ -3,7 +3,7 @@ import React, { Component } from 'react';
 import type { Node } from 'react';
 
 // external libraries
-import _ from 'lodash';
+import { isEmpty, cloneDeep } from 'lodash';
 
 // contains default theme and context provider
 import { ThemeContext } from './HOC/ThemeContext';
@@ -13,7 +13,8 @@ import { ThemeContext } from './HOC/ThemeContext';
 import { ROOT_THEME_API } from '../themes/API';
 
 // internal utility functions
-import { composeTheme } from '../utils/themes';
+import { appendToProperty } from '../utils/themes';
+import { hasProperty } from '../utils/props';
 
 type Props = {
   children: Node,
@@ -36,7 +37,7 @@ export class ThemeProvider extends Component<Props, State> {
     const { theme, themeOverrides } = props;
 
     this.state = {
-      theme: this.composeLibraryTheme(theme, themeOverrides)
+      theme: this._composeLibraryTheme(theme, themeOverrides)
     };
   }
 
@@ -51,28 +52,27 @@ export class ThemeProvider extends Component<Props, State> {
   //   formField: { root: '', label: '', error: '' },
   //   ... and so on, creating a complete theme for the library,
   //  }
-  composeLibraryTheme = (theme: Object, themeOverrides: Object) => {
+  _composeLibraryTheme = (theme: Object, themeOverrides: Object) => {
     // if themeOverrides is empty, no need for composition
-    if (_.isEmpty(themeOverrides)) {
-      return theme;
-    }
-    // obj to be returned
+    if (isEmpty(themeOverrides)) { return theme; }
+
+    // final object to be returned
     const composedTheme = {};
 
     for (const componentName in ROOT_THEME_API) {
       // check if ROOT_THEME_API contains the key of componentName
-      if ({}.hasOwnProperty.call(ROOT_THEME_API, componentName)) {
+      if (hasProperty(ROOT_THEME_API, componentName)) {
 
         // check if theme contains a key of componentName
-        if ({}.hasOwnProperty.call(theme, componentName)) {
+        if (hasProperty(theme, componentName)) {
           // add componentName as a key to final return obj
           composedTheme[componentName] = theme[componentName];
         }
 
         // also check if themeOverrides contains the key componentName
-        if ({}.hasOwnProperty.call(themeOverrides, componentName)) {
+        if (hasProperty(themeOverrides, componentName)) {
           // compose theme styles with user's themeOverrides
-          composedTheme[componentName] = composeTheme(
+          composedTheme[componentName] = this._applyThemeOverrides(
             theme[componentName],
             themeOverrides[componentName],
             ROOT_THEME_API[componentName]
@@ -80,9 +80,33 @@ export class ThemeProvider extends Component<Props, State> {
         }
       }
     }
-
     return composedTheme;
   };
+
+  _applyThemeOverrides = (
+    componentTheme: Object,
+    componentThemeOverrides: Object,
+    componentThemeAPI: Object
+  ) => {
+    // Return componentTheme if there are no overrides provided
+    if (isEmpty(componentThemeOverrides)) { return componentTheme; }
+
+    // final composed theme obj to be returned at end
+    const composedComponentTheme = cloneDeep(componentThemeAPI);
+
+    for (const className in componentThemeAPI) {
+      if (hasProperty(componentThemeAPI, className)) {
+        if (hasProperty(componentTheme, className)) {
+          appendToProperty(composedComponentTheme, className, componentTheme[className]);
+        }
+
+        if (hasProperty(componentThemeOverrides, className)) {
+          appendToProperty(composedComponentTheme, className, componentThemeOverrides[className]);
+        }
+      }
+    }
+    return composedComponentTheme;
+  }
 
   render() {
     const { theme } = this.state;

--- a/source/components/ThemeProvider.js
+++ b/source/components/ThemeProvider.js
@@ -3,7 +3,7 @@ import React, { Component } from 'react';
 import type { Node } from 'react';
 
 // external libraries
-import { isEmpty, cloneDeep } from 'lodash';
+import { isEmpty, isEqual, cloneDeep } from 'lodash';
 
 // contains default theme and context provider
 import { ThemeContext } from './HOC/ThemeContext';
@@ -39,6 +39,17 @@ export class ThemeProvider extends Component<Props, State> {
     this.state = {
       theme: this._composeLibraryTheme(theme, themeOverrides)
     };
+  }
+
+  componentWillReceiveProps(nextProps: Props) {
+    const { theme, themeOverrides } = this.props;
+    const { theme: nextTheme, themeOverrides: nextOverrides } = nextProps;
+
+    if (!isEqual(theme, nextTheme) || !isEqual(themeOverrides, nextOverrides)) {
+      this.setState(() => ({
+        theme: this._composeLibraryTheme(nextTheme, nextOverrides)
+      }));
+    }
   }
 
   // composeLibraryTheme returns a single obj containing theme definitions
@@ -111,6 +122,7 @@ export class ThemeProvider extends Component<Props, State> {
   render() {
     const { theme } = this.state;
     const providerState = { theme, ROOT_THEME_API };
+
     return (
       <ThemeContext.Provider value={providerState}>
         {this.props.children}

--- a/source/components/Tooltip.js
+++ b/source/components/Tooltip.js
@@ -1,13 +1,12 @@
 // @flow
 import React, { Component } from 'react';
 import type { ComponentType, Element } from 'react';
-import { isEqual } from 'lodash';
 
 // internal components
 import { withTheme } from './HOC/withTheme';
 
 // internal utility functions
-import { composeTheme, addThemeId } from '../utils/themes';
+import { composeTheme, addThemeId, didThemePropsChange } from '../utils/themes';
 
 // import constants
 import { IDENTIFIERS } from '../themes/API';
@@ -57,28 +56,7 @@ class TooltipBase extends Component<Props, State> {
   }
 
   componentWillReceiveProps(nextProps: Props) {
-    const { context, themeId, theme, themeOverrides } = this.props;
-    const {
-      context: nextContext,
-      themeId: nextThemeId,
-      theme: nextTheme,
-      themeOverrides: nextOverrides
-    } = nextProps;
-
-    if (
-      !isEqual(context, nextContext) ||
-      !isEqual(themeId, nextThemeId) ||
-      !isEqual(theme, nextTheme) ||
-      !isEqual(themeOverrides, nextOverrides)
-    ) {
-      this.setState(() => ({
-        composedTheme: composeTheme(
-          addThemeId(nextTheme || nextContext.theme, nextThemeId),
-          addThemeId(nextOverrides, nextThemeId),
-          nextContext.ROOT_THEME_API
-        )
-      }));
-    }
+    didThemePropsChange(this.props, nextProps, this.setState.bind(this));
   }
 
   render() {

--- a/source/components/Tooltip.js
+++ b/source/components/Tooltip.js
@@ -1,6 +1,7 @@
 // @flow
 import React, { Component } from 'react';
 import type { ComponentType, Element } from 'react';
+import { isEqual } from 'lodash';
 
 // internal components
 import { withTheme } from './HOC/withTheme';
@@ -53,6 +54,31 @@ class TooltipBase extends Component<Props, State> {
         context.ROOT_THEME_API
       )
     };
+  }
+
+  componentWillReceiveProps(nextProps: Props) {
+    const { context, themeId, theme, themeOverrides } = this.props;
+    const {
+      context: nextContext,
+      themeId: nextThemeId,
+      theme: nextTheme,
+      themeOverrides: nextOverrides
+    } = nextProps;
+
+    if (
+      !isEqual(context, nextContext) ||
+      !isEqual(themeId, nextThemeId) ||
+      !isEqual(theme, nextTheme) ||
+      !isEqual(themeOverrides, nextOverrides)
+    ) {
+      this.setState(() => ({
+        composedTheme: composeTheme(
+          addThemeId(nextTheme || nextContext.theme, nextThemeId),
+          addThemeId(nextOverrides, nextThemeId),
+          nextContext.ROOT_THEME_API
+        )
+      }));
+    }
   }
 
   render() {

--- a/source/components/layout/Flex.js
+++ b/source/components/layout/Flex.js
@@ -1,7 +1,7 @@
 // @flow
 import React, { Component } from 'react';
 import type { ChildrenArray } from 'react';
-import { pickBy } from 'lodash';
+import { pickBy, isEqual } from 'lodash';
 
 // components
 import { Base } from './Base';
@@ -55,6 +55,31 @@ class FlexBase extends Component<Props, State> {
         context.ROOT_THEME_API
       )
     };
+  }
+
+  componentWillReceiveProps(nextProps: Props) {
+    const { context, themeId, theme, themeOverrides } = this.props;
+    const {
+      context: nextContext,
+      themeId: nextThemeId,
+      theme: nextTheme,
+      themeOverrides: nextOverrides
+    } = nextProps;
+
+    if (
+      !isEqual(context, nextContext) ||
+      !isEqual(themeId, nextThemeId) ||
+      !isEqual(theme, nextTheme) ||
+      !isEqual(themeOverrides, nextOverrides)
+    ) {
+      this.setState(() => ({
+        composedTheme: composeTheme(
+          addThemeId(nextTheme || nextContext.theme, nextThemeId),
+          addThemeId(nextOverrides, nextThemeId),
+          nextContext.ROOT_THEME_API
+        )
+      }));
+    }
   }
 
   _getActiveClasses = ({ center, column, columnReverse, row, rowReverse }) => {

--- a/source/components/layout/Flex.js
+++ b/source/components/layout/Flex.js
@@ -1,14 +1,14 @@
 // @flow
 import React, { Component } from 'react';
 import type { ChildrenArray } from 'react';
-import { pickBy, isEqual } from 'lodash';
+import { pickBy } from 'lodash';
 
 // components
 import { Base } from './Base';
 import { withTheme } from '../HOC/withTheme';
 
 // utilities
-import { composeTheme, addThemeId } from '../../utils/themes';
+import { composeTheme, addThemeId, didThemePropsChange } from '../../utils/themes';
 
 // constants
 import { IDENTIFIERS } from '../../themes/API';
@@ -58,28 +58,7 @@ class FlexBase extends Component<Props, State> {
   }
 
   componentWillReceiveProps(nextProps: Props) {
-    const { context, themeId, theme, themeOverrides } = this.props;
-    const {
-      context: nextContext,
-      themeId: nextThemeId,
-      theme: nextTheme,
-      themeOverrides: nextOverrides
-    } = nextProps;
-
-    if (
-      !isEqual(context, nextContext) ||
-      !isEqual(themeId, nextThemeId) ||
-      !isEqual(theme, nextTheme) ||
-      !isEqual(themeOverrides, nextOverrides)
-    ) {
-      this.setState(() => ({
-        composedTheme: composeTheme(
-          addThemeId(nextTheme || nextContext.theme, nextThemeId),
-          addThemeId(nextOverrides, nextThemeId),
-          nextContext.ROOT_THEME_API
-        )
-      }));
-    }
+    didThemePropsChange(this.props, nextProps, this.setState.bind(this));
   }
 
   _getActiveClasses = ({ center, column, columnReverse, row, rowReverse }) => {

--- a/source/components/layout/Grid.js
+++ b/source/components/layout/Grid.js
@@ -1,7 +1,7 @@
 // @flow
 import React, { Component } from 'react';
 import type { ChildrenArray } from 'react';
-import { pickBy, isEmpty } from 'lodash';
+import { pickBy, isEmpty, isEqual } from 'lodash';
 
 // components
 import { Base } from './Base';
@@ -64,6 +64,31 @@ class GridBase extends Component<Props, State> {
         context.ROOT_THEME_API
       )
     };
+  }
+
+  componentWillReceiveProps(nextProps: Props) {
+    const { context, themeId, theme, themeOverrides } = this.props;
+    const {
+      context: nextContext,
+      themeId: nextThemeId,
+      theme: nextTheme,
+      themeOverrides: nextOverrides
+    } = nextProps;
+
+    if (
+      !isEqual(context, nextContext) ||
+      !isEqual(themeId, nextThemeId) ||
+      !isEqual(theme, nextTheme) ||
+      !isEqual(themeOverrides, nextOverrides)
+    ) {
+      this.setState(() => ({
+        composedTheme: composeTheme(
+          addThemeId(nextTheme || nextContext.theme, nextThemeId),
+          addThemeId(nextOverrides, nextThemeId),
+          nextContext.ROOT_THEME_API
+        )
+      }));
+    }
   }
 
   // creates obj passed Base component's inline styles (see render)

--- a/source/components/layout/Grid.js
+++ b/source/components/layout/Grid.js
@@ -1,7 +1,7 @@
 // @flow
 import React, { Component } from 'react';
 import type { ChildrenArray } from 'react';
-import { pickBy, isEmpty, isEqual } from 'lodash';
+import { pickBy, isEmpty } from 'lodash';
 
 // components
 import { Base } from './Base';
@@ -10,7 +10,7 @@ import { withTheme } from '../HOC/withTheme';
 // utilities
 import { numberToPx } from '../../utils/props';
 import { formatTemplateAreas } from '../../utils/layout';
-import { composeTheme, addThemeId } from '../../utils/themes';
+import { composeTheme, addThemeId, didThemePropsChange } from '../../utils/themes';
 
 // constants
 import { IDENTIFIERS } from '../../themes/API';
@@ -67,28 +67,7 @@ class GridBase extends Component<Props, State> {
   }
 
   componentWillReceiveProps(nextProps: Props) {
-    const { context, themeId, theme, themeOverrides } = this.props;
-    const {
-      context: nextContext,
-      themeId: nextThemeId,
-      theme: nextTheme,
-      themeOverrides: nextOverrides
-    } = nextProps;
-
-    if (
-      !isEqual(context, nextContext) ||
-      !isEqual(themeId, nextThemeId) ||
-      !isEqual(theme, nextTheme) ||
-      !isEqual(themeOverrides, nextOverrides)
-    ) {
-      this.setState(() => ({
-        composedTheme: composeTheme(
-          addThemeId(nextTheme || nextContext.theme, nextThemeId),
-          addThemeId(nextOverrides, nextThemeId),
-          nextContext.ROOT_THEME_API
-        )
-      }));
-    }
+    didThemePropsChange(this.props, nextProps, this.setState.bind(this));
   }
 
   // creates obj passed Base component's inline styles (see render)

--- a/source/components/layout/Gutter.js
+++ b/source/components/layout/Gutter.js
@@ -1,14 +1,13 @@
 // @flow
 import React, { Component } from 'react';
 import type { Element } from 'react';
-import { isEqual } from 'lodash';
 
 // components
 import { Base } from './Base';
 import { withTheme } from '../HOC/withTheme';
 
 // utility functions
-import { composeTheme, addThemeId } from '../../utils/themes';
+import { composeTheme, addThemeId, didThemePropsChange } from '../../utils/themes';
 import { numberToPx } from '../../utils/props';
 
 // constants
@@ -53,28 +52,7 @@ class GutterBase extends Component<Props, State> {
   }
 
   componentWillReceiveProps(nextProps: Props) {
-    const { context, themeId, theme, themeOverrides } = this.props;
-    const {
-      context: nextContext,
-      themeId: nextThemeId,
-      theme: nextTheme,
-      themeOverrides: nextOverrides
-    } = nextProps;
-
-    if (
-      !isEqual(context, nextContext) ||
-      !isEqual(themeId, nextThemeId) ||
-      !isEqual(theme, nextTheme) ||
-      !isEqual(themeOverrides, nextOverrides)
-    ) {
-      this.setState(() => ({
-        composedTheme: composeTheme(
-          addThemeId(nextTheme || nextContext.theme, nextThemeId),
-          addThemeId(nextOverrides, nextThemeId),
-          nextContext.ROOT_THEME_API
-        )
-      }));
-    }
+    didThemePropsChange(this.props, nextProps, this.setState.bind(this));
   }
 
   render() {

--- a/source/components/layout/Gutter.js
+++ b/source/components/layout/Gutter.js
@@ -1,6 +1,7 @@
 // @flow
 import React, { Component } from 'react';
 import type { Element } from 'react';
+import { isEqual } from 'lodash';
 
 // components
 import { Base } from './Base';
@@ -49,6 +50,31 @@ class GutterBase extends Component<Props, State> {
         context.ROOT_THEME_API
       )
     };
+  }
+
+  componentWillReceiveProps(nextProps: Props) {
+    const { context, themeId, theme, themeOverrides } = this.props;
+    const {
+      context: nextContext,
+      themeId: nextThemeId,
+      theme: nextTheme,
+      themeOverrides: nextOverrides
+    } = nextProps;
+
+    if (
+      !isEqual(context, nextContext) ||
+      !isEqual(themeId, nextThemeId) ||
+      !isEqual(theme, nextTheme) ||
+      !isEqual(themeOverrides, nextOverrides)
+    ) {
+      this.setState(() => ({
+        composedTheme: composeTheme(
+          addThemeId(nextTheme || nextContext.theme, nextThemeId),
+          addThemeId(nextOverrides, nextThemeId),
+          nextContext.ROOT_THEME_API
+        )
+      }));
+    }
   }
 
   render() {

--- a/source/utils/props.js
+++ b/source/utils/props.js
@@ -10,3 +10,6 @@ export const composeFunctions = (...fns: [Function, Function]) => (...args: [any
 
 export const numberToPx = (val: string | number) =>
   (typeof val === 'number' ? `${val}px` : val);
+
+export const hasProperty = (obj: Object, property: ?string) =>
+  Object.prototype.hasOwnProperty.call(obj, property);

--- a/source/utils/themes.js
+++ b/source/utils/themes.js
@@ -1,5 +1,6 @@
 // @flow
 import { isEmpty, cloneDeep } from 'lodash';
+import { hasProperty } from './props';
 
 export const appendToProperty = (dest: {}, name: string, value: string) => {
   dest[name] === '' ? (dest[name] = value) : (dest[name] += ' ' + value);
@@ -8,8 +9,8 @@ export const appendToProperty = (dest: {}, name: string, value: string) => {
 export const composeComponentStyles = (componentStyles: {}, componentTheme: {}) => {
   if (!componentTheme) return;
   for (const property in componentStyles) {
-    if (Object.prototype.hasOwnProperty.call(componentStyles, property)) {
-      if (Object.prototype.hasOwnProperty.call(componentTheme, property)) {
+    if (hasProperty(componentStyles, property)) {
+      if (hasProperty(componentTheme, property)) {
         appendToProperty(componentStyles, property, componentTheme[property]);
       }
     }
@@ -22,12 +23,11 @@ export const composeComponentStyles = (componentStyles: {}, componentTheme: {}) 
 // theme[themeId] to ensure it's an object
 export const addThemeId = (theme: {}, themeId: string) => {
   if (!isEmpty(theme) && themeId) {
-    const themeIdExists = Object.prototype.hasOwnProperty.call(theme, themeId);
+    const themeIdExists = hasProperty(theme, themeId);
     const themeIdIsObj = typeof theme[themeId] === 'object';
 
     return themeIdExists && themeIdIsObj ? theme : { [themeId]: theme };
   }
-
   return theme;
 };
 
@@ -49,10 +49,11 @@ export const composeTheme = (
   // Return theme if there are no overrides provided
   if (isEmpty(themeOverrides)) return theme;
 
+  // final object to be returned
   const composedTheme = cloneDeep(themeAPI);
 
   for (const componentId in themeAPI) {
-    if (Object.prototype.hasOwnProperty.call(composedTheme, componentId)) {
+    if (hasProperty(composedTheme, componentId)) {
       const componentStyles = composedTheme[componentId];
       composeComponentStyles(componentStyles, theme[componentId]);
       composeComponentStyles(componentStyles, themeOverrides[componentId]);

--- a/source/utils/themes.js
+++ b/source/utils/themes.js
@@ -1,5 +1,5 @@
 // @flow
-import { isEmpty, cloneDeep } from 'lodash';
+import { cloneDeep, isEmpty, isEqual } from 'lodash';
 import { hasProperty } from './props';
 
 export const appendToProperty = (dest: {}, name: string, value: string) => {
@@ -60,4 +60,48 @@ export const composeTheme = (
     }
   }
   return composedTheme;
+};
+
+type ThemeProps = {
+  context: {
+    theme: Object,
+    ROOT_THEME_API: Object
+  },
+  themeId: string,
+  theme: Object,
+  themeOverrides: Object
+};
+
+// Used in componentWillReceiveProps, this function compares the current
+// set of theme related props against the next set to see if any have changed.
+// If true, a component's theme is recomposed and local state is updated
+export const didThemePropsChange = (
+  {
+    context,
+    themeId,
+    theme,
+    themeOverrides
+  }: ThemeProps,
+  {
+    context: nextContext,
+    themeId: nextThemeId,
+    theme: nextTheme,
+    themeOverrides: nextOverrides
+  }: ThemeProps,
+  setState: Function
+) => {
+  if (
+    !isEqual(context, nextContext) ||
+    !isEqual(themeId, nextThemeId) ||
+    !isEqual(theme, nextTheme) ||
+    !isEqual(themeOverrides, nextOverrides)
+  ) {
+    setState(() => ({
+      composedTheme: composeTheme(
+        addThemeId(nextTheme || nextContext.theme, nextThemeId),
+        addThemeId(nextOverrides, nextThemeId),
+        nextContext.ROOT_THEME_API
+      )
+    }));
+  }
 };

--- a/stories/ThemeProvider.stories.js
+++ b/stories/ThemeProvider.stories.js
@@ -49,7 +49,8 @@ import CustomAutocompleteTheme from './theme-customizations/Autocomplete.custom.
 // themeOverrides
 import buttonOverrides from './theme-overrides/buttonOverrides.scss';
 import checkboxOverrides from './theme-overrides/checkboxOverrides.scss';
-import progressBarOverrides from './theme-overrides/progressBarOverrides.scss';
+import progressBarOverrides1 from './theme-overrides/progressBarOverrides.scss';
+import progressBarOverrides2 from './theme-overrides/customProgressBar.scss';
 
 // constants
 import { IDENTIFIERS } from '../source/themes/API';
@@ -203,17 +204,38 @@ storiesOf('ThemeProvider', module)
   .add('themeOverrides',
     withState({
       checked: false,
-      progress: 0
-    }, store => {
-      const ThemeOverrides = {
+      progress: 0,
+      previousOverrides: {
         [BUTTON]: buttonOverrides,
         [CHECKBOX]: checkboxOverrides,
-        [PROGRESS_BAR]: progressBarOverrides
+        [PROGRESS_BAR]: progressBarOverrides2
+      },
+      themeOverrides: {
+        [BUTTON]: buttonOverrides,
+        [CHECKBOX]: checkboxOverrides,
+        [PROGRESS_BAR]: progressBarOverrides1
+      }
+    }, store => {
+      const switchOverrides = () => {
+        const { previousOverrides, themeOverrides } = store.state;
+        store.set({
+          previousOverrides: themeOverrides,
+          themeOverrides: previousOverrides
+        });
       };
+
       return (
-        <ThemeProvider theme={SimpleTheme} themeOverrides={ThemeOverrides}>
+        <ThemeProvider theme={SimpleTheme} themeOverrides={store.state.themeOverrides}>
           <Gutter padding="30vh 20vw">
             <Flex row justifyContent="space-around" alignItems="center">
+              <FlexItem>
+                <Button
+                  label="Switch ProgressBar's Theme"
+                  onClick={switchOverrides}
+                  skin={ButtonSkin}
+                />
+              </FlexItem>
+
               <FlexItem>
                 <Button
                   label="+ 10%"

--- a/stories/ThemeProvider.stories.js
+++ b/stories/ThemeProvider.stories.js
@@ -15,6 +15,10 @@ import { Autocomplete } from '../source/components/Autocomplete';
 import { Radio } from '../source/components/Radio';
 import { Options } from '../source/components/Options';
 import { Button } from '../source/components/Button';
+import { ProgressBar } from '../source/components/ProgressBar';
+import { Flex } from '../source/components/layout/Flex';
+import { FlexItem } from '../source/components/layout/FlexItem';
+import { Gutter } from '../source/components/layout/Gutter';
 
 // skins
 import { InputSkin } from '../source/skins/simple/InputSkin';
@@ -27,9 +31,10 @@ import { RadioSkin } from '../source/skins/simple/RadioSkin';
 import { OptionsSkin } from '../source/skins/simple/OptionsSkin';
 import { ButtonSkin } from '../source/skins/simple/ButtonSkin';
 import { CheckboxSkin } from '../source/skins/simple/CheckboxSkin';
+import { ProgressBarSkin } from '../source/skins/simple/ProgressBarSkin';
 
-// theme
-import { IDENTIFIERS } from '../source/themes/API';
+// themes
+import { SimpleTheme } from '../source/themes/simple';
 import CustomTextAreaTheme from './theme-customizations/TextArea.custom.scss';
 import CustomTogglerTheme from './theme-customizations/Toggler.custom.scss';
 import CustomSwitchTheme from './theme-customizations/Switch.custom.scss';
@@ -40,33 +45,50 @@ import CustomModalTheme from './theme-customizations/Modal.custom.scss';
 import CustomButtonTheme from './theme-customizations/Button.custom.scss';
 import CustomCheckboxTheme from './theme-customizations/Checkbox.custom.scss';
 import CustomAutocompleteTheme from './theme-customizations/Autocomplete.custom.scss';
-import SimpleBubble from '../source/themes/simple/SimpleBubble.scss';
-import SimpleFormField from '../source/themes/simple/SimpleFormField.scss';
 
-const OPTIONS = [
-  'home',
-  'cat',
-  'dog',
-  'fish'
-];
+// themeOverrides
+import buttonOverrides from './theme-overrides/buttonOverrides.scss';
+import checkboxOverrides from './theme-overrides/checkboxOverrides.scss';
+import progressBarOverrides from './theme-overrides/progressBarOverrides.scss';
+
+// constants
+import { IDENTIFIERS } from '../source/themes/API';
+
+const MNEMONICS = ['home', 'cat', 'dog', 'fish'];
+
+const {
+  AUTOCOMPLETE,
+  BUBBLE,
+  BUTTON,
+  CHECKBOX,
+  FORM_FIELD,
+  INPUT,
+  MODAL,
+  OPTIONS,
+  PROGRESS_BAR,
+  RADIO,
+  SWITCH,
+  TEXT_AREA,
+  TOGGLER
+} = IDENTIFIERS;
 
 const CUSTOM_THEME = {
-  [IDENTIFIERS.TEXT_AREA]: CustomTextAreaTheme,
-  [IDENTIFIERS.TOGGLER]: CustomTogglerTheme,
-  [IDENTIFIERS.SWITCH]: CustomSwitchTheme,
-  [IDENTIFIERS.RADIO]: CustomRadioTheme,
-  [IDENTIFIERS.OPTIONS]: CustomOptionsTheme,
-  [IDENTIFIERS.INPUT]: CustomInputTheme,
-  [IDENTIFIERS.MODAL]: CustomModalTheme,
-  [IDENTIFIERS.BUTTON]: CustomButtonTheme,
-  [IDENTIFIERS.CHECKBOX]: CustomCheckboxTheme,
-  [IDENTIFIERS.AUTOCOMPLETE]: CustomAutocompleteTheme,
-  [IDENTIFIERS.BUBBLE]: SimpleBubble,
-  [IDENTIFIERS.FORM_FIELD]: SimpleFormField
+  [TEXT_AREA]: CustomTextAreaTheme,
+  [TOGGLER]: CustomTogglerTheme,
+  [SWITCH]: CustomSwitchTheme,
+  [RADIO]: CustomRadioTheme,
+  [OPTIONS]: CustomOptionsTheme,
+  [INPUT]: CustomInputTheme,
+  [MODAL]: CustomModalTheme,
+  [BUTTON]: CustomButtonTheme,
+  [CHECKBOX]: CustomCheckboxTheme,
+  [AUTOCOMPLETE]: CustomAutocompleteTheme,
+  [BUBBLE]: SimpleTheme[BUBBLE],
+  [FORM_FIELD]: SimpleTheme[FORM_FIELD]
 };
 
 storiesOf('ThemeProvider', module)
-  // ====== Stories ======
+  // ====== ThemeProvider Stories ======
 
   .add('custom theme',
     withState({
@@ -156,7 +178,7 @@ storiesOf('ThemeProvider', module)
         <div style={{ margin: '50px' }}>
           <Options
             isOpen
-            options={OPTIONS}
+            options={MNEMONICS}
             isOpeningUpward={false}
             noResults={false}
             skin={OptionsSkin}
@@ -166,7 +188,7 @@ storiesOf('ThemeProvider', module)
         <div style={{ margin: '400px 100px 250px 100px', height: '225px' }}>
           <Autocomplete
             label="Autocomplete with custom theme"
-            options={OPTIONS}
+            options={MNEMONICS}
             placeholder="Enter mnemonic..."
             maxSelections={12}
             maxVisibleOptions={5}
@@ -176,4 +198,60 @@ storiesOf('ThemeProvider', module)
         </div>
       </ThemeProvider>
     ))
+  )
+
+  .add('themeOverrides',
+    withState({
+      checked: false,
+      progress: 0
+    }, store => {
+      const ThemeOverrides = {
+        [BUTTON]: buttonOverrides,
+        [CHECKBOX]: checkboxOverrides,
+        [PROGRESS_BAR]: progressBarOverrides
+      };
+      return (
+        <ThemeProvider theme={SimpleTheme} themeOverrides={ThemeOverrides}>
+          <Gutter padding="30vh 20vw">
+            <Flex row justifyContent="space-around" alignItems="center">
+              <FlexItem>
+                <Button
+                  label="+ 10%"
+                  onClick={() => store.set({ progress: store.state.progress + 10 })}
+                  skin={ButtonSkin}
+                />
+              </FlexItem>
+
+              <FlexItem>
+                <Button
+                  label="- 10%"
+                  onClick={() => store.set({ progress: store.state.progress - 10 })}
+                  skin={ButtonSkin}
+                />
+              </FlexItem>
+
+              <FlexItem>
+                <Checkbox
+                  label="Reset"
+                  checked={store.state.checked}
+                  onChange={() => {
+                    store.set({ checked: true, progress: 0 });
+                    setTimeout(() => store.set({ checked: false }), 2000);
+                  }}
+                  skin={CheckboxSkin}
+                />
+              </FlexItem>
+            </Flex>
+
+            <div style={{ margin: '50px' }}>
+              <ProgressBar
+                label="100% Complete"
+                progress={store.state.progress}
+                skin={ProgressBarSkin}
+              />
+            </div>
+          </Gutter>
+        </ThemeProvider>
+      );
+    })
   );

--- a/stories/theme-overrides/buttonOverrides.scss
+++ b/stories/theme-overrides/buttonOverrides.scss
@@ -1,0 +1,22 @@
+.root {
+  font-size: 14px;
+  font-weight: bold;
+  letter-spacing: 2px;
+  background-color: #fff;
+  border: 2px solid #900000;
+  border-radius: 5px;
+  box-sizing: border-box;
+  color: #900000;
+  padding: 25px;
+  transition: all 0.2s ease-in-out;
+  width: 150px;
+
+  &:not(.disabled) {
+    &:hover {
+      background-color: #fff;
+      color: #E00000;
+      border: 2px solid #E00000;
+      cursor: pointer;
+    }
+  }
+}

--- a/stories/theme-overrides/checkboxOverrides.scss
+++ b/stories/theme-overrides/checkboxOverrides.scss
@@ -1,0 +1,40 @@
+.root {
+  .label {
+    font-size: 14px;
+    font-weight: bold;
+    letter-spacing: 2px;
+    text-transform: uppercase;
+    transition: all 0.2s ease-in-out;
+  }
+
+  .check {
+    transition: all 0.2s ease-in-out;
+    height: 40px;
+    width: 40px;
+    border: 2px solid #900000;
+  }
+  // BEGIN SPECIAL STATES ---------- //
+  &.checked {
+    .label {
+      transition: all 0.2s ease-in-out;
+      color: rgba(10, 145, 48, 0.6);
+    }
+
+    .check {
+      transition: all 0.2s ease-in-out;
+      background-color: #fff;
+      border: 2px solid rgba(10, 145, 48, 0.6);
+      &:after {
+        border-color: rgba(10, 145, 48, 0.6);
+        // border-style: solid;
+        // border-width: 0 $checkbox-check-thickness $checkbox-check-thickness 0;
+        // content: "";
+        width: 8px;
+        height: 16px;
+        // transform: rotate(45deg);
+        // margin-top: $checkbox-check-vertical-offset;
+      }
+    }
+  }
+  // END SPECIAL STATES ---------- //
+}

--- a/stories/theme-overrides/progressBarOverrides.scss
+++ b/stories/theme-overrides/progressBarOverrides.scss
@@ -1,0 +1,25 @@
+.track {
+  height: 50px;
+  border: 3px solid rgba(85, 85, 85, 1);
+  background: rgba(85, 85, 85, 0.9);
+}
+
+.progress {
+  background-color: #FF9999;
+  background-image: linear-gradient(to bottom, #FF9999, #FF99CC);
+
+  &:after {
+    background-image: linear-gradient(
+      -45deg,
+      rgba(255, 255, 255, .3) 25%,
+      transparent 25%,
+      transparent 50%,
+      rgba(255, 255, 255, .3) 50%,
+      rgba(255, 255, 255, .3) 75%,
+      transparent 75%,
+      transparent
+    );
+    z-index: 1;
+    background-size: 80px 80px;
+  }
+}


### PR DESCRIPTION
This PR fixes a bug where `ThemeProvider` failed to compose its `theme` prop with the user's custom styles passed as a `themeOverrides` prop. 

Adds a `themeOverrides` story to `ThemeProvider.stories.js` to exemplify intended behavior and show the bug is corrected.