### PR TITLE
[DDW-511] Provide simple skins by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## vNext
 
+### Features
+
+- Make it possible to provide simple skins via `ThemeProvider`
+  [PR 96](https://github.com/input-output-hk/react-polymorph/pull/96)
+
 ## 0.8.0
 
 ### Chores

--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ in both cases it is "just" an input field showing some text:
 
 Represents a single-line input field.
 
+![Standard Input](./docs/images/react-polymorph-input-example.png)
+
 ##### Example Usage:
 
 ```js
@@ -122,7 +124,6 @@ const MyStandardInput = () => (
 );
 ```
 
-![Standard Input](./docs/images/react-polymorph-input-example.png)
 
 ##### Input Props:
 
@@ -153,7 +154,9 @@ type InputProps = {
 
 #### Numeric Input
 
-Component specialized in guiding the user to enter correct floating point numbers:
+Component specialized in guiding the user to enter correct floating point numbers.
+
+![Standard Input](./docs/images/react-polymorph-numeric-input-example.png)
 
 ##### Example Usage:
 
@@ -175,7 +178,6 @@ const MyNumericInput = () => (
 );
 ```
 
-![Standard Input](./docs/images/react-polymorph-numeric-input-example.png)
 
 This is a simple example that shows how you can make/use specialized versions
 of basic components by composition - a core idea of `react-polymorph`!
@@ -214,6 +216,8 @@ type NumericInputProps = {
 
 Simple component that represents an input which can receive multiple lines of text. 
 
+![Standard Input](./docs/images/react-polymorph-textarea-example.png)
+
 ##### Example Usage:
 
 ```js
@@ -229,7 +233,6 @@ const MyTextArea = () => (
 );
 ```
 
-![Standard Input](./docs/images/react-polymorph-textarea-example.png)
 
 ##### TextArea Props:
 
@@ -263,6 +266,8 @@ type TextAreaProps = {
 
 Represents a clickable area.
 
+![Standard Input](./docs/images/react-polymorph-button-example.png)
+
 ##### Example Usage:
 
 ```js
@@ -274,7 +279,6 @@ const MyButton = () => (
 );
 ```
 
-![Standard Input](./docs/images/react-polymorph-button-example.png)
 
 ##### Button Props:
 
@@ -296,7 +300,9 @@ type ButtonProps = {
 #### Select
 
 The select component is like standard select but with additional logic for adding custom option 
-renderer and opening directions (upward / downward):
+renderer and opening directions (upward / downward).
+
+![Standard Input](./docs/images/react-polymorph-select-example.png)
 
 ##### Example Usage:
 
@@ -304,14 +310,21 @@ renderer and opening directions (upward / downward):
 import React from "react";
 import { Select } from "react-polymorph/lib/components";
 
+const COUNTRIES_WITH_FLAGS = [
+  { value: 'EN-gb', label: 'England', flag: flagEngland },
+  { value: 'ES-es', label: 'Spain', flag: flagSpain },
+  { value: 'TH-th', label: 'Thailand', flag: flagThailand },
+  { value: 'EN-en', label: 'USA', flag: flagUSA }
+];
+
 const MySelect = () => (
   <Select
     label="Countries"
-    options={OPRIONS_ARRAY}
+    options={COUNTRIES_WITH_FLAGS}
     optionRenderer={option => {
       return (
         <div className={styles.customOptionStyle}>
-          <img src={option.value} />
+          <img src={option.flag} />
           <span>{option.label}</span>
         </div>
       );
@@ -320,7 +333,6 @@ const MySelect = () => (
 );
 ```
 
-![Standard Input](./docs/images/react-polymorph-select-example.png)
 
 ##### Select Props:
 
@@ -349,7 +361,9 @@ type SelectProps = {
 
 #### Checkbox
 
-The checkbox is as simple as possible and does not have much logic:
+Represents a component which can toggle between checked and unchecked state.
+
+![Standard Input](./docs/images/react-polymorph-checkbox-example.png)
 
 ##### Example Usage:
 
@@ -361,8 +375,6 @@ const MyCheckbox = () => (
   <Checkbox label="My checkbox" />
 );
 ```
-
-![Standard Input](./docs/images/react-polymorph-checkbox-example.png)
 
 ##### Checkbox Props:
 
@@ -389,7 +401,9 @@ type CheckboxProps = {
 
 #### Switch
 
-Like checkbox but uses a different skin part:
+Like checkbox but uses a different skin part.
+
+![Standard Input](./docs/images/react-polymorph-switch-example.png)
 
 ##### Example Usage:
 
@@ -402,7 +416,6 @@ const MySwitch = () => (
 );
 ```
 
-![Standard Input](./docs/images/react-polymorph-switch-example.png)
 
 ##### Switch Props -> see Checkbox (above)
 
@@ -410,7 +423,9 @@ const MySwitch = () => (
 
 #### Toggler
 
-Like checkbox but uses a different skin part:
+Like checkbox but uses a different skin part.
+
+![Standard Input](./docs/images/react-polymorph-toggler-example.png)
 
 ##### Example Usage:
 
@@ -426,7 +441,6 @@ const MyToggler = () => (
 );
 ```
 
-![Standard Input](./docs/images/react-polymorph-toggler-example.png)
 
 ##### Toggler Props -> see Checkbox (above)
 
@@ -436,6 +450,8 @@ const MyToggler = () => (
 
 The modal is component which wraps its children as standard dialog.
 As is shown in example, modal can have multiple other polymorph components:
+
+![Standard Input](./docs/images/react-polymorph-modal-example.png)
 
 ##### Example Usage:
 
@@ -462,7 +478,6 @@ const MyModal = props => (
 );
 ```
 
-![Standard Input](./docs/images/react-polymorph-modal-example.png)
 
 ##### Modal Props:
 
@@ -485,6 +500,8 @@ type ModalProps = {
 The autocomplete input is specialized to help users to select between multiple 
 suggested words depending on entered letters:
 
+![Standard Input](./docs/images/react-polymorph-autocomplete-example.png)
+
 ##### Example Usage:
 
 ```js
@@ -504,7 +521,6 @@ const MyAutocomplete = props => (
 );
 ```
 
-![Standard Input](./docs/images/react-polymorph-autocomplete-example.png)
 
 ##### Autocomplete Props:
 
@@ -538,6 +554,8 @@ type AutocompleteProps = {
 The bubble component will open up an absolutely positioned speech bubble.
 This is position in respect to it's closest relatively positioned parent.
 
+![Standard Input](./docs/images/react-polymorph-bubble-example.png)
+
 ##### Example Usage:
 
 ```js
@@ -553,7 +571,6 @@ const MyBubble = props => (
 );
 ```
 
-![Standard Input](./docs/images/react-polymorph-bubble-example.png)
 
 ##### Bubble Props:
 
@@ -577,6 +594,8 @@ type BubbleProps = {
 
 The tooltip opens a bubble relative to it's children, containing text or html to display.
 
+![Standard Input](./docs/images/react-polymorph-tooltip-example.png)
+
 ##### Example Usage:
 
 ```js
@@ -592,7 +611,6 @@ const MyTooltip = props => (
 );
 ```
 
-![Standard Input](./docs/images/react-polymorph-tooltip-example.png)
 
 ##### Tooltip Props:
 
@@ -616,6 +634,8 @@ type TooltipProps = {
 
 The radio is as simple as possible and does not have much logic:
 
+![Standard Input](./docs/images/react-polymorph-radio-example.png)
+
 ##### Example Usage:
 
 ```js
@@ -629,7 +649,6 @@ const MyRadio = props => (
 );
 ```
 
-![Standard Input](./docs/images/react-polymorph-radio-example.png)
 
 ##### Radio Props:
 

--- a/README.md
+++ b/README.md
@@ -49,62 +49,122 @@ module: {
 
 Now you can import and use components like this in your app:
 
-```javascript
+```js
 import React from "react";
 import { Input } from "react-polymorph/lib/components";
-import { InputSkin } from "react-polymorph/lib/skins/simple";
+import { InputSkin } from "react-polymorph/lib/skins/simple/InputSkin";
+import { InputTheme } from "react-polymorph/lib/themes/simple/InputTheme";
 
-// Basic input component:
-const MyInput = () => <Input skin={InputSkin} />;
+const MyInput = () => (
+  <Input // <- Logic
+    skin={InputSkin} // <- Markup
+    theme={InputTheme} // <- Styling
+    label="My Input" // <- Component prop
+  />
+);
 ```
 
-Each component's _skin_ that you apply to your component will receive its styles (css/scss) via a _theme_.
-React-polymorph comes with Simple themes & skins out of the box, but all themes are completely customizable.
+Each component needs a _skin_ to render markup and will receive its styles (css/scss) via a _theme_.
+
+### Theme Provider
+
+Of course this would be a lot of code just to render a simple input. That's why you should always use a theme provider 
+to inject skins and themes into all components below the `ThemeProvider` automatically (components can be arbitrarily
+deep nested).
+
+```js
+import React from "react";
+import { Input } from "react-polymorph/lib/components";
+import { SimpleSkins } from "react-polymorph/lib/skins/simple";
+import { SimpleTheme } from "react-polymorph/lib/themes/simple";
+
+// Notice that we don't have to pass any skin or theme to the inputs:
+const MyForm = () => (
+  <div>
+    <Input label="First Name" />
+    <Input label="Last Name" />
+  </div>
+);
+
+const SimpleFormApp = () => (
+  <ThemeProvider skins={SimpleSkins} theme={SimpleTheme}>
+    <MyForm />
+  </ThemeProvider>
+);
+```
 
 ### Components and Skins
+
+React-polymorph comes with simple themes & skins out of the box, but anything is customizable.
 
 Imagine you need a standard text `Input` component for text and a `NumericInput`
 for floating point numbers. The only difference is the logic of the component,
 in both cases it is "just" an input field showing some text:
 
-#### Standard Input
+---
 
-The standard input is as simple as possible and does not have much logic:
+#### Input
 
-```javascript
+Represents a single-line input field.
+
+##### Example Usage:
+
+```js
 import React from "react";
 import { Input } from "react-polymorph/lib/components";
-import { InputSkin } from "react-polymorph/lib/skins/simple";
-import { InputTheme } from "react-polymorph/lib/themes/simple";
 
 // Standard input component:
-const MyStandardInput = props => (
+const MyStandardInput = () => (
   <Input
     label="Input with max. 5 Characters"
     maxLength={5}
-    skin={InputSkin}
-    theme={InputTheme}
   />
 );
 ```
 
 ![Standard Input](./docs/images/react-polymorph-input-example.png)
 
+##### Input Props:
+
+```js
+type InputProps = {
+  autoFocus: boolean,
+  className?: ?string,
+  disabled?: boolean,
+  error: string | Element<any>,
+  label?: string | Element<any>,
+  maxLength?: number,
+  minLength?: number,
+  onBlur?: Function,
+  onChange?: Function,
+  onFocus?: Function,
+  onKeyPress?: Function,
+  placeholder?: string,
+  readOnly: boolean,
+  setError?: Function,
+  skin?: ComponentType<any>,
+  theme: ?Object,
+  themeOverrides: Object,
+  value: string
+};
+```
+
+---
+
 #### Numeric Input
 
-The numeric input however is specialized in guiding the user to
-enter correct floating point numbers:
+Component specialized in guiding the user to enter correct floating point numbers:
 
-```javascript
+##### Example Usage:
+
+```js
 import React from "react";
 import { NumericInput } from "react-polymorph/lib/components";
 import { InputSkin } from "react-polymorph/lib/skins/simple";
-import { InputTheme } from "react-polymorph/lib/themes/simple";
 
-const MyNumericInput = props => (
+const MyNumericInput = () => (
   <NumericInput // notice the different logic component!
     skin={InputSkin} // but the same skin!
-    theme={InputTheme}
     label="Amount"
     placeholder="0.000000"
     maxBeforeDot={5}
@@ -120,57 +180,131 @@ const MyNumericInput = props => (
 This is a simple example that shows how you can make/use specialized versions
 of basic components by composition - a core idea of `react-polymorph`!
 
+##### NumericInput Props:
+
+```js
+type NumericInputProps = {
+  autoFocus?: boolean,
+  className?: string,
+  disabled?: boolean,
+  enforceMax: boolean,
+  label?: string | Element<any>,
+  enforceMin: boolean,
+  error?: string,
+  onBlur?: Function,
+  onChange?: Function,
+  onFocus?: Function,
+  maxAfterDot?: number,
+  maxBeforeDot?: number,
+  maxValue?: number,
+  minValue?: number,
+  readOnly?: boolean,
+  placeholder?: string,
+  setError?: Function,
+  skin?: ComponentType<any>,
+  theme: ?Object,
+  themeOverrides: Object,
+  value: string
+};
+```
+
+---
+
 #### Textarea
 
-The textarea is as simple as possible and does not have much logic:
+Simple component that represents an input which can receive multiple lines of text. 
 
-```javascript
+##### Example Usage:
+
+```js
 import React from "react";
 import { TextArea } from "react-polymorph/lib/components";
-import { TextAreaSkin } from "react-polymorph/lib/skins/simple";
-import { TextAreaTheme } from "react-polymorph/lib/themes/simple";
 
-const MyTextArea = props => (
+const MyTextArea = () => (
   <TextArea
     label="Textarea with fixed amount of rows to start with"
     placeholder="Your description here"
     rows={5}
-    skin={TextAreaSkin}
-    theme={TextAreaTheme}
   />
 );
 ```
 
 ![Standard Input](./docs/images/react-polymorph-textarea-example.png)
 
+##### TextArea Props:
+
+```js
+type TextAreaProps = {
+  autoFocus: boolean,
+  autoResize: boolean,
+  className?: string,
+  context: ThemeContextProp,
+  disabled?: boolean,
+  label?: string | Element<any>,
+  error?: string | Node,
+  maxLength?: number,
+  minLength?: number,
+  onBlur?: Function,
+  onChange?: Function,
+  onFocus?: Function,
+  placeholder?: string,
+  rows?: number,
+  skin?: ComponentType<any>,
+  theme: ?Object,
+  themeId: string,
+  themeOverrides: Object,
+  value: string
+};
+```
+
+---
+
 #### Button
 
-The button is as simple as possible and does not have much logic:
+Represents a clickable area.
 
-```javascript
+##### Example Usage:
+
+```js
 import React from "react";
 import { Button } from "react-polymorph/lib/components";
-import { ButtonSkin } from "react-polymorph/lib/skins/simple";
-import { ButtonTheme } from "react-polymorph/lib/themes/simple";
 
-const MyButton = props => (
-  <Button label="Button label" skin={ButtonSkin} theme={ButtonTheme} />
+const MyButton = () => (
+  <Button label="Button label" />
 );
 ```
 
 ![Standard Input](./docs/images/react-polymorph-button-example.png)
 
+##### Button Props:
+
+```js
+type ButtonProps = {
+  className?: string,
+  disabled?: boolean,
+  label?: string | Element<any>,
+  loading: boolean,
+  onClick?: Function,
+  skin?: ComponentType<any>,
+  theme: ?Object,
+  themeOverrides: Object
+};
+```
+
+---
+
 #### Select
 
-The select component is like standard select but with additional logic for adding custom option renderer and opening directions (upward / downward):
+The select component is like standard select but with additional logic for adding custom option 
+renderer and opening directions (upward / downward):
 
-```javascript
+##### Example Usage:
+
+```js
 import React from "react";
 import { Select } from "react-polymorph/lib/components";
-import { SelectSkin } from "react-polymorph/lib/skins/simple";
-import { SelectTheme } from "react-polymorph/lib/themes/simple";
 
-const MySelect = props => (
+const MySelect = () => (
   <Select
     label="Countries"
     options={OPRIONS_ARRAY}
@@ -182,82 +316,135 @@ const MySelect = props => (
         </div>
       );
     }}
-    skin={SelectSkin}
-    theme-{SelectTheme}
   />
 );
 ```
 
 ![Standard Input](./docs/images/react-polymorph-select-example.png)
 
+##### Select Props:
+
+```js
+type SelectProps = {
+  allowBlank: boolean,
+  autoFocus: boolean,
+  className?: string,
+  error?: string | Element<any>,
+  label?: string | Element<any>,
+  isOpeningUpward: boolean,
+  onBlur?: Function,
+  onChange?: Function,
+  onFocus?: Function,
+  optionRenderer?: Function,
+  options: Array<any>,
+  placeholder?: string,
+  skin?: ComponentType<any>,
+  theme: ?Object,
+  themeOverrides: Object,
+  value: string
+};
+```
+
+---
+
 #### Checkbox
 
 The checkbox is as simple as possible and does not have much logic:
 
-```javascript
+##### Example Usage:
+
+```js
 import React from "react";
 import { Checkbox } from "react-polymorph/lib/components";
-import { CheckboxSkin } from "react-polymorph/lib/skins/simple";
-import { CheckboxTheme } from "react-polymorph/lib/themes/simple";
 
-const MyCheckbox = props => (
-  <Checkbox label="My checkbox" skin={CheckboxSkin} theme={CheckboxTheme} />
+const MyCheckbox = () => (
+  <Checkbox label="My checkbox" />
 );
 ```
 
 ![Standard Input](./docs/images/react-polymorph-checkbox-example.png)
 
+##### Checkbox Props:
+
+```js
+type CheckboxProps = {
+  checked: boolean,
+  className?: string,
+  context: ThemeContextProp,
+  disabled?: boolean,
+  label?: string | Element<any>,
+  labelLeft?: string | Element<any>,
+  labelRight?: string | Element<any>,
+  onChange?: Function,
+  onBlur?: Function,
+  onFocus?: Function,
+  skin?: ComponentType<any>,
+  theme: ?Object,
+  themeId: string,
+  themeOverrides: Object
+};
+```
+
+---
+
 #### Switch
 
-The switch is as simple as possible and does not have much logic. Like checkbox but uses a different skin part:
+Like checkbox but uses a different skin part:
 
-```javascript
+##### Example Usage:
+
+```js
 import React from "react";
 import { Checkbox } from "react-polymorph/lib/components";
-import { SwitchSkin } from "react-polymorph/lib/skins/simple";
-import { SwitchTheme } from "react-polymorph/lib/themes/simple";
 
-const MySwitch = props => (
-  <Checkbox label="My switch" skin={SwitchSkin} theme={SwitchTheme} />
+const MySwitch = () => (
+  <Checkbox label="My switch" />
 );
 ```
 
 ![Standard Input](./docs/images/react-polymorph-switch-example.png)
 
+##### Switch Props -> see Checkbox (above)
+
+---
+
 #### Toggler
 
-The toggler is as simple as possible and does not have much logic. Like checkbox but uses a different skin part:
+Like checkbox but uses a different skin part:
 
-```javascript
+##### Example Usage:
+
+```js
 import React from "react";
 import { Checkbox } from "react-polymorph/lib/components";
-import { TogglerSkin } from "react-polymorph/lib/skins/simple";
-import { TogglerTheme } from "react-polymorph/lib/themes/simple";
 
-const MyToggler = props => (
+const MyToggler = () => (
   <Checkbox
     labelLeft="Included"
     labelRight="Excluded"
-    skin={TogglerSkin}
-    theme={TogglerTheme}
   />
 );
 ```
 
 ![Standard Input](./docs/images/react-polymorph-toggler-example.png)
 
+##### Toggler Props -> see Checkbox (above)
+
+---
+
 #### Modal
 
-The modal is component which wraps its children as standard dialog. As is shown in example, modal can have multiple other polymorph components:
+The modal is component which wraps its children as standard dialog.
+As is shown in example, modal can have multiple other polymorph components:
 
-```javascript
+##### Example Usage:
+
+```js
 import React from "react";
 import { Modal, Button } from "react-polymorph/lib/components";
-import { ModalSkin, ButtonSkin } from "react-polymorph/lib/skins/simple";
-import { ModalTheme, ButtonTheme } from "react-polymorph/lib/themes/simple";
 
 const MyModal = props => (
-  <Modal triggerCloseOnOverlayClick={false} skin={ModalSkin} theme={ModalTheme}>
+  <Modal triggerCloseOnOverlayClick={false}>
     <h1 className={styles.modalTitle}>
       Are you sure you want to delete this thing?
     </h1>
@@ -265,14 +452,10 @@ const MyModal = props => (
       <Button
         label="Cancel"
         onClick={closeModalCallback}
-        skin={ButtonSkin}
-        theme={ButtonTheme}
       />
       <Button
         label="Delete"
         onClick={closeModalCallback}
-        skin={ButtonSkin}
-        theme={ButtonTheme}
       />
     </div>
   </Modal>
@@ -281,15 +464,32 @@ const MyModal = props => (
 
 ![Standard Input](./docs/images/react-polymorph-modal-example.png)
 
+##### Modal Props:
+
+```js
+type ModalProps = {
+  contentLabel: string | Element<any>,
+  isOpen: boolean,
+  onClose?: Function,
+  skin?: ComponentType<any>,
+  triggerCloseOnOverlayClick: boolean,
+  theme: ?Object,
+  themeOverrides: Object
+};
+```
+
+---
+
 #### Autocomplete
 
-The autocomplete input is specialized to help users to select between multiple suggested words depending on entered letters:
+The autocomplete input is specialized to help users to select between multiple 
+suggested words depending on entered letters:
 
-```javascript
+##### Example Usage:
+
+```js
 import React from "react";
 import { Autocomplete } from "react-polymorph/lib/components";
-import { AutocompleteSkin } from "react-polymorph/lib/skins/simple";
-import { AutocompleteTheme } from "react-polymorph/lib/themes/simple";
 
 const MyAutocomplete = props => (
   <Autocomplete
@@ -300,27 +500,53 @@ const MyAutocomplete = props => (
     maxSelections={12}
     maxVisibleSuggestions={5}
     invalidCharsRegex={/[^a-zA-Z]/g}
-    skin={AutocompleteSkin}
-    theme={AutocompleteTheme}
   />
 );
 ```
 
 ![Standard Input](./docs/images/react-polymorph-autocomplete-example.png)
 
+##### Autocomplete Props:
+
+```js
+type AutocompleteProps = {
+  className?: string,
+  error: ?string,
+  invalidCharsRegex: RegExp,
+  isOpeningUpward: boolean,
+  label?: string | Element<any>,
+  maxSelections?: number,
+  maxVisibleOptions: number,
+  multipleSameSelections: boolean,
+  onChange?: Function,
+  options: Array<any>,
+  preselectedOptions?: Array<any>,
+  placeholder?: string,
+  renderSelections?: Function,
+  renderOptions?: Function,
+  skin?: ComponentType<any>,
+  sortAlphabetically: boolean,
+  theme: ?Object,
+  themeOverrides: Object
+};
+```
+
+---
+
 #### Bubble
 
-The bubble component will open up an absolutely positioned speech bubble. This is position in respect to it's closest relatively positioned parent.
+The bubble component will open up an absolutely positioned speech bubble.
+This is position in respect to it's closest relatively positioned parent.
 
-```javascript
+##### Example Usage:
+
+```js
 import React from "react";
 import { Bubble } from "react-polymorph/lib/components";
-import { BubbleSkin } from "react-polymorph/lib/skins/simple";
-import { BubbleTheme } from "react-polymorph/lib/themes/simple";
 
 const MyBubble = props => (
   <div className={{ position: "relative" }}>
-    <Bubble skin={BubbleSkin} theme={BubbleTheme}>
+    <Bubble>
       plain bubble
     </Bubble>
   </div>
@@ -329,21 +555,37 @@ const MyBubble = props => (
 
 ![Standard Input](./docs/images/react-polymorph-bubble-example.png)
 
+##### Bubble Props:
+
+```js
+type BubbleProps = {
+  className?: string,
+  isHidden: boolean,
+  isFloating: boolean,
+  isOpeningUpward: boolean,
+  isTransparent: boolean,
+  skin?: ComponentType<any>,
+  theme: ?Object,
+  themeOverrides: Object,
+  targetRef?: Ref<*>, // ref to the target DOM element used for positioning the bubble
+};
+```
+
+---
+
 #### Tooltip
 
 The tooltip opens a bubble relative to it's children, containing text or html to display.
 
-```javascript
+##### Example Usage:
+
+```js
 import React from "react";
 import { Tooltip } from "react-polymorph/lib/components";
-import { TooltipSkin } from "react-polymorph/lib/skins/simple";
-import { TooltipTheme } from "react-polymorph/lib/themes/simple";
 
 const MyTooltip = props => (
   <Tooltip
     tip="Description of the child element"
-    skin={TooltipSkin}
-    theme={TooltipTheme}
   >
     hover over me
   </Tooltip>
@@ -352,11 +594,31 @@ const MyTooltip = props => (
 
 ![Standard Input](./docs/images/react-polymorph-tooltip-example.png)
 
+##### Tooltip Props:
+
+```js
+type TooltipProps = {
+  className?: string,
+  isAligningRight?: boolean,
+  isBounded?: boolean,
+  isOpeningUpward: boolean,
+  isTransparent: boolean,
+  skin?: ComponentType<any>,
+  theme: ?Object,
+  themeOverrides: Object,
+  tip?: string | Element<any>
+};
+```
+
+---
+
 #### Radio
 
 The radio is as simple as possible and does not have much logic:
 
-```javascript
+##### Example Usage:
+
+```js
 import React from "react";
 import { Radio } from "react-polymorph/lib/components";
 import { RadioSkin } from "react-polymorph/lib/skins/simple";
@@ -369,22 +631,47 @@ const MyRadio = props => (
 
 ![Standard Input](./docs/images/react-polymorph-radio-example.png)
 
+##### Radio Props:
+
+```js
+type RadioProps = {
+  disabled?: boolean,
+  label?: string | Element<any>,
+  onBlur?: Function,
+  onChange?: Function,
+  onFocus?: Function,
+  selected: boolean,
+  skin?: ComponentType<any>,
+  theme: ?Object,
+  themeOverrides: Object
+};
+```
+
 ### Customizing Component Skins
 
 #### Theme API
 
-Each component has a theme API. This is a plain object which exposes the shape of a component's theme. Each property on the theme API object is a class name assigned to an element within the component's skin and a class definition within the component's theme. Below is the Button's theme API.
+Each component has a theme API. This is a plain object which exposes the shape of a component's theme. Each 
+property on the theme API object is a class name assigned to an element within the component's skin and a class 
+definition within the component's theme. Below is the Button's theme API.
 
-```javascript
+```js
 {
   root: '',
   disabled: ''
 }
 ```
 
-Every component accepts an optional `themeOverrides` property intended to provide a [CSS Module import object](https://github.com/css-modules/css-modules) which is used by the component to assign a user's local classnames to its DOM nodes. If the component has already been passed a theme prop, the css/scss properties passed via themeOverrides will be merged with the injected theme object. This automatic composition saves the user from manually piecing together custom styles with those of the injected theme that the user may wish to retain. If you want to customize a component's theme, the themeOverrides object must contain the appropriate classname mapping to its documented **theme API**. In this way, you can **add** or **override** classnames on the nodes of a specific component.
+Every component accepts an optional `themeOverrides` property intended to provide a 
+[CSS Module import object](https://github.com/css-modules/css-modules) which is used by the component to 
+assign a user's local classnames to its DOM nodes. If the component has already been passed a theme prop, 
+the css/scss properties passed via themeOverrides will be merged with the injected theme object. This automatic 
+composition saves the user from manually piecing together custom styles with those of the injected theme that 
+the user may wish to retain. If you want to customize a component's theme, the themeOverrides object must 
+contain the appropriate classname mapping to its documented **theme API**. In this way, you can **add** or 
+**override** classnames on the nodes of a specific component.
 
-### Overriding a styles in a theme
+### Overriding styles in a theme
 
 For example, if you want to override the background-color of `Button`'s injected theme with green:
 
@@ -472,11 +759,19 @@ will be composed with
 }
 ```
 
-In this case we are **composing** custom styles with an instance of `Button` where the Simple `ButtonTheme` was already injected. If a theme isn't passed to a component, a theme object implementing that component's full theme API is necessary. When implementing a component's full theme, take into account that every classname is there for a reason. You can either provide a component's theme as a prop or pass it through context as described in the next section.
+In this case we are **composing** custom styles with an instance of `Button` where the Simple `ButtonTheme` was 
+already injected. If a theme isn't passed to a component, a theme object implementing that component's full theme 
+API is necessary. When implementing a component's full theme, take into account that every classname is there for 
+a reason. You can either provide a component's theme as a prop or pass it through context as described in the 
+next section.
 
 ### ThemeProvider HOC
 
-`ThemeProvider` allows you to pass a theme to multiple instances of a component without explicitly passing them a theme prop. Wrap your component tree with `ThemeProvider` at the desired level in your component hierarchy. You can maintain different themes and themeOverrides for specific portions of your app's tree.
+`ThemeProvider` allows you to pass a theme to multiple instances of a component without explicitly 
+passing them a theme prop. Wrap your component tree with `ThemeProvider` at the desired level in your 
+component hierarchy. You can maintain different themes and themeOverrides for specific portions of your app's tree.
+
+#### Example Usage:
 
 ```js
 import React, { Component } from "react";
@@ -515,30 +810,35 @@ class App extends Component {
   setValue = value => this.setState({ value });
 
   render() {
+    // Custom Theme
     const SimpleTheme = {
       modal: { ...ModalTheme },
       formfield: { ...FormFieldTheme },
       input: { ...InputTheme },
       button: { ...ButtonTheme }
     };
+    // Custom Skins
+    const SimpleSkins = {
+      modal: ModalSkin,
+      formfield: FormFieldSkin,
+      input: InputSkin,
+      button: ButtonSkin,
+    };
 
     return (
-      <ThemeProvider theme={SimpleTheme}>
+      <ThemeProvider skins={SimpleSkins} theme={SimpleTheme}>
         <Modal
           isOpen={this.state.isOpen}
           triggerCloseOnOverlayClick={false}
-          skin={ModalSkin}
         >
           <div>
             <FormField
               label="FormField in Modal"
-              skin={FormFieldSkin}
               render={props => (
                 <Input
                   {...props}
                   value={this.state.value}
                   onChange={this.setValue}
-                  skin={InputSkin}
                 />
               )}
             />
@@ -549,7 +849,6 @@ class App extends Component {
               onClick={this.props.handleClick}
               className="primary"
               label="Submit"
-              skin={ButtonSkin}
             />
           </div>
         </Modal>
@@ -590,7 +889,11 @@ Create a CSS Module theme file for the component you wish to customize, for exam
 }
 ```
 
-Create a theme file that imports each component's custom styles as CSS-Modules object(s). Apply the styles according to the root theme API structure. The root theme API is simply an object whose keys are named after each component in the react-polymorph library. For example, the styles you assign to the input key will be applied to all instances of the `Input` component nested within `ThemeProvider`. The same goes for the formfield key and all nested instances of the `FormField` component.
+Create a theme file that imports each component's custom styles as CSS-Modules object(s). Apply the styles according 
+to the root theme API structure. The root theme API is simply an object whose keys are named after each component 
+in the react-polymorph library. For example, the styles you assign to the input key will be applied to all 
+instances of the `Input` component nested within `ThemeProvider`. The same goes for the formfield key and all 
+nested instances of the `FormField` component.
 
 ###### customInputs.js
 
@@ -604,7 +907,9 @@ export default {
 };
 ```
 
-Import your custom theme to pass `ThemeProvider`'s themeOverrides property. This will apply your custom css/scss to **all** of its nested react-polymorph components. In this example, all 3 instances of the `Input` and `FormField` components will have the user's custom css definitions composed with Simple InputTheme and FormFieldTheme.
+Import your custom theme to pass `ThemeProvider`'s themeOverrides property. This will apply your custom css/scss 
+to **all** of its nested react-polymorph components. In this example, all 3 instances of the `Input` and `FormField` 
+components will have the user's custom css definitions composed with Simple InputTheme and FormFieldTheme.
 
 ```js
 import React from "react";
@@ -618,7 +923,7 @@ import {
 } from "react-polymorph/lib/components";
 
 // skins
-import { FormFieldSkin, InputSkin } from "react-polymorph/lib/skins/simple";
+import { SimpleSkins } from "react-polymorph/lib/skins/simple";
 
 // themes
 import { FormFieldTheme, InputTheme } from "react-polymorph/lib/themes/simple";
@@ -633,28 +938,25 @@ const CustomInputs = props => {
   };
 
   return (
-    <ThemeProvider themeOverrides={CustomInputsTheme} theme={SimpleTheme}>
+    <ThemeProvider skins={SimpleSkins} themeOverrides={CustomInputsTheme} theme={SimpleTheme}>
       <FormField
         label="Recipient's First Name"
-        skin={FormFieldSkin}
         render={props => (
-          <Input {...props} placeholder="Avery" skin={InputSkin} />
+          <Input {...props} placeholder="Avery" />
         )}
       />
 
       <FormField
         label="Recipient's Last Name"
-        skin={FormFieldSkin}
         render={props => (
-          <Input {...props} placeholder="McKenna" skin={InputSkin} />
+          <Input {...props} placeholder="McKenna" />
         )}
       />
 
       <FormField
         label="Amount to Send"
-        skin={FormFieldSkin}
         render={props => (
-          <NumericInput {...props} placeholder="10.000" skin={InputSkin} />
+          <NumericInput {...props} placeholder="10.000" />
         )}
       />
     </ThemeProvider>
@@ -664,7 +966,8 @@ const CustomInputs = props => {
 export default CustomInputs;
 ```
 
-You may also pass the entire SimpleTheme object to `ThemeProvider` and maintain the same functionality without having to import themes specific to the components you're using.
+You may also pass the entire SimpleTheme object to `ThemeProvider` and maintain the same functionality without 
+having to import themes specific to the components you're using.
 
 ```js
 import React from "react";
@@ -672,11 +975,14 @@ import React from "react";
 // components
 import { ThemeProvider } from "react-polymorph/lib/components";
 
+// skins
+import { SimpleSkins } from "react-polymorph/lib/skins/simple";
+
 // themes
 import { SimpleTheme } from "react-polymorph/lib/themes/simple";
 
 const App = () => (
-  <ThemeProvider theme={SimpleTheme}>
+  <ThemeProvider skins={SimpleSkins} theme={SimpleTheme}>
     <div>...</div>
   </ThemeProvider>
 );

--- a/__tests__/Autocomplete.behavior.test.js
+++ b/__tests__/Autocomplete.behavior.test.js
@@ -1,7 +1,6 @@
 import React from 'react';
 
 import { Autocomplete } from '../source/components/Autocomplete';
-import { AutocompleteSkin } from '../source/skins/simple/AutocompleteSkin';
 import { mountInSimpleTheme } from './helpers/theming';
 
 const MNEMONIC_WORDS = [
@@ -37,10 +36,7 @@ const ABC_SORTED_MNEMONICS = [
 describe('Autocomplete onChange simulations', () => {
   test('Autocomplete is closed by default and when clicked is open and displays options', () => {
     const wrapper = mountInSimpleTheme(
-      <Autocomplete
-        options={MNEMONIC_WORDS}
-        skin={AutocompleteSkin}
-      />
+      <Autocomplete options={MNEMONIC_WORDS}/>
     );
     const component = wrapper.find('Autocomplete').instance();
     const input = wrapper.find('input');
@@ -50,7 +46,9 @@ describe('Autocomplete onChange simulations', () => {
     // first, via state
     expect(component.state.isOpen).toBe(false);
     // then, via classnames
-    expect(options.instance().className).toBe('options firstOptionHighlighted root isFloating isHidden');
+    expect(options.instance().className).toBe(
+      'options firstOptionHighlighted root isFloating isHidden'
+    );
 
     // open Autocomplete
     input.simulate('click', {});
@@ -60,15 +58,14 @@ describe('Autocomplete onChange simulations', () => {
     expect(component.state.isOpen).toBe(true);
     expect(component.state.filteredOptions.length).toBe(12);
     // then, via classnames
-    expect(options.instance().className).toBe('options isOpen firstOptionHighlighted root isFloating');
+    expect(options.instance().className).toBe(
+      'options isOpen firstOptionHighlighted root isFloating'
+    );
   });
 
   test('Autocomplete puts options in abc order and highlights first option by default when open', () => {
     const wrapper = mountInSimpleTheme(
-      <Autocomplete
-        options={MNEMONIC_WORDS}
-        skin={AutocompleteSkin}
-      />
+      <Autocomplete options={MNEMONIC_WORDS}/>
     );
     const component = wrapper.find('Autocomplete').instance();
     const input = wrapper.find('input');
@@ -102,10 +99,7 @@ describe('Autocomplete onChange simulations', () => {
     });
 
     const wrapper = mountInSimpleTheme(
-      <Autocomplete
-        options={MNEMONIC_WORDS}
-        skin={AutocompleteSkin}
-      />
+      <Autocomplete options={MNEMONIC_WORDS} />
     );
     const component = wrapper.find('Autocomplete').instance();
     const input = wrapper.find('input');
@@ -127,10 +121,7 @@ describe('Autocomplete onChange simulations', () => {
 
   test('Autocomplete shows correct options after user input is simulated', () => {
     const wrapper = mountInSimpleTheme(
-      <Autocomplete
-        options={MNEMONIC_WORDS}
-        skin={AutocompleteSkin}
-      />
+      <Autocomplete options={MNEMONIC_WORDS} />
     );
     const component = wrapper.find('Autocomplete').instance();
     const input = wrapper.find('input');
@@ -173,10 +164,7 @@ describe('Autocomplete onChange simulations', () => {
     });
 
     const wrapper = mountInSimpleTheme(
-      <Autocomplete
-        options={MNEMONIC_WORDS}
-        skin={AutocompleteSkin}
-      />
+      <Autocomplete options={MNEMONIC_WORDS} />
     );
     const component = wrapper.find('Autocomplete').instance();
     const input = wrapper.find('input');
@@ -202,10 +190,7 @@ describe('Autocomplete onChange simulations', () => {
     });
 
     const wrapper = mountInSimpleTheme(
-      <Autocomplete
-        options={MNEMONIC_WORDS}
-        skin={AutocompleteSkin}
-      />
+      <Autocomplete options={MNEMONIC_WORDS} />
     );
     const component = wrapper.find('Autocomplete').instance();
     const input = wrapper.find('input');
@@ -231,10 +216,7 @@ describe('Autocomplete onChange simulations', () => {
     });
 
     const wrapper = mountInSimpleTheme(
-      <Autocomplete
-        options={MNEMONIC_WORDS}
-        skin={AutocompleteSkin}
-      />
+      <Autocomplete options={MNEMONIC_WORDS} />
     );
     const component = wrapper.find('Autocomplete').instance();
     const input = wrapper.find('input');
@@ -260,10 +242,7 @@ describe('Autocomplete onChange simulations', () => {
     });
 
     const wrapper = mountInSimpleTheme(
-      <Autocomplete
-        options={MNEMONIC_WORDS}
-        skin={AutocompleteSkin}
-      />
+      <Autocomplete options={MNEMONIC_WORDS} />
     );
     const component = wrapper.find('Autocomplete').instance();
     const input = wrapper.find('input');
@@ -297,10 +276,7 @@ describe('Autocomplete onChange simulations', () => {
     });
 
     const wrapper = mountInSimpleTheme(
-      <Autocomplete
-        options={MNEMONIC_WORDS}
-        skin={AutocompleteSkin}
-      />
+      <Autocomplete options={MNEMONIC_WORDS} />
     );
     const component = wrapper.find('Autocomplete').instance();
     const input = wrapper.find('input');

--- a/__tests__/Autocomplete.test.js
+++ b/__tests__/Autocomplete.test.js
@@ -1,7 +1,6 @@
 import React from 'react';
 
 import { Autocomplete } from '../source/components/Autocomplete';
-import { AutocompleteSkin } from '../source/skins/simple/AutocompleteSkin';
 import { renderInSimpleTheme } from './helpers/theming';
 
 const OPTIONS = [
@@ -13,10 +12,7 @@ const OPTIONS = [
 
 test('Autocomplete renders correctly', () => {
   const component = renderInSimpleTheme(
-    <Autocomplete
-      options={OPTIONS}
-      skin={AutocompleteSkin}
-    />
+    <Autocomplete options={OPTIONS} />
   );
 
   const tree = component.toJSON();
@@ -28,7 +24,6 @@ test('Autocomplete renders with label', () => {
     <Autocomplete
       label="Enter your recovery phrase below"
       options={OPTIONS}
-      skin={AutocompleteSkin}
     />
   );
 
@@ -41,7 +36,6 @@ test('Autocomplete renders with a placeholder', () => {
     <Autocomplete
       placeholder="Enter recovery phrase"
       options={OPTIONS}
-      skin={AutocompleteSkin}
     />
   );
 
@@ -54,7 +48,6 @@ test('Autocomplete renders with an error', () => {
     <Autocomplete
       error="Your mnemonic phrase is incorrect"
       options={OPTIONS}
-      skin={AutocompleteSkin}
     />
   );
 
@@ -66,7 +59,6 @@ test('Autocomplete uses render prop - renderSelections', () => {
   const component = renderInSimpleTheme(
     <Autocomplete
       options={OPTIONS}
-      skin={AutocompleteSkin}
       renderSelections={getSelectionProps => {
         const { selectedOptions, removeSelection } = getSelectionProps();
 
@@ -92,7 +84,6 @@ test('Autocomplete uses render prop - renderOptions', () => {
   const component = renderInSimpleTheme(
     <Autocomplete
       options={OPTIONS}
-      skin={AutocompleteSkin}
       renderOptions={getOptionProps => {
         const { options } = getOptionProps({});
 

--- a/__tests__/Bubble.test.js
+++ b/__tests__/Bubble.test.js
@@ -1,13 +1,10 @@
 import React from 'react';
 
 import { Bubble } from '../source/components/Bubble';
-import { BubbleSkin } from '../source/skins/simple/BubbleSkin';
 import { renderInSimpleTheme } from './helpers/theming';
 
 test('Bubble renders correctly', () => {
-  const component = renderInSimpleTheme(
-    <Bubble skin={BubbleSkin} />
-  );
+  const component = renderInSimpleTheme(<Bubble />);
 
   const tree = component.toJSON();
   expect(tree).toMatchSnapshot();
@@ -15,7 +12,7 @@ test('Bubble renders correctly', () => {
 
 test('Bubble renders isOpeningUpward={true}', () => {
   const component = renderInSimpleTheme(
-    <Bubble isOpeningUpward skin={BubbleSkin} />
+    <Bubble isOpeningUpward />
   );
 
   const tree = component.toJSON();
@@ -24,7 +21,7 @@ test('Bubble renders isOpeningUpward={true}', () => {
 
 test('Bubble renders isTransparent={false}', () => {
   const component = renderInSimpleTheme(
-    <Bubble isTransparent={false} skin={BubbleSkin} />
+    <Bubble isTransparent={false} />
   );
 
   const tree = component.toJSON();
@@ -33,7 +30,7 @@ test('Bubble renders isTransparent={false}', () => {
 
 test('Bubble renders isHidden={true}', () => {
   const component = renderInSimpleTheme(
-    <Bubble isHidden skin={BubbleSkin} />
+    <Bubble isHidden />
   );
 
   const tree = component.toJSON();
@@ -42,7 +39,7 @@ test('Bubble renders isHidden={true}', () => {
 
 test('Bubble renders isFloating={true}', () => {
   const component = renderInSimpleTheme(
-    <Bubble isFloating skin={BubbleSkin} />
+    <Bubble isFloating />
   );
 
   const tree = component.toJSON();

--- a/__tests__/Button.test.js
+++ b/__tests__/Button.test.js
@@ -1,13 +1,10 @@
 import React from 'react';
 
 import { Button } from '../source/components/Button';
-import { ButtonSkin } from '../source/skins/simple/ButtonSkin';
 import { renderInSimpleTheme } from './helpers/theming';
 
 test('Button renders correctly', () => {
-  const component = renderInSimpleTheme(
-    <Button skin={ButtonSkin} />
-  );
+  const component = renderInSimpleTheme(<Button />);
 
   const tree = component.toJSON();
   expect(tree).toMatchSnapshot();
@@ -15,7 +12,7 @@ test('Button renders correctly', () => {
 
 test('Button renders with a label', () => {
   const component = renderInSimpleTheme(
-    <Button label="send" skin={ButtonSkin} />
+    <Button label="send" />
   );
 
   const tree = component.toJSON();
@@ -24,7 +21,7 @@ test('Button renders with a label', () => {
 
 test('Button is disabled', () => {
   const component = renderInSimpleTheme(
-    <Button disabled skin={ButtonSkin} />
+    <Button disabled />
   );
 
   const tree = component.toJSON();

--- a/__tests__/Checkbox.test.js
+++ b/__tests__/Checkbox.test.js
@@ -1,12 +1,11 @@
 import React from 'react';
 
 import { Checkbox } from '../source/components/Checkbox';
-import { CheckboxSkin } from '../source/skins/simple/CheckboxSkin';
 import { renderInSimpleTheme } from './helpers/theming';
 
 test('Checkbox renders correctly', () => {
   const component = renderInSimpleTheme(
-    <Checkbox skin={CheckboxSkin} />
+    <Checkbox />
   );
 
   const tree = component.toJSON();
@@ -15,7 +14,7 @@ test('Checkbox renders correctly', () => {
 
 test('Checkbox renders with a label', () => {
   const component = renderInSimpleTheme(
-    <Checkbox label="check here" skin={CheckboxSkin} />
+    <Checkbox label="check here" />
   );
 
   const tree = component.toJSON();
@@ -24,7 +23,7 @@ test('Checkbox renders with a label', () => {
 
 test('Checkbox is disabled', () => {
   const component = renderInSimpleTheme(
-    <Checkbox disabled skin={CheckboxSkin} />
+    <Checkbox disabled />
   );
 
   const tree = component.toJSON();
@@ -33,7 +32,7 @@ test('Checkbox is disabled', () => {
 
 test('Checkbox is checked', () => {
   const component = renderInSimpleTheme(
-    <Checkbox checked skin={CheckboxSkin} />
+    <Checkbox checked />
   );
 
   const tree = component.toJSON();

--- a/__tests__/FormField.test.js
+++ b/__tests__/FormField.test.js
@@ -1,17 +1,13 @@
 import React from 'react';
 
 import { FormField } from '../source/components/FormField';
-import { FormFieldSkin } from '../source/skins/simple/FormFieldSkin';
 import { renderInSimpleTheme } from './helpers/theming';
 
 const renderFormField = () => <div className="render-prop" />;
 
 test('FormField renders correctly', () => {
   const component = renderInSimpleTheme(
-    <FormField
-      skin={FormFieldSkin}
-      render={renderFormField}
-    />
+    <FormField render={renderFormField} />
   );
 
   const tree = component.toJSON();
@@ -22,7 +18,6 @@ test('FormField renders with label', () => {
   const component = renderInSimpleTheme(
     <FormField
       label="Add a Label"
-      skin={FormFieldSkin}
       render={renderFormField}
     />
   );
@@ -35,7 +30,6 @@ test('FormField renders with an error', () => {
   const component = renderInSimpleTheme(
     <FormField
       error="Add an Error"
-      skin={FormFieldSkin}
       render={renderFormField}
     />
   );
@@ -48,7 +42,6 @@ test('FormField is disabled', () => {
   const component = renderInSimpleTheme(
     <FormField
       disabled
-      skin={FormFieldSkin}
       render={({ disabled }) => <span>{disabled.toString()}</span>}
     />
   );
@@ -60,7 +53,6 @@ test('FormField is disabled', () => {
 test('FormField renders an input element', () => {
   const component = renderInSimpleTheme(
     <FormField
-      skin={FormFieldSkin}
       render={() => <input className="render-prop" />}
     />
   );

--- a/__tests__/Input.test.js
+++ b/__tests__/Input.test.js
@@ -1,12 +1,11 @@
 import React from 'react';
 
 import { Input } from '../source/components/Input';
-import { InputSkin } from '../source/skins/simple/InputSkin';
 import { renderInSimpleTheme } from './helpers/theming';
 
 test('Input renders correctly', () => {
   const component = renderInSimpleTheme(
-    <Input skin={InputSkin} />
+    <Input />
   );
 
   const tree = component.toJSON();
@@ -15,7 +14,7 @@ test('Input renders correctly', () => {
 
 test('Input renders with placeholder', () => {
   const component = renderInSimpleTheme(
-    <Input placeholder="0.0000" skin={InputSkin} />
+    <Input placeholder="0.0000" />
   );
 
   const tree = component.toJSON();
@@ -24,7 +23,7 @@ test('Input renders with placeholder', () => {
 
 test('Input renders with a value', () => {
   const component = renderInSimpleTheme(
-    <Input value="there is value" skin={InputSkin} />
+    <Input value="there is value" />
   );
 
   const tree = component.toJSON();
@@ -33,10 +32,7 @@ test('Input renders with a value', () => {
 
 test('Input is readOnly', () => {
   const component = renderInSimpleTheme(
-    <Input
-      readOnly
-      skin={InputSkin}
-    />
+    <Input readOnly />
   );
 
   const tree = component.toJSON();

--- a/__tests__/NumericInput.behavior.test.js
+++ b/__tests__/NumericInput.behavior.test.js
@@ -1,13 +1,12 @@
 import React from 'react';
 
 import { NumericInput } from '../source/components/NumericInput';
-import { InputSkin } from '../source/skins/simple/InputSkin';
 import { mountInSimpleTheme } from './helpers/theming';
 
 describe('NumericInput onChange simulations', () => {
   test('onChange updates state with valid amount', () => {
     const wrapper = mountInSimpleTheme(
-      <NumericInput skin={InputSkin} />
+      <NumericInput />
     );
 
     const component = wrapper.find('NumericInput').instance();
@@ -20,10 +19,7 @@ describe('NumericInput onChange simulations', () => {
 
   test('onChange creates error via invalid amount: value > maxValue', () => {
     const wrapper = mountInSimpleTheme(
-      <NumericInput
-        maxValue={1000}
-        skin={InputSkin}
-      />
+      <NumericInput maxValue={1000} />
     );
 
     const component = wrapper.find('NumericInput').instance();
@@ -38,10 +34,7 @@ describe('NumericInput onChange simulations', () => {
 
   test('onChange creates error via invalid amount: value < minValue', () => {
     const wrapper = mountInSimpleTheme(
-      <NumericInput
-        minValue={500}
-        skin={InputSkin}
-      />
+      <NumericInput minValue={500} />
     );
 
     const component = wrapper.find('NumericInput').instance();
@@ -56,10 +49,7 @@ describe('NumericInput onChange simulations', () => {
 
   test('onChange is passed invalid amount, maxBeforeDot is enforced correctly', () => {
     const wrapper = mountInSimpleTheme(
-      <NumericInput
-        maxBeforeDot={3}
-        skin={InputSkin}
-      />
+      <NumericInput maxBeforeDot={3} />
     );
 
     const component = wrapper.find('NumericInput').instance();
@@ -77,10 +67,7 @@ describe('NumericInput onChange simulations', () => {
 
   test('onChange is passed invalid amount, maxAfterDot is enforced correctly', () => {
     const wrapper = mountInSimpleTheme(
-      <NumericInput
-        maxAfterDot={4}
-        skin={InputSkin}
-      />
+      <NumericInput maxAfterDot={4} />
     );
 
     const component = wrapper.find('NumericInput').instance();
@@ -98,10 +85,7 @@ describe('NumericInput onChange simulations', () => {
 
   test('integers only - onChange is passed invalid amount, maxAfterDot is enforced correctly', () => {
     const wrapper = mountInSimpleTheme(
-      <NumericInput
-        maxAfterDot={0}
-        skin={InputSkin}
-      />
+      <NumericInput maxAfterDot={0} />
     );
 
     const component = wrapper.find('NumericInput').instance();
@@ -123,7 +107,6 @@ describe('NumericInput onChange simulations', () => {
         enforceMax
         maxValue={24999}
         maxAfterDot={2}
-        skin={InputSkin}
       />
     );
 
@@ -164,7 +147,6 @@ describe('NumericInput onChange simulations', () => {
         enforceMin
         minValue={99.99}
         maxAfterDot={2}
-        skin={InputSkin}
       />
     );
 

--- a/__tests__/NumericInput.test.js
+++ b/__tests__/NumericInput.test.js
@@ -1,14 +1,11 @@
 import React from 'react';
 
 import { NumericInput } from '../source/components/NumericInput';
-import { InputSkin } from '../source/skins/simple/InputSkin';
 import { renderInSimpleTheme } from './helpers/theming';
 
 test('NumericInput renders correctly', () => {
   const component = renderInSimpleTheme(
-    <NumericInput
-      skin={InputSkin}
-    />
+    <NumericInput />
   );
 
   const tree = component.toJSON();
@@ -17,10 +14,7 @@ test('NumericInput renders correctly', () => {
 
 test('NumericInput renders with placeholder', () => {
   const component = renderInSimpleTheme(
-    <NumericInput
-      placeholder="0.0000"
-      skin={InputSkin}
-    />
+    <NumericInput placeholder="0.0000" />
   );
 
   const tree = component.toJSON();
@@ -29,10 +23,7 @@ test('NumericInput renders with placeholder', () => {
 
 test('NumericInput is disabled', () => {
   const component = renderInSimpleTheme(
-    <NumericInput
-      disabled
-      skin={InputSkin}
-    />
+    <NumericInput disabled />
   );
 
   const tree = component.toJSON();
@@ -41,10 +32,7 @@ test('NumericInput is disabled', () => {
 
 test('NumericInput is readOnly', () => {
   const component = renderInSimpleTheme(
-    <NumericInput
-      readOnly
-      skin={InputSkin}
-    />
+    <NumericInput readOnly />
   );
 
   const tree = component.toJSON();
@@ -53,10 +41,7 @@ test('NumericInput is readOnly', () => {
 
 test('NumericInput renders with an error', () => {
   const component = renderInSimpleTheme(
-    <NumericInput
-      error="Invalid Amount"
-      skin={InputSkin}
-    />
+    <NumericInput error="Invalid Amount" />
   );
 
   const tree = component.toJSON();
@@ -65,10 +50,7 @@ test('NumericInput renders with an error', () => {
 
 test('NumericInput renders with a value', () => {
   const component = renderInSimpleTheme(
-    <NumericInput
-      value="555.333"
-      skin={InputSkin}
-    />
+    <NumericInput value="555.333" />
   );
 
   const tree = component.toJSON();

--- a/__tests__/Options.test.js
+++ b/__tests__/Options.test.js
@@ -1,7 +1,6 @@
 import React from 'react';
 
 import { Options } from '../source/components/Options';
-import { OptionsSkin } from '../source/skins/simple/OptionsSkin';
 import { renderInSimpleTheme } from './helpers/theming';
 
 const MNEMONIC_WORDS = [
@@ -29,10 +28,7 @@ const COUNTRIES_OPTIONS = [
 
 test('Options renders correctly', () => {
   const component = renderInSimpleTheme(
-    <Options
-      options={MNEMONIC_WORDS}
-      skin={OptionsSkin}
-    />
+    <Options options={MNEMONIC_WORDS} />
   );
 
   const tree = component.toJSON();
@@ -43,7 +39,6 @@ test('Options uses render prop - render', () => {
   const component = renderInSimpleTheme(
     <Options
       options={MNEMONIC_WORDS}
-      skin={OptionsSkin}
       render={getOptionProps => {
         const { options } = getOptionProps();
         return options.map((option, index) => (
@@ -63,7 +58,6 @@ test('Options uses render prop - optionRenderer', () => {
   const component = renderInSimpleTheme(
     <Options
       options={COUNTRIES_OPTIONS}
-      skin={OptionsSkin}
       optionRenderer={option => (
         <div>
           <span>{option.german}</span>

--- a/__tests__/Radio.test.js
+++ b/__tests__/Radio.test.js
@@ -2,12 +2,11 @@ import React from 'react';
 import renderer from 'react-test-renderer';
 
 import { Radio } from '../source/components/Radio';
-import { RadioSkin } from '../source/skins/simple/RadioSkin';
 import { renderInSimpleTheme } from './helpers/theming';
 
 test('Radio renders correctly', () => {
   const component = renderInSimpleTheme(
-    <Radio skin={RadioSkin} />
+    <Radio />
   );
 
   const tree = component.toJSON();
@@ -16,7 +15,7 @@ test('Radio renders correctly', () => {
 
 test('Radio renders with a label', () => {
   const component = renderInSimpleTheme(
-    <Radio label="click here" skin={RadioSkin} />
+    <Radio label="click here" />
   );
 
   const tree = component.toJSON();
@@ -25,7 +24,7 @@ test('Radio renders with a label', () => {
 
 test('Radio is disabled', () => {
   const component = renderInSimpleTheme(
-    <Radio disabled skin={RadioSkin} />
+    <Radio disabled />
   );
 
   const tree = component.toJSON();
@@ -34,7 +33,7 @@ test('Radio is disabled', () => {
 
 test('Radio is selected', () => {
   const component = renderInSimpleTheme(
-    <Radio selected skin={RadioSkin} />
+    <Radio selected />
   );
 
   const tree = component.toJSON();

--- a/__tests__/Select.test.js
+++ b/__tests__/Select.test.js
@@ -22,10 +22,7 @@ const COUNTRIES_DISABLED_OPTIONS = [
 
 test('Select renders correctly', () => {
   const component = renderInSimpleTheme(
-    <Select
-      options={COUNTRIES}
-      skin={SelectSkin}
-    />
+    <Select options={COUNTRIES} />
   );
 
   const tree = component.toJSON();
@@ -37,7 +34,6 @@ test('Select renders with placeholder', () => {
     <Select
       placeholder="Select your country …"
       options={COUNTRIES}
-      skin={SelectSkin}
     />
   );
 
@@ -50,7 +46,6 @@ test('Select renders with an error', () => {
     <Select
       error="Please select a different option"
       options={COUNTRIES}
-      skin={SelectSkin}
     />
   );
 
@@ -60,10 +55,7 @@ test('Select renders with an error', () => {
 
 test('Select renders with disabled options', () => {
   const component = renderInSimpleTheme(
-    <Select
-      options={COUNTRIES_DISABLED_OPTIONS}
-      skin={SelectSkin}
-    />
+    <Select options={COUNTRIES_DISABLED_OPTIONS} />
   );
 
   const tree = component.toJSON();
@@ -75,7 +67,6 @@ test('Select isOpeningUpward={true}', () => {
     <Select
       isOpeningUpward
       options={COUNTRIES}
-      skin={SelectSkin}
     />
   );
 
@@ -88,7 +79,6 @@ test('Select isOpen={true}', () => {
     <Select
       isOpen
       options={COUNTRIES}
-      skin={SelectSkin}
     />
   );
 
@@ -100,7 +90,6 @@ test('Select uses render prop - optionRenderer', () => {
   const component = renderInSimpleTheme(
     <Select
       options={COUNTRIES}
-      skin={SelectSkin}
       optionRenderer={option => (
         <div>
           <span>German: {option.label}</span>

--- a/__tests__/Switch.test.js
+++ b/__tests__/Switch.test.js
@@ -3,7 +3,7 @@ import renderer from 'react-test-renderer';
 
 import { Checkbox } from '../source/components/Checkbox';
 import { SwitchSkin } from '../source/skins/simple/SwitchSkin';
-import { IDENTIFIERS } from '../source/themes/API';
+import { IDENTIFIERS } from '../source/components';
 import { renderInSimpleTheme } from './helpers/theming';
 
 test('Switch renders correctly', () => {

--- a/__tests__/TextArea.test.js
+++ b/__tests__/TextArea.test.js
@@ -2,12 +2,11 @@ import React from 'react';
 import renderer from 'react-test-renderer';
 
 import { TextArea } from '../source/components/TextArea';
-import { TextAreaSkin } from '../source/skins/simple/TextAreaSkin';
 import { renderInSimpleTheme } from './helpers/theming';
 
 test('TextArea renders correctly', () => {
   const component = renderInSimpleTheme(
-    <TextArea skin={TextAreaSkin} />
+    <TextArea />
   );
 
   const tree = component.toJSON();
@@ -16,10 +15,7 @@ test('TextArea renders correctly', () => {
 
 test('TextArea renders with placeholder', () => {
   const component = renderInSimpleTheme(
-    <TextArea
-      placeholder="0.0000"
-      skin={TextAreaSkin}
-    />
+    <TextArea placeholder="0.0000" />
   );
 
   const tree = component.toJSON();
@@ -28,10 +24,7 @@ test('TextArea renders with placeholder', () => {
 
 test('TextArea renders with an error', () => {
   const component = renderInSimpleTheme(
-    <TextArea
-      error="Please enter valid input"
-      skin={TextAreaSkin}
-    />
+    <TextArea error="Please enter valid input" />
   );
 
   const tree = component.toJSON();
@@ -40,10 +33,7 @@ test('TextArea renders with an error', () => {
 
 test('TextArea renders with a value', () => {
   const component = renderInSimpleTheme(
-    <TextArea
-      value="this one has a value"
-      skin={TextAreaSkin}
-    />
+    <TextArea value="this one has a value" />
   );
 
   const tree = component.toJSON();
@@ -52,10 +42,7 @@ test('TextArea renders with a value', () => {
 
 test('TextArea renders with 5 rows', () => {
   const component = renderInSimpleTheme(
-    <TextArea
-      rows={5}
-      skin={TextAreaSkin}
-    />
+    <TextArea rows={5} />
   );
 
   const tree = component.toJSON();

--- a/__tests__/Toggler.test.js
+++ b/__tests__/Toggler.test.js
@@ -3,7 +3,7 @@ import renderer from 'react-test-renderer';
 
 import { Checkbox } from '../source/components/Checkbox';
 import { TogglerSkin } from '../source/skins/simple/TogglerSkin';
-import { IDENTIFIERS } from '../source/themes/API';
+import { IDENTIFIERS } from '../source/components';
 import { renderInSimpleTheme } from './helpers/theming';
 
 test('Toggler renders correctly', () => {

--- a/__tests__/helpers/theming.js
+++ b/__tests__/helpers/theming.js
@@ -4,10 +4,11 @@ import { mount } from 'enzyme';
 
 import { SimpleTheme } from '../../source/themes/simple';
 import { ThemeProvider } from '../../source/components/ThemeProvider';
+import { SimpleSkins } from '../../source/skins/simple';
 
 export const renderInSimpleTheme = (children) => (
   renderer.create(
-    <ThemeProvider theme={SimpleTheme}>
+    <ThemeProvider theme={SimpleTheme} skins={SimpleSkins}>
       {children}
     </ThemeProvider>
   )
@@ -15,7 +16,7 @@ export const renderInSimpleTheme = (children) => (
 
 export const mountInSimpleTheme = (children) => (
   mount(
-    <ThemeProvider theme={SimpleTheme}>
+    <ThemeProvider theme={SimpleTheme} skins={SimpleSkins}>
       {children}
     </ThemeProvider>
   )

--- a/source/components/Autocomplete.js
+++ b/source/components/Autocomplete.js
@@ -14,7 +14,7 @@ import { createEmptyContext, withTheme } from './HOC/withTheme';
 import { composeTheme, addThemeId, didThemePropsChange } from '../utils/themes';
 import { composeFunctions } from '../utils/props';
 
-import { IDENTIFIERS } from '../themes/API';
+import { IDENTIFIERS } from '.';
 import type { ThemeContextProp } from './HOC/withTheme';
 
 type Props = {
@@ -33,7 +33,7 @@ type Props = {
   placeholder?: string,
   renderSelections?: Function,
   renderOptions?: Function,
-  skin: ComponentType<any>,
+  skin?: ComponentType<any>,
   sortAlphabetically: boolean,
   theme: ?Object, // will take precedence over theme in context if passed
   themeId: string,
@@ -225,13 +225,15 @@ class AutocompleteBase extends Component<Props, State> {
       invalidCharsRegex,
       multipleSameSelections,
       sortAlphabetically,
-      skin: AutocompleteSkin,
+      skin,
       theme,
       themeOverrides,
       onChange,
       error,
       ...rest
     } = this.props;
+
+    const AutocompleteSkin = skin || context.skins[IDENTIFIERS.AUTOCOMPLETE];
 
     return (
       <GlobalListeners

--- a/source/components/Bubble.js
+++ b/source/components/Bubble.js
@@ -9,7 +9,7 @@ import { composeTheme, addThemeId, didThemePropsChange } from '../utils/themes';
 import { addDocumentListeners, removeDocumentListeners } from '../utils/events';
 
 // import constants
-import { IDENTIFIERS } from '../themes/API';
+import { IDENTIFIERS } from '.';
 import type { ThemeContextProp } from './HOC/withTheme';
 
 type Props = {
@@ -19,7 +19,7 @@ type Props = {
   isFloating: boolean,
   isOpeningUpward: boolean,
   isTransparent: boolean,
-  skin: ComponentType<any>,
+  skin?: ComponentType<any>,
   theme: ?Object, // takes precedence over them in context if passed
   themeId: string,
   themeOverrides: Object, // custom css/scss from user adhering to component's theme API
@@ -184,12 +184,14 @@ class BubbleBase extends Component<Props, State> {
   render() {
     // destructuring props ensures only the "...rest" get passed down
     const {
-      skin: BubbleSkin,
+      skin,
       theme,
       themeOverrides,
       context,
       ...rest
     } = this.props;
+
+    const BubbleSkin = skin || context.skins[IDENTIFIERS.BUBBLE];
 
     return (
       <BubbleSkin

--- a/source/components/Button.js
+++ b/source/components/Button.js
@@ -7,7 +7,7 @@ import { createEmptyContext, withTheme } from './HOC/withTheme';
 import { composeTheme, addThemeId, didThemePropsChange } from '../utils/themes';
 
 // import constants
-import { IDENTIFIERS } from '../themes/API';
+import { IDENTIFIERS } from '.';
 import type { ThemeContextProp } from './HOC/withTheme';
 
 type Props = {
@@ -17,7 +17,7 @@ type Props = {
   label?: string | Element<any>,
   loading: boolean,
   onClick?: Function,
-  skin: ComponentType<any>,
+  skin?: ComponentType<any>,
   theme: ?Object, // will take precedence over theme in context if passed
   themeId: string,
   themeOverrides: Object // custom css/scss from user that adheres to component's theme API
@@ -59,12 +59,14 @@ class ButtonBase extends Component<Props, State> {
   render() {
     // destructuring props ensures only the "...rest" get passed down
     const {
-      skin: ButtonSkin,
+      skin,
       theme,
       themeOverrides,
       context,
       ...rest
     } = this.props;
+
+    const ButtonSkin = skin || context.skins[IDENTIFIERS.BUTTON];
 
     return <ButtonSkin theme={this.state.composedTheme} {...rest} />;
   }

--- a/source/components/Checkbox.js
+++ b/source/components/Checkbox.js
@@ -7,7 +7,7 @@ import { createEmptyContext, withTheme } from './HOC/withTheme';
 import { composeTheme, addThemeId, didThemePropsChange } from '../utils/themes';
 
 // import constants
-import { IDENTIFIERS } from '../themes/API';
+import { IDENTIFIERS } from '.';
 import type { ThemeContextProp } from './HOC/withTheme';
 
 type Props = {
@@ -21,7 +21,7 @@ type Props = {
   onChange?: Function,
   onBlur?: Function,
   onFocus?: Function,
-  skin: ComponentType<any>,
+  skin?: ComponentType<any>,
   theme: ?Object, // will take precedence over theme in context if passed
   themeId: string,
   themeOverrides: Object
@@ -63,12 +63,14 @@ class CheckboxBase extends Component<Props, State> {
   render() {
     // destructuring props ensures only the "...rest" get passed down
     const {
-      skin: CheckboxSkin,
+      skin,
       theme,
       themeOverrides,
       context,
       ...rest
     } = this.props;
+
+    const CheckboxSkin = skin || context.skins[IDENTIFIERS.CHECKBOX];
 
     return <CheckboxSkin theme={this.state.composedTheme} {...rest} />;
   }

--- a/source/components/FormField.js
+++ b/source/components/FormField.js
@@ -7,7 +7,7 @@ import { createEmptyContext, withTheme } from './HOC/withTheme';
 import { composeTheme, addThemeId, didThemePropsChange } from '../utils/themes';
 
 // import constants
-import { IDENTIFIERS } from '../themes/API';
+import { IDENTIFIERS } from '.';
 import type { ThemeContextProp } from './HOC/withTheme';
 
 type Props = {
@@ -18,7 +18,7 @@ type Props = {
   inputRef?: Ref<*>,
   label?: string | Element<any>,
   render: Function,
-  skin: ComponentType<any>,
+  skin?: ComponentType<any>,
   theme: ?Object, // will take precedence over theme in context if passed
   themeId: string,
   themeOverrides: Object
@@ -70,7 +70,7 @@ class FormFieldBase extends Component<Props, State> {
   render() {
     // destructuring props ensures only the "...rest" get passed down
     const {
-      skin: FormFieldSkin,
+      skin,
       theme,
       themeOverrides,
       error,
@@ -78,6 +78,8 @@ class FormFieldBase extends Component<Props, State> {
       inputRef,
       ...rest
     } = this.props;
+
+    const FormFieldSkin = skin || context.skins[IDENTIFIERS.FORM_FIELD];
 
     return (
       <FormFieldSkin

--- a/source/components/HOC/ThemeContext.js
+++ b/source/components/HOC/ThemeContext.js
@@ -20,10 +20,15 @@ if (React.createContext) {
 }
 
 type Theme = {
+  skins: Object,
   theme: Object,
   ROOT_THEME_API: Object
 };
 
-const defaultContext = { theme: ROOT_THEME_API, ROOT_THEME_API };
+const defaultContext = {
+  skins: {},
+  theme: ROOT_THEME_API,
+  ROOT_THEME_API
+};
 
 export const ThemeContext: Context<Theme> = createContext(defaultContext);

--- a/source/components/HOC/withTheme.js
+++ b/source/components/HOC/withTheme.js
@@ -6,11 +6,13 @@ import { ThemeContext } from './ThemeContext';
 import { getDisplayName } from '../../utils/props';
 
 export type ThemeContextProp = {
+  skins: Object,
   theme: Object,
   ROOT_THEME_API: Object
 };
 
 export const createEmptyContext = (): ThemeContextProp => ({
+  skins: {},
   theme: {},
   ROOT_THEME_API: {}
 });

--- a/source/components/Header.js
+++ b/source/components/Header.js
@@ -8,7 +8,7 @@ import { createEmptyContext, withTheme } from './HOC/withTheme';
 import { composeTheme, addThemeId, didThemePropsChange } from '../utils/themes';
 
 // constants
-import { IDENTIFIERS } from '../themes/API';
+import { IDENTIFIERS } from '.';
 import type { ThemeContextProp } from './HOC/withTheme';
 
 type Props = {
@@ -27,7 +27,7 @@ type Props = {
   regular?: boolean,
   right?: boolean,
   left?: boolean,
-  skin: ComponentType<any>,
+  skin?: ComponentType<any>,
   theme: ?Object,
   themeId: string,
   themeOverrides: Object,
@@ -119,8 +119,9 @@ class HeaderBase extends Component <Props, State> {
   };
 
   render() {
-    const { children, className, skin: HeaderSkin, ...styleProps } = this.props;
+    const { children, className, skin, context, ...styleProps } = this.props;
 
+    const HeaderSkin = skin || context.skins[IDENTIFIERS.HEADER];
     const reducedTheme = this._assembleHeaderTheme(styleProps);
     const inlineStyles = this._assembleInlineStyles(styleProps);
 

--- a/source/components/InfiniteScroll.js
+++ b/source/components/InfiniteScroll.js
@@ -9,7 +9,7 @@ import { createEmptyContext, withTheme } from './HOC/withTheme';
 import { composeTheme, addThemeId, didThemePropsChange } from '../utils/themes';
 
 // constants
-import { IDENTIFIERS } from '../themes/API';
+import { IDENTIFIERS } from '.';
 import type { ReactElementRef } from '../utils/types.js';
 import type { ThemeContextProp } from './HOC/withTheme';
 
@@ -18,7 +18,7 @@ type Props = {
   context: ThemeContextProp,
   fetchData: Function,
   renderItems?: Function,
-  skin: ComponentType<any>,
+  skin?: ComponentType<any>,
   theme: ?Object, // will take precedence over theme in context if passed
   themeId: string,
   themeOverrides: Object,
@@ -111,8 +111,9 @@ class InfiniteScrollBase extends Component<Props, State> {
     const {
       props: {
         className,
+        context,
         renderItems,
-        skin: InfiniteScrollSkin,
+        skin,
         themeId
       },
       state: {
@@ -126,6 +127,7 @@ class InfiniteScrollBase extends Component<Props, State> {
     } = this;
 
     if (!this._isFunction(renderItems)) { return null; }
+    const InfiniteScrollSkin = skin || context.skins[IDENTIFIERS.INFINITE_SCROLL];
 
     return (
       <InfiniteScrollSkin

--- a/source/components/Input.js
+++ b/source/components/Input.js
@@ -12,7 +12,7 @@ import { createEmptyContext, withTheme } from './HOC/withTheme';
 import { composeTheme, addThemeId, didThemePropsChange } from '../utils/themes';
 
 // constants
-import { IDENTIFIERS } from '../themes/API';
+import { IDENTIFIERS } from '.';
 import type { ThemeContextProp } from './HOC/withTheme';
 
 type Props = {
@@ -31,7 +31,7 @@ type Props = {
   placeholder?: string,
   readOnly: boolean,
   setError?: Function,
-  skin: ComponentType<any>,
+  skin?: ComponentType<any>,
   theme: ?Object, // will take precedence over theme in context if passed
   themeId: string,
   themeOverrides: Object,
@@ -147,7 +147,7 @@ class InputBase extends Component<Props, State> {
   render() {
     // destructuring props ensures only the "...rest" get passed down
     const {
-      skin: InputSkin,
+      skin,
       context,
       theme,
       themeOverrides,
@@ -159,6 +159,8 @@ class InputBase extends Component<Props, State> {
       autoFocus,
       ...rest
     } = this.props;
+
+    const InputSkin = skin || context.skins[IDENTIFIERS.INPUT];
 
     return (
       <InputSkin

--- a/source/components/LoadingSpinner.js
+++ b/source/components/LoadingSpinner.js
@@ -7,14 +7,14 @@ import { createEmptyContext, withTheme } from './HOC/withTheme';
 import { composeTheme, addThemeId, didThemePropsChange } from '../utils/themes';
 
 // import constants
-import { IDENTIFIERS } from '../themes/API';
+import { IDENTIFIERS } from '.';
 import type { ThemeContextProp } from './HOC/withTheme';
 
 type Props = {
   big: boolean,
   className?: string,
   context: ThemeContextProp,
-  skin: ComponentType<any>,
+  skin?: ComponentType<any>,
   theme: ?Object, // will take precedence over theme in context if passed
   themeId: string,
   themeOverrides: Object,
@@ -58,12 +58,14 @@ class LoadingSpinnerBase extends Component<Props, State> {
   render() {
     // destructuring props ensures only the "...rest" get passed down
     const {
-      skin: LoadingSpinnerSkin,
+      skin,
       theme,
       themeOverrides,
       context,
       ...rest
     } = this.props;
+
+    const LoadingSpinnerSkin = skin || context.skins[IDENTIFIERS.LOADING_SPINNER];
 
     return <LoadingSpinnerSkin theme={this.state.composedTheme} {...rest} />;
   }

--- a/source/components/Modal.js
+++ b/source/components/Modal.js
@@ -7,7 +7,7 @@ import { createEmptyContext, withTheme } from './HOC/withTheme';
 import { composeTheme, addThemeId, didThemePropsChange } from '../utils/themes';
 
 // import constants
-import { IDENTIFIERS } from '../themes/API';
+import { IDENTIFIERS } from '.';
 import type { ThemeContextProp } from './HOC/withTheme';
 
 type Props = {
@@ -15,7 +15,7 @@ type Props = {
   context: ThemeContextProp,
   isOpen: boolean,
   onClose?: Function,
-  skin: ComponentType<any>,
+  skin?: ComponentType<any>,
   triggerCloseOnOverlayClick: boolean,
   theme: ?Object, // will take precedence over theme in context if passed
   themeId: string,
@@ -60,12 +60,14 @@ class ModalBase extends Component<Props, State> {
   render() {
     // destructuring props ensures only the "...rest" get passed down
     const {
-      skin: ModalSkin,
+      skin,
       theme,
       themeOverrides,
       context,
       ...rest
     } = this.props;
+
+    const ModalSkin = skin || context.skins[IDENTIFIERS.MODAL];
 
     return <ModalSkin theme={this.state.composedTheme} {...rest} />;
   }

--- a/source/components/NumericInput.js
+++ b/source/components/NumericInput.js
@@ -12,7 +12,7 @@ import { createEmptyContext, withTheme } from './HOC/withTheme';
 import { composeTheme, addThemeId, didThemePropsChange } from '../utils/themes';
 
 // import constants
-import { IDENTIFIERS } from '../themes/API';
+import { IDENTIFIERS } from '.';
 import type { ThemeContextProp } from './HOC/withTheme';
 
 type Props = {
@@ -34,7 +34,7 @@ type Props = {
   readOnly?: boolean,
   placeholder?: string,
   setError?: Function,
-  skin: ComponentType<any>,
+  skin?: ComponentType<any>,
   theme: ?Object, // will take precedence over theme in context if passed
   themeId: string,
   themeOverrides: Object,
@@ -464,7 +464,7 @@ class NumericInputBase extends Component<Props, State> {
   render() {
     // destructuring props ensures only the "...rest" get passed down
     const {
-      skin: InputSkin,
+      skin,
       theme,
       themeOverrides,
       onChange,
@@ -476,6 +476,8 @@ class NumericInputBase extends Component<Props, State> {
       maxAfterDot,
       ...rest
     } = this.props;
+
+    const InputSkin = skin || context.skins[IDENTIFIERS.INPUT];
 
     return (
       <InputSkin

--- a/source/components/Options.js
+++ b/source/components/Options.js
@@ -18,7 +18,7 @@ import { composeTheme, addThemeId, didThemePropsChange } from '../utils/themes';
 import { composeFunctions } from '../utils/props';
 
 // import constants
-import { IDENTIFIERS } from '../themes/API';
+import { IDENTIFIERS } from '.';
 import type { ThemeContextProp } from './HOC/withTheme';
 
 type Props = {
@@ -39,7 +39,7 @@ type Props = {
   // TODO: Why do we have two separate props for selection?
   selectedOption?: any,
   selectedOptions?: Array<any>,
-  skin: ComponentType<any>,
+  skin?: ComponentType<any>,
   targetRef?: Ref<*>,
   theme: ?Object, // if passed by user, it will take precedence over this.props.context.theme
   themeId: string,
@@ -274,7 +274,7 @@ class OptionsBase extends Component<Props, State> {
   render() {
     // destructuring props ensures only the "...rest" get passed down
     const {
-      skin: OptionsSkin,
+      skin,
       targetRef,
       theme,
       themeOverrides,
@@ -286,6 +286,8 @@ class OptionsBase extends Component<Props, State> {
     } = this.props;
 
     const { composedTheme, highlightedOptionIndex } = this.state;
+
+    const OptionsSkin = skin || context.skins[IDENTIFIERS.OPTIONS];
 
     return (
       <OptionsSkin

--- a/source/components/ProgressBar.js
+++ b/source/components/ProgressBar.js
@@ -7,7 +7,7 @@ import { createEmptyContext, withTheme } from './HOC/withTheme';
 import { composeTheme, addThemeId, didThemePropsChange } from '../utils/themes';
 
 // import constants
-import { IDENTIFIERS } from '../themes/API';
+import { IDENTIFIERS } from '.';
 import type { ThemeContextProp } from './HOC/withTheme';
 
 type Props = {
@@ -15,7 +15,7 @@ type Props = {
   context: ThemeContextProp,
   label?: string,
   progress: number,
-  skin: ComponentType<any>,
+  skin?: ComponentType<any>,
   theme: ?Object, // will take precedence over theme in context if passed
   themeId: string,
   themeOverrides: Object // custom css/scss from user that adheres to component's theme API
@@ -57,12 +57,14 @@ class ProgressBarBase extends Component<Props, State> {
   render() {
     // destructuring props ensures only the "...rest" get passed down
     const {
-      skin: ProgressBarSkin,
+      skin,
       theme,
       themeOverrides,
       context,
       ...rest
     } = this.props;
+
+    const ProgressBarSkin = skin || context.skins[IDENTIFIERS.PROGRESS_BAR];
 
     return <ProgressBarSkin theme={this.state.composedTheme} {...rest} />;
   }

--- a/source/components/Radio.js
+++ b/source/components/Radio.js
@@ -7,7 +7,7 @@ import { createEmptyContext, withTheme } from './HOC/withTheme';
 import { composeTheme, addThemeId, didThemePropsChange } from '../utils/themes';
 
 // import constants
-import { IDENTIFIERS } from '../themes/API';
+import { IDENTIFIERS } from '.';
 import type { ThemeContextProp } from './HOC/withTheme';
 
 type Props = {
@@ -18,7 +18,7 @@ type Props = {
   onChange?: Function,
   onFocus?: Function,
   selected: boolean,
-  skin: ComponentType<any>,
+  skin?: ComponentType<any>,
   theme: ?Object, // will take precedence over theme in context if passed
   themeId: string,
   themeOverrides: Object
@@ -60,12 +60,14 @@ class RadioBase extends Component<Props, State> {
   render() {
     // destructuring props ensures only the "...rest" get passed down
     const {
-      skin: RadioSkin,
+      skin,
       theme,
       themeOverrides,
       context,
       ...rest
     } = this.props;
+
+    const RadioSkin = skin || context.skins[IDENTIFIERS.RADIO];
 
     return <RadioSkin theme={this.state.composedTheme} {...rest} />;
   }

--- a/source/components/Select.js
+++ b/source/components/Select.js
@@ -11,7 +11,7 @@ import { createEmptyContext, withTheme } from './HOC/withTheme';
 import { composeTheme, addThemeId, didThemePropsChange } from '../utils/themes';
 
 // import constants
-import { IDENTIFIERS } from '../themes/API';
+import { IDENTIFIERS } from '.';
 import type { ThemeContextProp } from './HOC/withTheme';
 
 type Props = {
@@ -28,7 +28,7 @@ type Props = {
   optionRenderer?: Function,
   options: Array<any>,
   placeholder?: string,
-  skin: ComponentType<any>,
+  skin?: ComponentType<any>,
   theme: ?Object, // will take precedence over theme in context if passed
   themeId: string,
   themeOverrides: Object,
@@ -128,7 +128,7 @@ class SelectBase extends Component<Props, State> {
   render() {
     // destructuring props ensures only the "...rest" get passed down
     const {
-      skin: SelectSkin,
+      skin,
       theme,
       themeOverrides,
       autoFocus,
@@ -136,6 +136,8 @@ class SelectBase extends Component<Props, State> {
       allowBlank,
       ...rest
     } = this.props;
+
+    const SelectSkin = skin || context.skins[IDENTIFIERS.SELECT];
 
     return (
       <GlobalListeners

--- a/source/components/TextArea.js
+++ b/source/components/TextArea.js
@@ -11,7 +11,7 @@ import { createEmptyContext, withTheme } from './HOC/withTheme';
 import { composeTheme, addThemeId, didThemePropsChange } from '../utils/themes';
 
 // import constants
-import { IDENTIFIERS } from '../themes/API';
+import { IDENTIFIERS } from '.';
 import type { ThemeContextProp } from './HOC/withTheme';
 
 type Props = {
@@ -29,7 +29,7 @@ type Props = {
   onFocus?: Function,
   placeholder?: string,
   rows?: number,
-  skin: ComponentType<any>,
+  skin?: ComponentType<any>,
   theme: ?Object, // will take precedence over theme in context if passed
   themeId: string,
   themeOverrides: Object,
@@ -110,7 +110,7 @@ class TextAreaBase extends Component<Props, State> {
     const { textareaElement } = this;
     if (!textareaElement.current) return;
     textareaElement.current.focus();
-  }
+  };
 
   onChange = (event: SyntheticInputEvent<>) => {
     const { onChange, disabled } = this.props;
@@ -177,7 +177,7 @@ class TextAreaBase extends Component<Props, State> {
   render() {
     // destructuring props ensures only the "...rest" get passed down
     const {
-      skin: TextAreaSkin,
+      skin,
       theme,
       themeOverrides,
       onChange,
@@ -187,6 +187,8 @@ class TextAreaBase extends Component<Props, State> {
       autoResize,
       ...rest
     } = this.props;
+
+    const TextAreaSkin = skin || context.skins[IDENTIFIERS.TEXT_AREA];
 
     return (
       <TextAreaSkin

--- a/source/components/ThemeProvider.js
+++ b/source/components/ThemeProvider.js
@@ -18,18 +18,21 @@ import { hasProperty } from '../utils/props';
 
 type Props = {
   children?: ?Node,
+  skins: Object,
   theme: Object,
   themeOverrides: Object // custom css/scss from user that adheres to shape of ROOT_THEME_API
 };
 
 type State = {
-  theme: Object
+  theme: Object,
 };
 
 export class ThemeProvider extends Component<Props, State> {
   // define static properties
   static displayName = 'ThemeProvider';
   static defaultProps = {
+    skins: {},
+    theme: {},
     themeOverrides: {}
   };
 
@@ -123,7 +126,8 @@ export class ThemeProvider extends Component<Props, State> {
 
   render() {
     const { theme } = this.state;
-    const providerState = { theme, ROOT_THEME_API };
+    const { skins } = this.props;
+    const providerState = { skins, theme, ROOT_THEME_API };
 
     return (
       <ThemeContext.Provider value={providerState}>

--- a/source/components/Tooltip.js
+++ b/source/components/Tooltip.js
@@ -7,7 +7,7 @@ import { createEmptyContext, withTheme } from './HOC/withTheme';
 import { composeTheme, addThemeId, didThemePropsChange } from '../utils/themes';
 
 // import constants
-import { IDENTIFIERS } from '../themes/API';
+import { IDENTIFIERS } from '.';
 import type { ThemeContextProp } from './HOC/withTheme';
 
 type Props = {
@@ -17,7 +17,7 @@ type Props = {
   isBounded?: boolean,
   isOpeningUpward: boolean,
   isTransparent: boolean,
-  skin: ComponentType<any>,
+  skin?: ComponentType<any>,
   theme: ?Object, // will take precedence over theme in context if passed
   themeOverrides: Object, // custom css/scss from user that adheres to component's theme API
   themeId: string,
@@ -60,7 +60,9 @@ class TooltipBase extends Component<Props, State> {
 
   render() {
     // destructuring props ensures only the "...rest" get passed down
-    const { skin: TooltipSkin, theme, themeOverrides, context, ...rest } = this.props;
+    const { skin, theme, themeOverrides, context, ...rest } = this.props;
+
+    const TooltipSkin = skin || context.skins[IDENTIFIERS.TOOLTIP];
 
     return <TooltipSkin theme={this.state.composedTheme} {...rest} />;
   }

--- a/source/components/index.js
+++ b/source/components/index.js
@@ -1,0 +1,24 @@
+// @flow
+export const IDENTIFIERS = {
+  AUTOCOMPLETE: 'autocomplete',
+  BUBBLE: 'bubble',
+  BUTTON: 'button',
+  CHECKBOX: 'checkbox',
+  FLEX: 'flex',
+  FORM_FIELD: 'formfield',
+  GRID: 'grid',
+  GUTTER: 'gutter',
+  HEADER: 'header',
+  INFINITE_SCROLL: 'infinitescroll',
+  INPUT: 'input',
+  LOADING_SPINNER: 'loadingspinner',
+  MODAL: 'modal',
+  OPTIONS: 'options',
+  PROGRESS_BAR: 'progressbar',
+  RADIO: 'radio',
+  SELECT: 'select',
+  SWITCH: 'switch',
+  TEXT_AREA: 'textarea',
+  TOGGLER: 'toggler',
+  TOOLTIP: 'tooltip'
+};

--- a/source/components/layout/Flex.js
+++ b/source/components/layout/Flex.js
@@ -11,7 +11,7 @@ import { createEmptyContext, withTheme } from '../HOC/withTheme';
 import { composeTheme, addThemeId, didThemePropsChange } from '../../utils/themes';
 
 // constants
-import { IDENTIFIERS } from '../../themes/API';
+import { IDENTIFIERS } from '..';
 import type { ThemeContextProp } from '../HOC/withTheme';
 
 type Props = {

--- a/source/components/layout/Grid.js
+++ b/source/components/layout/Grid.js
@@ -13,7 +13,7 @@ import { formatTemplateAreas } from '../../utils/layout';
 import { composeTheme, addThemeId, didThemePropsChange } from '../../utils/themes';
 
 // constants
-import { IDENTIFIERS } from '../../themes/API';
+import { IDENTIFIERS } from '..';
 import type { ThemeContextProp } from '../HOC/withTheme';
 
 type Props = {

--- a/source/components/layout/Gutter.js
+++ b/source/components/layout/Gutter.js
@@ -11,7 +11,7 @@ import { composeTheme, addThemeId, didThemePropsChange } from '../../utils/theme
 import { numberToPx } from '../../utils/props';
 
 // constants
-import { IDENTIFIERS } from '../../themes/API';
+import { IDENTIFIERS } from '..';
 import type { ThemeContextProp } from '../HOC/withTheme';
 
 type Props = {

--- a/source/skins/simple/ButtonSpinnerSkin.js
+++ b/source/skins/simple/ButtonSpinnerSkin.js
@@ -13,7 +13,7 @@ import { LoadingSpinnerSkin } from './LoadingSpinnerSkin';
 import { pickDOMProps } from '../../utils/props';
 
 // constants
-import { IDENTIFIERS } from '../../themes/API';
+import { IDENTIFIERS } from '../../components';
 
 type Props = {
   className: string,

--- a/source/skins/simple/index.js
+++ b/source/skins/simple/index.js
@@ -1,0 +1,41 @@
+// @flow
+import { IDENTIFIERS } from '../../components';
+import { AutocompleteSkin } from './AutocompleteSkin';
+import { BubbleSkin } from './BubbleSkin';
+import { ButtonSkin } from './ButtonSkin';
+import { CheckboxSkin } from './CheckboxSkin';
+import { FormFieldSkin } from './FormFieldSkin';
+import { HeaderSkin } from './HeaderSkin';
+import { InfiniteScrollSkin } from './InfiniteScrollSkin';
+import { InputSkin } from './InputSkin';
+import { LoadingSpinnerSkin } from './LoadingSpinnerSkin';
+import { ModalSkin } from './ModalSkin';
+import { OptionsSkin } from './OptionsSkin';
+import { ProgressBarSkin } from './ProgressBarSkin';
+import { RadioSkin } from './RadioSkin';
+import { SelectSkin } from './SelectSkin';
+import { SwitchSkin } from './SwitchSkin';
+import { TextAreaSkin } from './TextAreaSkin';
+import { TogglerSkin } from './TogglerSkin';
+import { TooltipSkin } from './TooltipSkin';
+
+export const SimpleSkins = {
+  [IDENTIFIERS.AUTOCOMPLETE]: AutocompleteSkin,
+  [IDENTIFIERS.BUBBLE]: BubbleSkin,
+  [IDENTIFIERS.BUTTON]: ButtonSkin,
+  [IDENTIFIERS.CHECKBOX]: CheckboxSkin,
+  [IDENTIFIERS.FORM_FIELD]: FormFieldSkin,
+  [IDENTIFIERS.HEADER]: HeaderSkin,
+  [IDENTIFIERS.INFINITE_SCROLL]: InfiniteScrollSkin,
+  [IDENTIFIERS.INPUT]: InputSkin,
+  [IDENTIFIERS.LOADING_SPINNER]: LoadingSpinnerSkin,
+  [IDENTIFIERS.MODAL]: ModalSkin,
+  [IDENTIFIERS.OPTIONS]: OptionsSkin,
+  [IDENTIFIERS.PROGRESS_BAR]: ProgressBarSkin,
+  [IDENTIFIERS.RADIO]: RadioSkin,
+  [IDENTIFIERS.SELECT]: SelectSkin,
+  [IDENTIFIERS.SWITCH]: SwitchSkin,
+  [IDENTIFIERS.TEXT_AREA]: TextAreaSkin,
+  [IDENTIFIERS.TOGGLER]: TogglerSkin,
+  [IDENTIFIERS.TOOLTIP]: TooltipSkin
+};

--- a/source/themes/API/index.js
+++ b/source/themes/API/index.js
@@ -1,4 +1,5 @@
 // @flow
+import { IDENTIFIERS } from '../../components';
 import { AUTOCOMPLETE_THEME_API } from './autocomplete';
 import { BUBBLE_THEME_API } from './bubble';
 import { BUTTON_THEME_API } from './button';
@@ -20,30 +21,6 @@ import { SWITCH_THEME_API } from './switch';
 import { TEXT_AREA_THEME_API } from './textarea';
 import { TOGGLER_THEME_API } from './toggler';
 import { TOOLTIP_THEME_API } from './tooltip';
-
-export const IDENTIFIERS = {
-  AUTOCOMPLETE: 'autocomplete',
-  BUBBLE: 'bubble',
-  BUTTON: 'button',
-  CHECKBOX: 'checkbox',
-  FLEX: 'flex',
-  FORM_FIELD: 'formfield',
-  GRID: 'grid',
-  GUTTER: 'gutter',
-  HEADER: 'header',
-  INFINITE_SCROLL: 'infinitescroll',
-  INPUT: 'input',
-  LOADING_SPINNER: 'loadingspinner',
-  MODAL: 'modal',
-  OPTIONS: 'options',
-  PROGRESS_BAR: 'progressbar',
-  RADIO: 'radio',
-  SELECT: 'select',
-  SWITCH: 'switch',
-  TEXT_AREA: 'textarea',
-  TOGGLER: 'toggler',
-  TOOLTIP: 'tooltip'
-};
 
 export const ROOT_THEME_API = {
   [IDENTIFIERS.AUTOCOMPLETE]: AUTOCOMPLETE_THEME_API,

--- a/source/themes/simple/index.js
+++ b/source/themes/simple/index.js
@@ -1,6 +1,6 @@
 // @flow
 // import theme IDENTIFIERS constants
-import { IDENTIFIERS } from '../API';
+import { IDENTIFIERS } from '../../components';
 
 // css modules plugin converts all imports below into plain objects
 import SimpleAutocomplete from './SimpleAutocomplete.scss';

--- a/stories/Autocomplete.stories.js
+++ b/stories/Autocomplete.stories.js
@@ -12,11 +12,6 @@ import { Autocomplete } from '../source/components/Autocomplete';
 import { Modal } from '../source/components/Modal';
 import { Button } from '../source/components/Button';
 
-// skins
-import { AutocompleteSkin } from '../source/skins/simple/AutocompleteSkin';
-import { ModalSkin } from '../source/skins/simple/ModalSkin';
-import { ButtonSkin } from '../source/skins/simple/ButtonSkin';
-
 // themes
 import CustomAutocompleteTheme from './theme-customizations/Autocomplete.custom.scss';
 
@@ -50,18 +45,17 @@ storiesOf('Autocomplete', module)
   // ====== Stories ======
 
   .add('Enter mnemonics - plain', () => (
-    <Autocomplete skin={AutocompleteSkin} />
+    <Autocomplete />
   ))
 
   .add('Enter mnemonics - label', () => (
-    <Autocomplete label="Recovery phrase" skin={AutocompleteSkin} />
+    <Autocomplete label="Recovery phrase" />
   ))
 
   .add('Enter mnemonics - placeholder', () => (
     <Autocomplete
       label="Recovery phrase"
       placeholder="Enter recovery phrase"
-      skin={AutocompleteSkin}
     />
   ))
 
@@ -70,7 +64,6 @@ storiesOf('Autocomplete', module)
       label="Recovery phrase"
       placeholder="Enter recovery phrase"
       error="Please enter mnemonics in right order"
-      skin={AutocompleteSkin}
     />
   ))
 
@@ -83,7 +76,6 @@ storiesOf('Autocomplete', module)
         sortAlphabetically={false}
         multipleSameSelections={false}
         maxSelections={9}
-        skin={AutocompleteSkin}
         onChange={selectedOpts => store.set({ selectedOpts })}
       />
     ))
@@ -96,7 +88,6 @@ storiesOf('Autocomplete', module)
         options={OPTIONS}
         placeholder="Enter mnemonic..."
         maxSelections={9}
-        skin={AutocompleteSkin}
         onChange={selectedOpts => store.set({ selectedOpts })}
       />
     ))
@@ -110,7 +101,6 @@ storiesOf('Autocomplete', module)
         placeholder="Enter mnemonic..."
         maxSelections={12}
         maxVisibleOptions={5}
-        skin={AutocompleteSkin}
         onChange={selectedOpts => store.set({ selectedOpts })}
       />
     ))
@@ -126,7 +116,6 @@ storiesOf('Autocomplete', module)
         placeholder="Enter mnemonic..."
         maxSelections={12}
         maxVisibleOptions={5}
-        skin={AutocompleteSkin}
         onChange={selectedOpts => store.set({ selectedOpts })}
       />
     ))
@@ -141,7 +130,6 @@ storiesOf('Autocomplete', module)
         maxSelections={12}
         maxVisibleOptions={5}
         invalidCharsRegex={/[^a-zA-Z]/g}
-        skin={AutocompleteSkin}
         onChange={selectedOpts => store.set({ selectedOpts })}
       />
     ))
@@ -154,7 +142,6 @@ storiesOf('Autocomplete', module)
           <Modal
             isOpen={store.state.isOpen}
             triggerCloseOnOverlayClick={false}
-            skin={ModalSkin}
             onClose={() => store.set({ isOpen: false })}
           >
             <div className={styles.dialogWrapper}>
@@ -169,7 +156,6 @@ storiesOf('Autocomplete', module)
                   maxSelections={12}
                   maxVisibleOptions={5}
                   invalidCharsRegex={/[^a-zA-Z]/g}
-                  skin={AutocompleteSkin}
                   onChange={selectedOpts => store.set({ selectedOpts })}
                 />
               </div>
@@ -178,7 +164,6 @@ storiesOf('Autocomplete', module)
                   onClick={() => store.set({ isOpen: false })}
                   className="primary"
                   label="Submit"
-                  skin={ButtonSkin}
                 />
               </div>
             </div>
@@ -205,7 +190,6 @@ storiesOf('Autocomplete', module)
           label="Recovery phrase"
           options={OPTIONS}
           placeholder="Enter mnemonic..."
-          skin={AutocompleteSkin}
         />
         <button onClick={() => autocompleteRef.current.clear()}>clear</button>
       </div>
@@ -222,7 +206,6 @@ storiesOf('Autocomplete', module)
         multipleSameSelections={false}
         maxSelections={7}
         maxVisibleOptions={7}
-        skin={AutocompleteSkin}
         onChange={selectedOpts => store.set({ selectedOpts })}
         renderSelections={getSelectionProps => {
           const {
@@ -267,7 +250,6 @@ storiesOf('Autocomplete', module)
         multipleSameSelections
         maxSelections={10}
         maxVisibleOptions={7}
-        skin={AutocompleteSkin}
         onChange={selectedOpts => store.set({ selectedOpts })}
         renderOptions={getOptionProps => {
           const {
@@ -337,7 +319,6 @@ storiesOf('Autocomplete', module)
         maxSelections={12}
         maxVisibleOptions={5}
         invalidCharsRegex={/[^a-zA-Z]/g}
-        skin={AutocompleteSkin}
         onChange={selectedOpts => store.set({ selectedOpts })}
       />
     ))
@@ -353,7 +334,6 @@ storiesOf('Autocomplete', module)
         maxSelections={12}
         maxVisibleOptions={5}
         invalidCharsRegex={/[^a-zA-Z]/g}
-        skin={AutocompleteSkin}
         onChange={selectedOpts => store.set({ selectedOpts })}
       />
     ))

--- a/stories/Bubble.stories.js
+++ b/stories/Bubble.stories.js
@@ -7,9 +7,6 @@ import { storiesOf } from '@storybook/react';
 // components
 import { Bubble } from '../source/components/Bubble';
 
-// skins
-import { BubbleSkin } from '../source/skins/simple/BubbleSkin';
-
 // themes
 import BubbleCustomTheme from './theme-customizations/Bubble.custom.scss';
 
@@ -28,13 +25,13 @@ storiesOf('Bubble', module)
 
   .add('plain', () => (
     <div className={styles.container}>
-      <Bubble skin={BubbleSkin}>plain bubble</Bubble>
+      <Bubble>plain bubble</Bubble>
     </div>
   ))
 
   .add('isOpeningUpward', () => (
     <div className={styles.container}>
-      <Bubble isOpeningUpward skin={BubbleSkin}>
+      <Bubble isOpeningUpward>
         isOpeningUpward bubble
       </Bubble>
     </div>
@@ -42,7 +39,7 @@ storiesOf('Bubble', module)
 
   .add('isTransparent={false}', () => (
     <div className={styles.container}>
-      <Bubble isTransparent={false} skin={BubbleSkin}>
+      <Bubble isTransparent={false}>
         solid bubble
       </Bubble>
     </div>
@@ -50,7 +47,7 @@ storiesOf('Bubble', module)
 
   .add('custom class', () => (
     <div className={styles.container}>
-      <Bubble className={styles.customBubble} skin={BubbleSkin}>
+      <Bubble className={styles.customBubble}>
         this bubble is right aligned;
       </Bubble>
     </div>
@@ -59,7 +56,7 @@ storiesOf('Bubble', module)
   .add('isHidden', () => (
     <div className={styles.container}>
       There should be no bubble shown!
-      <Bubble isHidden skin={BubbleSkin}>
+      <Bubble isHidden>
         should not be visible!
       </Bubble>
     </div>
@@ -68,7 +65,7 @@ storiesOf('Bubble', module)
   .add('isFloating', () => (
     <div className={styles.scrollContainer}>
       <div className={styles.scrollContent}>
-        <Bubble isFloating skin={BubbleSkin}>
+        <Bubble isFloating>
           floating above scroll content
         </Bubble>
       </div>
@@ -84,7 +81,6 @@ storiesOf('Bubble', module)
       <Bubble
         isTransparent={false}
         themeOverrides={themeOverrides}
-        skin={BubbleSkin}
       >
         theme overrides
       </Bubble>
@@ -93,7 +89,7 @@ storiesOf('Bubble', module)
 
   .add('custom theme', () => (
     <div className={styles.container}>
-      <Bubble isTransparent={false} theme={BubbleCustomTheme} skin={BubbleSkin}>
+      <Bubble isTransparent={false} theme={BubbleCustomTheme}>
         custom theme
       </Bubble>
     </div>

--- a/stories/Button.stories.js
+++ b/stories/Button.stories.js
@@ -8,7 +8,6 @@ import { storiesOf } from '@storybook/react';
 import { Button } from '../source/components/Button';
 
 // skins
-import { ButtonSkin } from '../source/skins/simple/ButtonSkin';
 import { ButtonSpinnerSkin } from '../source/skins/simple/ButtonSpinnerSkin';
 
 // themes
@@ -26,10 +25,10 @@ storiesOf('Button', module)
 
   // ====== Stories ======
 
-  .add('plain', () => <Button label="Button label" skin={ButtonSkin} />)
+  .add('plain', () => <Button label="Button label" />)
 
   .add('disabled', () => (
-    <Button disabled label="Button label" skin={ButtonSkin} />
+    <Button disabled label="Button label" />
   ))
 
   .add('with LoadingSpinner', () => (
@@ -40,10 +39,9 @@ storiesOf('Button', module)
     <Button
       label="theme overrides"
       themeOverrides={themeOverrides}
-      skin={ButtonSkin}
     />
   ))
 
   .add('custom theme', () => (
-    <Button label="Custom theme" theme={CustomButtonTheme} skin={ButtonSkin} />
+    <Button label="Custom theme" theme={CustomButtonTheme} />
   ));

--- a/stories/Header.stories.js
+++ b/stories/Header.stories.js
@@ -7,9 +7,6 @@ import { storiesOf } from '@storybook/react';
 // components
 import { Header } from '../source/components/Header';
 
-// skins
-import { HeaderSkin } from '../source/skins/simple/HeaderSkin';
-
 // themes
 import CustomTheme from './theme-customizations/Header.custom.scss';
 
@@ -26,39 +23,31 @@ storiesOf('Header', module)
 
   .add('positioning', () => (
     <div className={styles.wrapper}>
-      <Header left skin={HeaderSkin}>
-        Wallet Name - left
-      </Header>
-
-      <Header center skin={HeaderSkin}>
-        Wallet Name - center
-      </Header>
-
-      <Header right skin={HeaderSkin}>
-        Wallet Name - right
-      </Header>
+      <Header left>Wallet Name - left</Header>
+      <Header center>Wallet Name - center</Header>
+      <Header right>Wallet Name - right</Header>
     </div>
   ))
 
   .add('font', () => (
     <div className={styles.wrapper}>
-      <Header thin themeOverrides={custom} skin={HeaderSkin}>
+      <Header thin themeOverrides={custom}>
         Wallet Name - thin
       </Header>
 
-      <Header light themeOverrides={custom} skin={HeaderSkin}>
+      <Header light themeOverrides={custom}>
         Wallet Name - light
       </Header>
 
-      <Header regular themeOverrides={custom} skin={HeaderSkin}>
+      <Header regular themeOverrides={custom}>
         Wallet Name - regular
       </Header>
 
-      <Header medium themeOverrides={custom} skin={HeaderSkin}>
+      <Header medium themeOverrides={custom}>
         Wallet Name - medium
       </Header>
 
-      <Header bold themeOverrides={custom} skin={HeaderSkin}>
+      <Header bold themeOverrides={custom}>
         Wallet Name - bold
       </Header>
     </div>
@@ -66,11 +55,11 @@ storiesOf('Header', module)
 
   .add('text', () => (
     <div className={styles.wrapper}>
-      <Header lowerCase skin={HeaderSkin}>
+      <Header lowerCase>
         Wallet Name - lowerCase
       </Header>
 
-      <Header upperCase skin={HeaderSkin}>
+      <Header upperCase>
         Wallet Name - upperCase
       </Header>
     </div>
@@ -78,19 +67,19 @@ storiesOf('Header', module)
 
   .add('simple theme', () => (
     <div className={styles.wrapper}>
-      <Header h1 skin={HeaderSkin}>
+      <Header h1>
         Wallet Name - h1
       </Header>
 
-      <Header h2 skin={HeaderSkin}>
+      <Header h2>
         Wallet Name - h2
       </Header>
 
-      <Header h3 skin={HeaderSkin}>
+      <Header h3>
         Wallet Name - h3
       </Header>
 
-      <Header h4 skin={HeaderSkin}>
+      <Header h4>
         Wallet Name - h4
       </Header>
     </div>
@@ -98,19 +87,19 @@ storiesOf('Header', module)
 
   .add('override theme - props', () => (
     <div className={styles.wrapper}>
-      <Header h1 lowerCase skin={HeaderSkin}>
+      <Header h1 lowerCase>
         Wallet Name - h1 lowerCase
       </Header>
 
-      <Header h2 left skin={HeaderSkin}>
+      <Header h2 left>
         Wallet Name - h2 left
       </Header>
 
-      <Header h3 right skin={HeaderSkin}>
+      <Header h3 right>
         Wallet Name - h3 right
       </Header>
 
-      <Header h4 upperCase skin={HeaderSkin}>
+      <Header h4 upperCase>
         Wallet Name - h4 upperCase
       </Header>
     </div>
@@ -118,19 +107,19 @@ storiesOf('Header', module)
 
   .add('override theme - themeOverrides', () => (
     <div className={styles.wrapper}>
-      <Header h1 themeOverrides={custom} skin={HeaderSkin}>
+      <Header h1 themeOverrides={custom}>
         Wallet Name - h1
       </Header>
 
-      <Header h2 themeOverrides={custom} skin={HeaderSkin}>
+      <Header h2 themeOverrides={custom}>
         Wallet Name - h2
       </Header>
 
-      <Header h3 themeOverrides={custom} skin={HeaderSkin}>
+      <Header h3 themeOverrides={custom}>
         Wallet Name - h3
       </Header>
 
-      <Header h4 themeOverrides={custom} skin={HeaderSkin}>
+      <Header h4 themeOverrides={custom}>
         Wallet Name - h4
       </Header>
     </div>
@@ -138,13 +127,13 @@ storiesOf('Header', module)
 
   .add('override combo - props & themeOverrides', () => (
     <div className={styles.wrapper}>
-      <Header h3 upperCase left themeOverrides={custom} skin={HeaderSkin}>
+      <Header h3 upperCase left themeOverrides={custom}>
         Wallet Name - h3
       </Header>
-      <Header h3 upperCase right themeOverrides={custom} skin={HeaderSkin}>
+      <Header h3 upperCase right themeOverrides={custom}>
         Wallet Name - h3
       </Header>
-      <Header h3 lowerCase center themeOverrides={custom} skin={HeaderSkin}>
+      <Header h3 lowerCase center themeOverrides={custom}>
         Wallet Name - h3
       </Header>
     </div>
@@ -152,10 +141,10 @@ storiesOf('Header', module)
 
   .add('custom theme', () => (
     <div className={styles.wrapper}>
-      <Header h1 theme={CustomTheme} skin={HeaderSkin}>
+      <Header h1 theme={CustomTheme}>
         My Custom Theme
       </Header>
-      <Header h1 center upperCase theme={CustomTheme} skin={HeaderSkin}>
+      <Header h1 center upperCase theme={CustomTheme}>
         My Custom Theme with Prop Overrides
       </Header>
     </div>

--- a/stories/InfiniteScroll.stories.js
+++ b/stories/InfiniteScroll.stories.js
@@ -11,11 +11,6 @@ import { LoadingSpinner } from '../source/components/LoadingSpinner';
 import { Flex } from '../source/components/layout/Flex';
 import { FlexItem } from '../source/components/layout/FlexItem';
 
-// skins
-import { InfiniteScrollSkin } from '../source/skins/simple/InfiniteScrollSkin';
-import { HeaderSkin } from '../source/skins/simple/HeaderSkin';
-import { LoadingSpinnerSkin } from '../source/skins/simple/LoadingSpinnerSkin';
-
 // styles && theme overrides
 import styles from './InfiniteScroll.stories.scss';
 import themeOverrides from './theme-overrides/customInfiniteScroll.scss';
@@ -33,7 +28,6 @@ storiesOf('InfiniteScroll', module)
   .add('simple', () => (
     <Flex center className={full}>
       <InfiniteScroll
-        skin={InfiniteScrollSkin}
         themeOverrides={themeOverrides}
         fetchData={setState => {
           setState({ isLoading: true }, async () => {
@@ -62,10 +56,10 @@ storiesOf('InfiniteScroll', module)
             {data.map((user, index) => (
               <FlexItem key={index} theme={theme}>
                 <div style={{ marginBottom: '5px' }}>
-                  <Header bold h2 left skin={HeaderSkin}>
+                  <Header bold h2 left>
                     {user.name.first} {user.name.last}
                   </Header>
-                  <Header h3 left skin={HeaderSkin}>
+                  <Header h3 left>
                     {user.email}
                   </Header>
                 </div>
@@ -78,7 +72,7 @@ storiesOf('InfiniteScroll', module)
             {!hasMoreData && <div>End of Users</div>}
             {isLoading && (
               <FlexItem className={spinner}>
-                <LoadingSpinner big skin={LoadingSpinnerSkin} />
+                <LoadingSpinner big />
               </FlexItem>
             )}
             {error && <div>Error</div>}

--- a/stories/Input.stories.js
+++ b/stories/Input.stories.js
@@ -9,9 +9,6 @@ import { withState } from '@dump247/storybook-state';
 // components
 import { Input } from '../source/components/Input';
 
-// skins
-import { InputSkin } from '../source/skins/simple/InputSkin';
-
 // themes
 import CustomInputTheme from './theme-customizations/Input.custom.scss';
 
@@ -32,7 +29,6 @@ storiesOf('Input', module)
       <Input
         value={store.state.value}
         onChange={value => store.set({ value })}
-        skin={InputSkin}
       />
     ))
   )
@@ -43,7 +39,6 @@ storiesOf('Input', module)
         label="Click Me to Focus"
         value={store.state.value}
         onChange={value => store.set({ value })}
-        skin={InputSkin}
       />
     ))
   )
@@ -54,7 +49,6 @@ storiesOf('Input', module)
         value={store.state.value}
         placeholder="user name"
         onChange={value => store.set({ value })}
-        skin={InputSkin}
       />
     ))
   )
@@ -67,7 +61,6 @@ storiesOf('Input', module)
         value={store.state.value}
         placeholder="autoFocus"
         onChange={value => store.set({ value })}
-        skin={InputSkin}
       />
     ))
   )
@@ -77,7 +70,6 @@ storiesOf('Input', module)
       disabled
       label="Disabled Input"
       placeholder="user name"
-      skin={InputSkin}
     />
   ))
 
@@ -88,7 +80,6 @@ storiesOf('Input', module)
         error="Something went wrong"
         value={store.state.value}
         onChange={value => store.set({ value })}
-        skin={InputSkin}
       />
     ))
   )
@@ -101,7 +92,6 @@ storiesOf('Input', module)
         placeholder="min length"
         minLength={8}
         onChange={value => store.set({ value })}
-        skin={InputSkin}
       />
     ))
   )
@@ -114,7 +104,6 @@ storiesOf('Input', module)
         placeholder="max length"
         maxLength={5}
         onChange={value => store.set({ value })}
-        skin={InputSkin}
       />
     ))
   )
@@ -126,7 +115,6 @@ storiesOf('Input', module)
         type="password"
         placeholder="password"
         onChange={value => store.set({ value })}
-        skin={InputSkin}
       />
     ))
   )
@@ -140,7 +128,6 @@ storiesOf('Input', module)
         onChange={value => store.set({ value })}
         onFocus={() => store.set({ focused: true, blurred: false })}
         onBlur={() => store.set({ blurred: true, focused: false })}
-        skin={InputSkin}
       />
     ))
   )
@@ -154,7 +141,6 @@ storiesOf('Input', module)
         maxLength={5}
         onKeyPress={action('onKeyPress')}
         onChange={value => store.set({ value })}
-        skin={InputSkin}
       />
     ))
   )
@@ -168,7 +154,6 @@ storiesOf('Input', module)
         value={store.state.value}
         placeholder="type here..."
         onChange={value => store.set({ value })}
-        skin={InputSkin}
       />
     ))
   )
@@ -181,7 +166,6 @@ storiesOf('Input', module)
         value={store.state.value}
         placeholder="type here..."
         onChange={value => store.set({ value })}
-        skin={InputSkin}
       />
     ))
   );

--- a/stories/Layout.stories.js
+++ b/stories/Layout.stories.js
@@ -12,9 +12,6 @@ import { GridItem } from '../source/components/layout/GridItem';
 import { Gutter } from '../source/components/layout/Gutter';
 import { Header } from '../source/components/Header';
 
-// skins
-import { HeaderSkin } from '../source/skins/simple/HeaderSkin';
-
 // styles && themeOverrides
 import styles from './Layout.stories.scss';
 import customFlex from './theme-overrides/customFlex.scss';
@@ -259,23 +256,23 @@ storiesOf('Layout', module)
           gap={10}
         >
           <GridItem gridArea="content">
-            <Header h2 left skin={HeaderSkin}>content</Header>
+            <Header h2 left>content</Header>
           </GridItem>
 
           <GridItem gridArea="sidebar">
-            <Header h2 left skin={HeaderSkin}>sidebar</Header>
+            <Header h2 left>sidebar</Header>
           </GridItem>
 
           <GridItem gridArea="header">
-            <Header h2 left skin={HeaderSkin}>header</Header>
+            <Header h2 left>header</Header>
           </GridItem>
 
           <GridItem gridArea="footer">
-            <Header h2 left skin={HeaderSkin}>footer</Header>
+            <Header h2 left>footer</Header>
           </GridItem>
 
           <GridItem gridArea="aside">
-            <Header h2 left skin={HeaderSkin}>aside</Header>
+            <Header h2 left>aside</Header>
           </GridItem>
         </Grid>
       </Gutter>

--- a/stories/LoadingSpinner.stories.js
+++ b/stories/LoadingSpinner.stories.js
@@ -7,9 +7,6 @@ import { storiesOf } from '@storybook/react';
 // components
 import { LoadingSpinner } from '../source/components/LoadingSpinner';
 
-// skins
-import { LoadingSpinnerSkin } from '../source/skins/simple/LoadingSpinnerSkin';
-
 // // theme overrides and styles
 import dashedSpinner from './theme-overrides/dashedSpinner.scss';
 import adaSpinner from './theme-overrides/adaSpinner.scss';
@@ -25,13 +22,13 @@ storiesOf('LoadingSpinner', module)
 
   .add('small', () => (
     <div className={styles.marginWrapper}>
-      <LoadingSpinner skin={LoadingSpinnerSkin} />
+      <LoadingSpinner />
     </div>
   ))
 
   .add('big', () => (
     <div className={styles.marginWrapper}>
-      <LoadingSpinner big skin={LoadingSpinnerSkin} />
+      <LoadingSpinner big />
     </div>
   ))
 
@@ -40,7 +37,6 @@ storiesOf('LoadingSpinner', module)
       <LoadingSpinner
         big
         themeOverrides={dashedSpinner}
-        skin={LoadingSpinnerSkin}
       />
     </div>
   ))
@@ -50,7 +46,6 @@ storiesOf('LoadingSpinner', module)
       <LoadingSpinner
         big
         themeOverrides={adaSpinner}
-        skin={LoadingSpinnerSkin}
       />
     </div>
   ))
@@ -60,7 +55,6 @@ storiesOf('LoadingSpinner', module)
       <LoadingSpinner
         big
         themeOverrides={daedalusSpinner}
-        skin={LoadingSpinnerSkin}
       />
     </div>
   ));

--- a/stories/Modal.stories.js
+++ b/stories/Modal.stories.js
@@ -9,10 +9,6 @@ import { withState } from '@dump247/storybook-state';
 import { Modal } from '../source/components/Modal';
 import { Button } from '../source/components/Button';
 
-// skins
-import { ModalSkin } from '../source/skins/simple/ModalSkin';
-import { ButtonSkin } from '../source/skins/simple/ButtonSkin';
-
 // themes
 import CustomModalTheme from './theme-customizations/Modal.custom.scss';
 
@@ -35,7 +31,6 @@ storiesOf('Modal', module)
         isOpen={store.state.isOpen}
         triggerCloseOnOverlayClick
         onClose={() => store.set({ isOpen: !store.state.isOpen })}
-        skin={ModalSkin}
       >
         <h1 className={styles.modalTitle}>Click outside of modal to cancel</h1>
       </Modal>
@@ -47,7 +42,6 @@ storiesOf('Modal', module)
       <Modal
         isOpen={store.state.isOpen}
         triggerCloseOnOverlayClick={false}
-        skin={ModalSkin}
       >
         <h1 className={styles.modalTitle}>
           Are you sure you want to delete this thing?
@@ -57,13 +51,11 @@ storiesOf('Modal', module)
             className={styles.cancelButton}
             label="Cancel"
             onClick={() => store.set({ isOpen: !store.state.isOpen })}
-            skin={ButtonSkin}
           />
           <Button
             className={styles.deleteButton}
             label="Delete"
             onClick={() => store.set({ isOpen: !store.state.isOpen })}
-            skin={ButtonSkin}
           />
         </div>
       </Modal>
@@ -77,7 +69,6 @@ storiesOf('Modal', module)
         isOpen={store.state.isOpen}
         triggerCloseOnOverlayClick
         onClose={() => store.set({ isOpen: !store.state.isOpen })}
-        skin={ModalSkin}
       >
         <h1 className={styles.modalTitle}>Click outside of modal to cancel</h1>
       </Modal>
@@ -91,7 +82,6 @@ storiesOf('Modal', module)
         isOpen={store.state.isOpen}
         triggerCloseOnOverlayClick
         onClose={() => store.set({ isOpen: !store.state.isOpen })}
-        skin={ModalSkin}
       >
         <h1 className={styles.modalTitle}>Click outside of modal to cancel</h1>
       </Modal>

--- a/stories/NumericInput.stories.js
+++ b/stories/NumericInput.stories.js
@@ -8,9 +8,6 @@ import { withState } from '@dump247/storybook-state';
 // components
 import { NumericInput } from '../source/components/NumericInput';
 
-// skins
-import { InputSkin } from '../source/skins/simple/InputSkin';
-
 // themes
 import CustomInputTheme from './theme-customizations/Input.custom.scss';
 
@@ -33,7 +30,6 @@ storiesOf('NumericInput', module)
         maxBeforeDot={6}
         maxAfterDot={6}
         onChange={value => store.set({ value })}
-        skin={InputSkin}
       />
     ))
   )
@@ -46,7 +42,6 @@ storiesOf('NumericInput', module)
         maxBeforeDot={6}
         maxAfterDot={6}
         onChange={value => store.set({ value })}
-        skin={InputSkin}
       />
     ))
   )
@@ -59,7 +54,6 @@ storiesOf('NumericInput', module)
         maxBeforeDot={6}
         maxAfterDot={6}
         onChange={value => store.set({ value })}
-        skin={InputSkin}
       />
     ))
   )
@@ -74,7 +68,6 @@ storiesOf('NumericInput', module)
         maxBeforeDot={6}
         maxAfterDot={6}
         onChange={value => store.set({ value })}
-        skin={InputSkin}
       />
     ))
   )
@@ -89,7 +82,6 @@ storiesOf('NumericInput', module)
         onChange={value => store.set({ value })}
         onFocus={() => store.set({ focused: true, blurred: false })}
         onBlur={() => store.set({ blurred: true, focused: false })}
-        skin={InputSkin}
       />
     ))
   )
@@ -102,7 +94,6 @@ storiesOf('NumericInput', module)
         value={store.state.value}
         placeholder="0.000000"
         onChange={value => store.set({ value })}
-        skin={InputSkin}
       />
     ))
   )
@@ -116,7 +107,6 @@ storiesOf('NumericInput', module)
         maxBeforeDot={3}
         maxAfterDot={4}
         onChange={value => store.set({ value })}
-        skin={InputSkin}
       />
     ))
   )
@@ -130,7 +120,6 @@ storiesOf('NumericInput', module)
         maxBeforeDot={3}
         maxAfterDot={0}
         onChange={value => store.set({ value })}
-        skin={InputSkin}
       />
     ))
   )
@@ -143,7 +132,6 @@ storiesOf('NumericInput', module)
         placeholder="0.000000"
         maxValue={30000}
         onChange={value => store.set({ value })}
-        skin={InputSkin}
       />
     ))
   )
@@ -157,7 +145,6 @@ storiesOf('NumericInput', module)
         minValue={50}
         maxAfterDot={6}
         onChange={value => store.set({ value })}
-        skin={InputSkin}
       />
     ))
   )
@@ -172,7 +159,6 @@ storiesOf('NumericInput', module)
         minValue={50}
         maxAfterDot={6}
         onChange={value => store.set({ value })}
-        skin={InputSkin}
       />
     ))
   )
@@ -189,7 +175,6 @@ storiesOf('NumericInput', module)
         enforceMax
         enforceMin
         onChange={value => store.set({ value })}
-        skin={InputSkin}
       />
     ))
   )
@@ -204,7 +189,6 @@ storiesOf('NumericInput', module)
         placeholder="0.000000"
         maxAfterDot={6}
         onChange={value => store.set({ value })}
-        skin={InputSkin}
       />
     ))
   )
@@ -218,7 +202,6 @@ storiesOf('NumericInput', module)
         placeholder="0.000000"
         maxAfterDot={6}
         onChange={value => store.set({ value })}
-        skin={InputSkin}
       />
     ))
   );

--- a/stories/Options.stories.js
+++ b/stories/Options.stories.js
@@ -10,11 +10,6 @@ import { Autocomplete } from '../source/components/Autocomplete';
 import { Select } from '../source/components/Select';
 import { Options } from '../source/components/Options';
 
-// skins
-import { AutocompleteSkin } from '../source/skins/simple/AutocompleteSkin';
-import { SelectSkin } from '../source/skins/simple/SelectSkin';
-import { OptionsSkin } from '../source/skins/simple/OptionsSkin';
-
 // themes
 import CustomOptionsTheme from './theme-customizations/Options.custom.scss';
 
@@ -55,7 +50,6 @@ storiesOf('Options', module)
         value={store.state.value}
         onChange={value => store.set({ value })}
         options={OPTIONS_COLLECTION}
-        skin={SelectSkin}
       />
     ))
   )
@@ -70,7 +64,6 @@ storiesOf('Options', module)
         maxVisibleOptions={5}
         invalidCharsRegex={/[^a-zA-Z]/g}
         onChange={selectedOpts => store.set({ selectedOpts })}
-        skin={AutocompleteSkin}
       />
     ))
   )
@@ -82,6 +75,5 @@ storiesOf('Options', module)
       options={OPTIONS_COLLECTION}
       isOpeningUpward={false}
       noResults={false}
-      skin={OptionsSkin}
     />
   ));

--- a/stories/ProgressBar.stories.js
+++ b/stories/ProgressBar.stories.js
@@ -7,9 +7,6 @@ import { storiesOf } from '@storybook/react';
 // components
 import { ProgressBar } from '../source/components/ProgressBar';
 
-// skins
-import { ProgressBarSkin } from '../source/skins/simple/ProgressBarSkin';
-
 // styles
 import styles from './ProgressBar.stories.scss';
 import themeOverrides from './theme-overrides/customProgressBar.scss';
@@ -23,19 +20,19 @@ storiesOf('ProgressBar', module)
 
   .add('default - 30%', () => (
     <div className={styles.marginWrapper}>
-      <ProgressBar progress={30} skin={ProgressBarSkin} />
+      <ProgressBar progress={30} />
     </div>
   ))
 
   .add('default - 50%', () => (
     <div className={styles.marginWrapper}>
-      <ProgressBar progress={50} skin={ProgressBarSkin} />
+      <ProgressBar progress={50} />
     </div>
   ))
 
   .add('default - label', () => (
     <div className={styles.marginWrapper}>
-      <ProgressBar label="Pending Transaction" skin={ProgressBarSkin} />
+      <ProgressBar label="Pending Transaction" />
     </div>
   ))
 
@@ -44,7 +41,6 @@ storiesOf('ProgressBar', module)
       <ProgressBar
         progress={50}
         themeOverrides={themeOverrides}
-        skin={ProgressBarSkin}
       />
     </div>
   ))
@@ -54,7 +50,6 @@ storiesOf('ProgressBar', module)
       <ProgressBar
         label="Pending Transaction"
         themeOverrides={themeOverrides}
-        skin={ProgressBarSkin}
       />
     </div>
   ));

--- a/stories/Radio.stories.js
+++ b/stories/Radio.stories.js
@@ -8,9 +8,6 @@ import { withState } from '@dump247/storybook-state';
 // components
 import { Radio } from '../source/components/Radio';
 
-// skins
-import { RadioSkin } from '../source/skins/simple/RadioSkin';
-
 // themes
 import CustomRadioTheme from './theme-customizations/Radio.custom.scss';
 
@@ -33,7 +30,6 @@ storiesOf('Radio', module)
         <Radio
           selected={store.state.selected}
           onChange={() => store.set({ selected: !store.state.selected })}
-          skin={RadioSkin}
         />
       </div>
     ))
@@ -41,7 +37,7 @@ storiesOf('Radio', module)
 
   .add('disabled', () => (
     <div className={styles.container}>
-      <Radio disabled skin={RadioSkin} />
+      <Radio disabled />
     </div>
   ))
 
@@ -52,7 +48,6 @@ storiesOf('Radio', module)
           label="My radio"
           selected={store.state.selected}
           onChange={() => store.set({ selected: !store.state.selected })}
-          skin={RadioSkin}
         />
       </div>
     ))
@@ -64,7 +59,6 @@ storiesOf('Radio', module)
         className={styles.padding}
         selected={store.state.selected}
         onChange={() => store.set({ selected: !store.state.selected })}
-        skin={RadioSkin}
       />
     ))
   )
@@ -77,7 +71,6 @@ storiesOf('Radio', module)
           label="My radio"
           selected={store.state.selected}
           onChange={() => store.set({ selected: !store.state.selected })}
-          skin={RadioSkin}
         />
       </div>
     ))
@@ -92,7 +85,6 @@ storiesOf('Radio', module)
                 which were written down in a secure place"
           selected={store.state.selected}
           onChange={() => store.set({ selected: !store.state.selected })}
-          skin={RadioSkin}
         />
       </div>
     ))
@@ -104,7 +96,6 @@ storiesOf('Radio', module)
         <Radio
           selected={store.state.selected}
           onChange={() => store.set({ selected: !store.state.selected })}
-          skin={RadioSkin}
           label={
             <div>
               Example for a <strong>bold</strong> word in an html label
@@ -123,7 +114,6 @@ storiesOf('Radio', module)
           label="Radio with a composed theme"
           selected={store.state.selected}
           onChange={() => store.set({ selected: !store.state.selected })}
-          skin={RadioSkin}
         />
       </div>
     ))
@@ -137,7 +127,6 @@ storiesOf('Radio', module)
           label="Radio with a custom theme"
           selected={store.state.selected}
           onChange={() => store.set({ selected: !store.state.selected })}
-          skin={RadioSkin}
         />
       </div>
     ))

--- a/stories/Select.stories.js
+++ b/stories/Select.stories.js
@@ -5,13 +5,10 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { withState } from '@dump247/storybook-state';
 
-// components & skins
+// components
 import { Select } from '../source/components/Select';
-import { SelectSkin } from '../source/skins/simple/SelectSkin';
 import { Modal } from '../source/components/Modal';
-import { ModalSkin } from '../source/skins/simple/ModalSkin';
 import { Button } from '../source/components/Button';
-import { ButtonSkin } from '../source/skins/simple/ButtonSkin';
 
 // themes
 import { SimpleTheme } from '../source/themes/simple';
@@ -27,7 +24,7 @@ import flagThailand from './images/th.png';
 import flagUSA from './images/us.png';
 
 // constants
-import { IDENTIFIERS } from '../source/themes/API';
+import { IDENTIFIERS } from '../source/components';
 
 // helpers
 import { decorateWithSimpleTheme } from './helpers/theming';
@@ -65,7 +62,6 @@ storiesOf('Select', module)
         value={store.state.value}
         onChange={value => store.set({ value })}
         options={COUNTRIES}
-        skin={SelectSkin}
       />
     ))
   )
@@ -77,7 +73,6 @@ storiesOf('Select', module)
         value={store.state.value}
         onChange={value => store.set({ value })}
         options={COUNTRIES}
-        skin={SelectSkin}
       />
     ))
   )
@@ -89,7 +84,6 @@ storiesOf('Select', module)
         onChange={value => store.set({ value })}
         options={COUNTRIES}
         placeholder="Select your country …"
-        skin={SelectSkin}
       />
     ))
   )
@@ -100,7 +94,6 @@ storiesOf('Select', module)
         value={store.state.value}
         onChange={value => store.set({ value })}
         options={COUNTRIES}
-        skin={SelectSkin}
       />
     ))
   )
@@ -113,7 +106,6 @@ storiesOf('Select', module)
         value={store.state.value}
         onChange={value => store.set({ value })}
         options={COUNTRIES}
-        skin={SelectSkin}
       />
     ))
   )
@@ -130,7 +122,6 @@ storiesOf('Select', module)
             <span>{option.label}</span>
           </div>
           )}
-        skin={SelectSkin}
       />
     ))
   )
@@ -145,7 +136,6 @@ storiesOf('Select', module)
         value={store.state.value}
         onChange={value => store.set({ value })}
         options={COUNTRIES}
-        skin={SelectSkin}
       />
     ))
   )
@@ -158,7 +148,6 @@ storiesOf('Select', module)
         label="Countries (has disabled options)"
         options={COUNTRIES_WITH_DISABLED_OPTIONS}
         placeholder="Select your country …"
-        skin={SelectSkin}
       />
     ))
   )
@@ -170,7 +159,6 @@ storiesOf('Select', module)
           value={store.state.value}
           onChange={value => store.set({ value })}
           options={COUNTRIES}
-          skin={SelectSkin}
         />
       </div>
     ))
@@ -185,7 +173,6 @@ storiesOf('Select', module)
         label="Countries (has disabled options)"
         options={COUNTRIES_WITH_DISABLED_OPTIONS}
         placeholder="Select your country …"
-        skin={SelectSkin}
       />
     ))
   )
@@ -197,7 +184,6 @@ storiesOf('Select', module)
           <Modal
             isOpen={store.state.isOpen}
             triggerCloseOnOverlayClick={false}
-            skin={ModalSkin}
             onClose={() => store.set({ isOpen: false })}
           >
             <div className={styles.dialogWrapper}>
@@ -209,7 +195,6 @@ storiesOf('Select', module)
                   value={store.state.value}
                   onChange={value => store.set({ value })}
                   options={COUNTRIES}
-                  skin={SelectSkin}
                 />
               </div>
               <div className={styles.actions}>
@@ -217,7 +202,6 @@ storiesOf('Select', module)
                   onClick={() => store.set({ isOpen: false })}
                   className="primary"
                   label="Submit"
-                  skin={ButtonSkin}
                 />
               </div>
             </div>

--- a/stories/Switch.stories.js
+++ b/stories/Switch.stories.js
@@ -8,15 +8,12 @@ import { withState } from '@dump247/storybook-state';
 // components
 import { Checkbox } from '../source/components/Checkbox';
 
-// skins
-import { SwitchSkin } from '../source/skins/simple/SwitchSkin';
-
 // themes
 import CustomSwitchTheme from './theme-customizations/Switch.custom.scss';
 
 // custom styles & theme overrides
 import themeOverrides from './theme-overrides/customSwitch.scss';
-import { IDENTIFIERS } from '../source/themes/API';
+import { IDENTIFIERS } from '../source/components';
 
 // helpers
 import { decorateWithSimpleTheme } from './helpers/theming';
@@ -33,13 +30,12 @@ storiesOf('Switch', module)
         checked={store.state.checked}
         onChange={() => store.set({ checked: !store.state.checked })}
         themeId={IDENTIFIERS.SWITCH}
-        skin={SwitchSkin}
       />
     ))
   )
 
   .add('disabled', () => (
-    <Checkbox disabled themeId={IDENTIFIERS.SWITCH} skin={SwitchSkin} />
+    <Checkbox disabled themeId={IDENTIFIERS.SWITCH} />
   ))
 
   .add('short label',
@@ -49,7 +45,6 @@ storiesOf('Switch', module)
         checked={store.state.checked}
         onChange={() => store.set({ checked: !store.state.checked })}
         themeId={IDENTIFIERS.SWITCH}
-        skin={SwitchSkin}
       />
     ))
   )
@@ -62,7 +57,6 @@ storiesOf('Switch', module)
         checked={store.state.checked}
         onChange={() => store.set({ checked: !store.state.checked })}
         themeId={IDENTIFIERS.SWITCH}
-        skin={SwitchSkin}
       />
     ))
   )
@@ -76,7 +70,6 @@ storiesOf('Switch', module)
         checked={store.state.checked}
         onChange={() => store.set({ checked: !store.state.checked })}
         themeId={IDENTIFIERS.SWITCH}
-        skin={SwitchSkin}
       />
     ))
   )
@@ -90,7 +83,6 @@ storiesOf('Switch', module)
           label="theme overrides"
           checked={store.state.checked}
           onChange={() => store.set({ checked: !store.state.checked })}
-          skin={SwitchSkin}
         />
       </div>
     ))
@@ -105,7 +97,6 @@ storiesOf('Switch', module)
           label="custom theme"
           checked={store.state.checked}
           onChange={() => store.set({ checked: !store.state.checked })}
-          skin={SwitchSkin}
         />
       </div>
     ))

--- a/stories/ThemeProvider.stories.js
+++ b/stories/ThemeProvider.stories.js
@@ -53,7 +53,7 @@ import progressBarOverrides1 from './theme-overrides/progressBarOverrides.scss';
 import progressBarOverrides2 from './theme-overrides/customProgressBar.scss';
 
 // constants
-import { IDENTIFIERS } from '../source/themes/API';
+import { IDENTIFIERS } from '../source/components';
 
 const MNEMONICS = ['home', 'cat', 'dog', 'fish'];
 

--- a/stories/Toggler.stories.js
+++ b/stories/Toggler.stories.js
@@ -8,15 +8,12 @@ import { withState } from '@dump247/storybook-state';
 // components
 import { Checkbox } from '../source/components/Checkbox';
 
-// skins
-import { TogglerSkin } from '../source/skins/simple/TogglerSkin';
-
 // themes
 import CustomTogglerTheme from './theme-customizations/Toggler.custom.scss';
 
 // theme overrides and identifiers
 import themeOverrides from './theme-overrides/customToggler.scss';
-import { IDENTIFIERS } from '../source/themes/API';
+import { IDENTIFIERS } from '../source/components';
 
 // theme
 import { decorateWithSimpleTheme } from './helpers/theming';
@@ -35,7 +32,6 @@ storiesOf('Toggler', module)
         themeId={IDENTIFIERS.TOGGLER}
         labelLeft="Included"
         labelRight="Excluded"
-        skin={TogglerSkin}
       />
     ))
   )
@@ -50,7 +46,6 @@ storiesOf('Toggler', module)
           themeId={IDENTIFIERS.TOGGLER}
           labelLeft="Included"
           labelRight="Excluded"
-          skin={TogglerSkin}
         />
         <span>&nbsp;from the amount</span>
       </div>
@@ -66,7 +61,6 @@ storiesOf('Toggler', module)
         labelLeft="Included"
         labelRight="Excluded"
         themeId={IDENTIFIERS.TOGGLER}
-        skin={TogglerSkin}
       />
     ))
   )
@@ -80,7 +74,6 @@ storiesOf('Toggler', module)
         themeId={IDENTIFIERS.TOGGLER}
         labelLeft="Included"
         labelRight="Excluded"
-        skin={TogglerSkin}
       />
     ))
   )
@@ -94,7 +87,6 @@ storiesOf('Toggler', module)
         themeId={IDENTIFIERS.TOGGLER}
         labelLeft="Included"
         labelRight="Excluded"
-        skin={TogglerSkin}
       />
     ))
   );

--- a/stories/Tooltip.stories.js
+++ b/stories/Tooltip.stories.js
@@ -7,9 +7,6 @@ import { storiesOf } from '@storybook/react';
 // components
 import { Tooltip } from '../source/components/Tooltip';
 
-// skins
-import { TooltipSkin } from '../source/skins/simple/TooltipSkin';
-
 // themes
 import { SimpleTheme } from '../source/themes/simple';
 import CustomBubbleTheme from './theme-customizations/Bubble.custom.scss';
@@ -17,7 +14,7 @@ import CustomBubbleTheme from './theme-customizations/Bubble.custom.scss';
 // custom styles & theme overrides
 import styles from './Tooltip.stories.scss';
 import themeOverrides from './theme-overrides/customTooltipBubble.scss';
-import { IDENTIFIERS } from '../source/themes/API';
+import { IDENTIFIERS } from '../source/components';
 
 // helpers
 import { decorateWithSimpleTheme } from './helpers/theming';
@@ -30,7 +27,7 @@ storiesOf('Tooltip', module)
 
   .add('plain', () => (
     <div className={styles.container}>
-      <Tooltip skin={TooltipSkin} tip="plain tooltip, nothing special about me">
+      <Tooltip tip="plain tooltip, nothing special about me">
         hover over me
       </Tooltip>
     </div>
@@ -39,7 +36,6 @@ storiesOf('Tooltip', module)
   .add('html', () => (
     <div className={styles.container}>
       <Tooltip
-        skin={TooltipSkin}
         tip={
           <div>
             I can use <span className={styles.htmlTip}>HTML</span>
@@ -53,7 +49,7 @@ storiesOf('Tooltip', module)
 
   .add('isAligningRight', () => (
     <div className={styles.container}>
-      <Tooltip isAligningRight skin={TooltipSkin} tip="I am aligning right">
+      <Tooltip isAligningRight tip="I am aligning right">
         hover over me
       </Tooltip>
     </div>
@@ -63,7 +59,6 @@ storiesOf('Tooltip', module)
     <div className={styles.container}>
       <Tooltip
         isBounded
-        skin={TooltipSkin}
         tip="Help, I am stuck in this small box"
       >
         hover over me
@@ -75,7 +70,6 @@ storiesOf('Tooltip', module)
     <div className={styles.container}>
       <Tooltip
         className={styles.customTooltip}
-        skin={TooltipSkin}
         tip="How did I get all the way over here?"
       >
         hover over me
@@ -87,7 +81,6 @@ storiesOf('Tooltip', module)
     <div className={styles.container}>
       <Tooltip
         isOpeningUpward={false}
-        skin={TooltipSkin}
         tip="I come from a land down under"
       >
         hover over me
@@ -103,7 +96,6 @@ storiesOf('Tooltip', module)
           [IDENTIFIERS.BUBBLE]: themeOverrides
         }}
         isOpeningUpward
-        skin={TooltipSkin}
         isTransparent={false}
         tip="plain tooltip, with theme overrides"
       >
@@ -116,7 +108,6 @@ storiesOf('Tooltip', module)
     <div className={styles.container}>
       <Tooltip
         theme={{ ...SimpleTheme, [IDENTIFIERS.BUBBLE]: CustomBubbleTheme }}
-        skin={TooltipSkin}
         isTransparent={false}
         tip="plain tooltip, with a custom theme"
       >

--- a/stories/helpers/theming.js
+++ b/stories/helpers/theming.js
@@ -1,9 +1,10 @@
 import React from 'react';
 import { ThemeProvider } from '../../source/components/ThemeProvider';
 import { SimpleTheme } from '../../source/themes/simple';
+import { SimpleSkins } from '../../source/skins/simple';
 
 export const decorateWithSimpleTheme = (story) => (
-  <ThemeProvider theme={SimpleTheme}>
+  <ThemeProvider theme={SimpleTheme} skins={SimpleSkins}>
     {story()}
   </ThemeProvider>
 );


### PR DESCRIPTION
This PR makes it possible to provides the simple skins by default (via `ThemeProvider`) to all components, so we don't have to explicitly import and pass skins to components (except if we want to, like with toggles and switches which override the look and feel of the common base class).

**Before:**
```js
import React from 'react';
import { ThemeProvider } from '../../source/components/ThemeProvider';
import { SimpleTheme } from '../../source/themes/simple';

export const decorateWithSimpleTheme = (story) => (
  <ThemeProvider theme={SimpleTheme}>
    {story()}
  </ThemeProvider>
);
```

```js
import React from "react";
import { Radio } from "react-polymorph/lib/components";
import { RadioSkin } from "react-polymorph/lib/skins/simple";

const MyRadio = props => (
  // Only the theme is provided by the ThemeProvider
  <Radio label="My radio" skin={SimpleRadioSkin} />
);
```

**After:**
```js
import React from 'react';
import { ThemeProvider } from '../../source/components/ThemeProvider';
import { SimpleTheme } from '../../source/themes/simple';
import { SimpleSkins } from '../../source/skins/simple';
export const decorateWithSimpleTheme = (story) => (
  <ThemeProvider theme={SimpleTheme} skins={SimpleSkins}>
    {story()}
  </ThemeProvider>
);
```

```js
import React from "react";
import { Radio } from "react-polymorph/lib/components";

const MyRadio = props => (
  // The theme and skin is provided by the ThemeProvider
  <Radio label="My radio" />
);
```

Saves a lot of boilerplate 😉 

Also updated and improved the README to reflect this feature.

**NOTE:** This is not a breaking change since the previous way still works exactly the same. Providing the skin is always possible but just not mandatory anymore (if using a `ThemeProvider`).