### PR TITLE
Fix Checkbox z-order on firefox

### DIFF
--- a/source/skins/simple/CheckboxSkin.js
+++ b/source/skins/simple/CheckboxSkin.js
@@ -33,6 +33,11 @@ export const CheckboxSkin = (props: Props) => (
       }
     }}
   >
+    {props.label && (
+      <label className={props.theme[props.themeId].label}>
+        {props.label}
+      </label>
+    )}
     <input
       {...pickDOMProps(props)}
       className={props.theme[props.themeId].input}
@@ -44,10 +49,5 @@ export const CheckboxSkin = (props: Props) => (
         props.checked ? props.theme[props.themeId].checked : null
       ])}
     />
-    {props.label && (
-      <label className={props.theme[props.themeId].label}>
-        {props.label}
-      </label>
-    )}
   </div>
 );

--- a/source/themes/simple/SimpleCheckbox.scss
+++ b/source/themes/simple/SimpleCheckbox.scss
@@ -38,6 +38,7 @@ $checkbox-label-text-color-disabled: var(--rp-checkbox-label-text-color-disabled
 }
 
 .check {
+  order: 1;
   align-self: center;
   border: $checkbox-border;
   border-radius: $checkbox-border-radius;
@@ -52,6 +53,7 @@ $checkbox-label-text-color-disabled: var(--rp-checkbox-label-text-color-disabled
 }
 
 .label {
+  order: 2;
   color: $checkbox-label-text-color;
   font-family: $checkbox-label-font-family;
   font-size: $checkbox-label-font-size;


### PR DESCRIPTION
### Problem

It is impossible to click checkboxes in Firefox. You can even verify by attaching Selenium to `geckodriver` and if you try and programmatically click the checkbox you will get this error:
```Element <div class="SimpleCheckbox_check"> is not clickable at point (289,516) because another element <input class="SimpleCheckbox_input" type="checkbox"> obscures it```

### The Fix

We could fix it by changing the `z-index` of the `input` to always be above the `label` but I'm concerned this may get messy because somebody using `react-polymorph` may have their own `z-order` system in their application and this would mess with it with no easy general-case fix.

Therefore I instead just change the render order in the HTML and take advantage of the `flex` display to specify the positioning:

**Step 1**) Swap the order of the `label` and the `input` such that now the input appears over the label. This fixes the bug but now the checkbox appears on the right of the label!
**Step 2**) Enforce the order of the `label` and `input` in the css (`flex` container). This fixes the order!

### Downside

Part of this fix makes changes to the `SimpleCheckbox.scss` which means if somebody overrode or used a completely new theme, they may suddenly find all their checkbox&label positions reversed once they upgrade this library.