### PR TITLE
[DDW-375] Adjust NumericInput maxAfterDot Config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## Fixes
 
+- Fixes NumericInput's value processing logic to only return integer numbers before the decimal when maxAfterDot is 0. Adds a behavior test and a story for this functionality. [PR 91](https://github.com/input-output-hk/react-polymorph/pull/91)
+
 - Fixes a bug where ThemeProvider failed to compose its theme prop with the user's custom styles passed as the themeOverrides prop. Adds a check to all components using context for when themeOverrides or theme changes in context. If there is a change, the component's theme and themeOverrides will be composed again and local state will update. Adds a themeOverrides story to ThemeProvider's stories to show intended functionality of theme composition and dynamic theme switching. [PR 90](https://github.com/input-output-hk/react-polymorph/pull/90)
 
 ## Features

--- a/__tests__/NumericInput.behavior.test.js
+++ b/__tests__/NumericInput.behavior.test.js
@@ -98,6 +98,27 @@ describe('NumericInput onChange simulations', () => {
     expect(component.state.oldValue).toBe('85.9854');
   });
 
+  test('integers only - onChange is passed invalid amount, maxAfterDot is enforced correctly', () => {
+    const wrapper = mountInSimpleTheme(
+      <NumericInput
+        maxAfterDot={0}
+        skin={InputSkin}
+      />
+    );
+
+    const component = wrapper.find('NumericInputBase').instance();
+    const input = wrapper.find('input');
+
+    // simulate onChange with only an integer (valid)
+    input.simulate('change', { target: { value: '1234' } });
+    expect(component.state.oldValue).toBe('1234');
+
+    // simulate onChange with floating point number (invalid)
+    input.simulate('change', { target: { value: '5678.985' } });
+    // should drop decimal & all numbers after decimal: '.985'
+    expect(component.state.oldValue).toBe('5678');
+  });
+
   test('onChange simulates amount exceeding maxValue, enforceMax is enforced', () => {
     const wrapper = mountInSimpleTheme(
       <NumericInput

--- a/source/components/NumericInput.js
+++ b/source/components/NumericInput.js
@@ -413,14 +413,17 @@ class NumericInputBase extends Component<Props, State> {
         afterDot += '0';
       }
     }
+    // if maxAfterDot is 0, drop decimal & numbers after decimal, return int
+    if (maxAfterDot === 0) { return beforeDot; }
 
     // return input value w/decimal restrictions as a string
-    const result = beforeDot + '.' + afterDot;
-    return result;
+    return beforeDot + '.' + afterDot;
   }
 
   _separate(value: string) {
     this.setState({ oldValue: value });
+    // value will not contain '.' if maxAfterDot is 0, return early
+    if (value && !value.includes('.')) { return value; }
     if (value) {
       const splitedValue = value.split('.');
       const separatedValue = splitedValue[0]

--- a/stories/NumericInput.stories.js
+++ b/stories/NumericInput.stories.js
@@ -107,7 +107,7 @@ storiesOf('NumericInput', module)
     ))
   )
 
-  .add('beforeDot(3) and afterDot(4)',
+  .add('maxBeforeDot(3) and maxAfterDot(4)',
     withState({ value: '' }, store => (
       <NumericInput
         label="Amount"
@@ -115,6 +115,20 @@ storiesOf('NumericInput', module)
         placeholder="000.0000"
         maxBeforeDot={3}
         maxAfterDot={4}
+        onChange={value => store.set({ value })}
+        skin={InputSkin}
+      />
+    ))
+  )
+
+  .add('maxBeforeDot(3) and maxAfterDot(0)',
+    withState({ value: '' }, store => (
+      <NumericInput
+        label="Integers Only"
+        value={store.state.value}
+        placeholder="123"
+        maxBeforeDot={3}
+        maxAfterDot={0}
         onChange={value => store.set({ value })}
         skin={InputSkin}
       />


### PR DESCRIPTION
- Fixes `NumericInput`'s value processing logic to only return the integer numbers before the decimal when `maxAfterDot={0}`.

- Adds one new behavior test for `NumericInput` which tests `maxAfterDot={0}`.

- Adds one new story for `NumericInput` which shows intended behavior when `maxAfterDot={0}`.

----------------------------------------------------------------------------------------------------

- [x] PR is updated to the most recent version of target branch (and there are no conflicts)
- [x] PR has good description that summarizes all changes and shows some screenshots or animated GIFs of important UI changes
- [x] CHANGELOG entry has been added and is linked to the correct PR on GitHub
- [x] Automated tests: All acceptance tests are passing (`yarn run test`)
- [x] There are no *flow* errors or warnings (`yarn run flow:test`)
- [x] There are no *lint* errors or warnings (`yarn run lint`)
- [x] Storybook works and no stories are broken (`yarn run storybook`)