### PR TITLE
[DDW-609] Fix Options Drop Down Max Height for Small Screens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Fixes
 
+- Sets max height of Options drop down based on window height and offset of Options' target ref.
+  Changes flow type Ref to ElementRef in components and skins. [PR 102](https://github.com/input-output-hk/react-polymorph/pull/102)
+
 - Updates vulnerable packages found by Github's automatic security audit.
   Fixes Checkbox component's render method to use the `themeId` prop for 
   accessing a skin in `context` when one isn't provided via props instead 

--- a/__tests__/__snapshots__/Autocomplete.test.js.snap
+++ b/__tests__/__snapshots__/Autocomplete.test.js.snap
@@ -40,6 +40,11 @@ exports[`Autocomplete renders correctly 1`] = `
       >
         <ul
           className="ul"
+          style={
+            Object {
+              "maxHeight": "300px",
+            }
+          }
         >
           <li
             aria-hidden={true}
@@ -129,6 +134,11 @@ exports[`Autocomplete renders with a placeholder 1`] = `
       >
         <ul
           className="ul"
+          style={
+            Object {
+              "maxHeight": "300px",
+            }
+          }
         >
           <li
             aria-hidden={true}
@@ -221,6 +231,11 @@ exports[`Autocomplete renders with an error 1`] = `
       >
         <ul
           className="ul"
+          style={
+            Object {
+              "maxHeight": "300px",
+            }
+          }
         >
           <li
             aria-hidden={true}
@@ -317,6 +332,11 @@ exports[`Autocomplete renders with label 1`] = `
       >
         <ul
           className="ul"
+          style={
+            Object {
+              "maxHeight": "300px",
+            }
+          }
         >
           <li
             aria-hidden={true}
@@ -405,6 +425,11 @@ exports[`Autocomplete uses render prop - renderOptions 1`] = `
       >
         <ul
           className="ul"
+          style={
+            Object {
+              "maxHeight": "300px",
+            }
+          }
         >
           <li>
             <span>
@@ -477,6 +502,11 @@ exports[`Autocomplete uses render prop - renderSelections 1`] = `
       >
         <ul
           className="ul"
+          style={
+            Object {
+              "maxHeight": "300px",
+            }
+          }
         >
           <li
             aria-hidden={true}

--- a/__tests__/__snapshots__/Options.test.js.snap
+++ b/__tests__/__snapshots__/Options.test.js.snap
@@ -11,6 +11,7 @@ exports[`Options renders correctly 1`] = `
   >
     <ul
       className="ul"
+      style={null}
     >
       <li
         aria-hidden={true}
@@ -140,6 +141,7 @@ exports[`Options uses render prop - optionRenderer 1`] = `
   >
     <ul
       className="ul"
+      style={null}
     >
       <li
         aria-hidden={true}
@@ -241,6 +243,7 @@ exports[`Options uses render prop - render 1`] = `
   >
     <ul
       className="ul"
+      style={null}
     >
       <li>
         <span>

--- a/__tests__/__snapshots__/Select.test.js.snap
+++ b/__tests__/__snapshots__/Select.test.js.snap
@@ -35,6 +35,11 @@ exports[`Select isOpen={true} 1`] = `
       >
         <ul
           className="ul"
+          style={
+            Object {
+              "maxHeight": "300px",
+            }
+          }
         >
           <li
             aria-hidden={true}
@@ -147,6 +152,11 @@ exports[`Select isOpeningUpward={true} 1`] = `
       >
         <ul
           className="ul"
+          style={
+            Object {
+              "maxHeight": "300px",
+            }
+          }
         >
           <li
             aria-hidden={true}
@@ -259,6 +269,11 @@ exports[`Select renders correctly 1`] = `
       >
         <ul
           className="ul"
+          style={
+            Object {
+              "maxHeight": "300px",
+            }
+          }
         >
           <li
             aria-hidden={true}
@@ -375,6 +390,11 @@ exports[`Select renders with an error 1`] = `
       >
         <ul
           className="ul"
+          style={
+            Object {
+              "maxHeight": "300px",
+            }
+          }
         >
           <li
             aria-hidden={true}
@@ -487,6 +507,11 @@ exports[`Select renders with disabled options 1`] = `
       >
         <ul
           className="ul"
+          style={
+            Object {
+              "maxHeight": "300px",
+            }
+          }
         >
           <li
             aria-hidden={true}
@@ -587,6 +612,11 @@ exports[`Select renders with placeholder 1`] = `
       >
         <ul
           className="ul"
+          style={
+            Object {
+              "maxHeight": "300px",
+            }
+          }
         >
           <li
             aria-hidden={true}
@@ -699,6 +729,11 @@ exports[`Select uses render prop - optionRenderer 1`] = `
       >
         <ul
           className="ul"
+          style={
+            Object {
+              "maxHeight": "300px",
+            }
+          }
         >
           <li
             aria-hidden={true}

--- a/source/components/Autocomplete.js
+++ b/source/components/Autocomplete.js
@@ -238,11 +238,12 @@ class AutocompleteBase extends Component<Props, State> {
     return (
       <GlobalListeners
         optionsIsOpen={this.state.isOpen}
+        optionsIsOpeningUpward={this.props.isOpeningUpward}
         optionsRef={this.optionsElement}
         rootRef={this.rootElement}
         toggleOpen={this.toggleOpen}
       >
-        {() => (
+        {({ optionsMaxHeight }) => (
           <AutocompleteSkin
             error={error || this.state.error}
             filteredOptions={this.state.filteredOptions}
@@ -254,6 +255,7 @@ class AutocompleteBase extends Component<Props, State> {
             inputValue={this.state.inputValue}
             isOpen={this.state.isOpen}
             onKeyDown={this.onKeyDown}
+            optionsMaxHeight={optionsMaxHeight}
             optionsRef={this.optionsElement}
             removeOption={this.removeOption}
             rootRef={this.rootElement}

--- a/source/components/Bubble.js
+++ b/source/components/Bubble.js
@@ -1,6 +1,6 @@
 // @flow
 import React, { Component } from 'react';
-import type { ComponentType, Element, ElementRef, Ref } from 'react';
+import type { ComponentType, Element, ElementRef } from 'react';
 import createRef from 'create-react-ref/lib/createRef';
 
 // internal utility functions
@@ -23,7 +23,7 @@ type Props = {
   theme: ?Object, // takes precedence over them in context if passed
   themeId: string,
   themeOverrides: Object, // custom css/scss from user adhering to component's theme API
-  targetRef?: Ref<*>, // ref to the target DOM element used for positioning the bubble
+  targetRef?: ElementRef<*>, // ref to the target DOM element used for positioning the bubble
 };
 
 type State = {

--- a/source/components/FormField.js
+++ b/source/components/FormField.js
@@ -1,6 +1,6 @@
 // @flow
 import React, { Component } from 'react';
-import type { Ref, ComponentType, Element } from 'react';
+import type { ElementRef, ComponentType, Element } from 'react';
 
 // internal utility functions
 import { createEmptyContext, withTheme } from './HOC/withTheme';
@@ -15,7 +15,7 @@ type Props = {
   context: ThemeContextProp,
   disabled?: boolean,
   error?: string | Element<any>,
-  inputRef?: Ref<*>,
+  inputRef?: ElementRef<*>,
   label?: string | Element<any>,
   render: Function,
   skin?: ComponentType<any>,

--- a/source/components/HOC/GlobalListeners.js
+++ b/source/components/HOC/GlobalListeners.js
@@ -130,7 +130,7 @@ export class GlobalListeners extends Component<Props, State> {
     const { rootRef, optionsIsOpeningUpward } = this.props;
 
     if (!documentElement || !documentElement.style || !rootRef || !rootRef.current) {
-      return; // --rp-options-max-height-default defaults to 300px
+      return;
     }
 
     const { height, top } = rootRef.current.getBoundingClientRect();
@@ -141,7 +141,7 @@ export class GlobalListeners extends Component<Props, State> {
     }
 
     // opening downwards case
-    const optionsMaxHeight = window.innerHeight - top - height - 25;
+    const optionsMaxHeight = window.innerHeight - top - height - 30;
     if (!optionsIsOpeningUpward && optionsMaxHeight > 0) {
       this.setState({ optionsMaxHeight });
     }

--- a/source/components/HOC/GlobalListeners.js
+++ b/source/components/HOC/GlobalListeners.js
@@ -1,7 +1,8 @@
 // @flow
 import React, { Component } from 'react';
 // $FlowFixMe
-import type { SyntheticMouseEvent } from 'react';
+import type { SyntheticMouseEvent, ElementRef } from 'react';
+import { debounce } from 'lodash';
 
 import {
   addDocumentListeners,
@@ -14,17 +15,38 @@ import {
 type Props = {
   children: Function,
   optionsIsOpen: boolean,
-  optionsRef: ?Object,
-  rootRef: ?Object,
+  optionsIsOpeningUpward: boolean,
+  optionsRef?: ElementRef<*>,
+  rootRef?: ElementRef<*>,
   toggleOpen: Function
 };
 
-export class GlobalListeners extends Component<Props> {
+type State = {
+  optionsMaxHeight: number
+};
+
+export class GlobalListeners extends Component<Props, State> {
   // define static properties
   static displayName = 'GlobalListeners';
   static defaultProps = {
     optionsIsOpen: false
   };
+
+  constructor(props: Props) {
+    super(props);
+
+    this.state = {
+      optionsMaxHeight: 300
+    };
+  }
+
+  componentDidMount() {
+    if (this.props.optionsIsOpen) { return; }
+    // adds scroll and resize event listeners for calculating Options max-height
+    this._addCalculateMaxHeightListeners();
+    // runs initial Options max-height calculation
+    this._calculateOptionsMaxHeight();
+  }
 
   componentWillReceiveProps(nextProps: Props) {
     const { optionsIsOpen } = this.props;
@@ -32,10 +54,17 @@ export class GlobalListeners extends Component<Props> {
     // if Options is transferring from closed to open, add listeners
     // if Options is transferring from open to closed, remove listeners
     if (!optionsIsOpen && nextProps.optionsIsOpen) {
+      // first remove max-height calc handler on scroll and resize
+      // then add toggle handler on scroll and resize
+      this._removeGlobalListeners();
       addWindowListeners(this._getWindowListeners());
       addDocumentListeners(this._getDocumentListeners());
+
     } else if (optionsIsOpen && !nextProps.optionsIsOpen) {
+      // remove toggle handler on scroll and resize
+      // then add calc max-height calc handler on scroll and resize
       this._removeGlobalListeners();
+      this._addCalculateMaxHeightListeners();
     }
   }
 
@@ -61,15 +90,15 @@ export class GlobalListeners extends Component<Props> {
   }
 
   _getDocumentListeners = () => ({
-    click: this.handleDocumentClick,
-    scroll: this.handleDocumentScroll
+    click: this._handleDocumentClick,
+    scroll: this._handleDocumentScroll
   });
 
   _getWindowListeners = () => ({
-    resize: this.handleWindowResize
+    resize: this._handleWindowResize
   });
 
-  handleDocumentClick = (event: SyntheticMouseEvent<>) => {
+  _handleDocumentClick = (event: SyntheticMouseEvent<>) => {
     const { optionsIsOpen, rootRef } = this.props;
 
     // ensure Options is open
@@ -83,11 +112,43 @@ export class GlobalListeners extends Component<Props> {
     this._removeListenersAndToggle();
   };
 
-  handleWindowResize = () => this._removeListenersAndToggle();
+  _handleWindowResize = () => this._removeListenersAndToggle();
 
-  handleDocumentScroll = () => this._removeListenersAndToggle();
+  _handleDocumentScroll = () => this._removeListenersAndToggle();
+
+  _addCalculateMaxHeightListeners = () => {
+    const scrollListener = ['scroll', debounce(this._calculateOptionsMaxHeight, 300)];
+    const resizeListener = ['resize', debounce(this._calculateOptionsMaxHeight, 300)];
+    document.addEventListener(...scrollListener);
+    window.addEventListener(...resizeListener);
+  }
+
+  // calculates max-height for Options, max-height shouldn't be greater than distance
+  // from Options rootRef to edge of window (up or down) else Options run off page
+  _calculateOptionsMaxHeight = () => {
+    const { documentElement } = document;
+    const { rootRef, optionsIsOpeningUpward } = this.props;
+
+    if (!documentElement || !documentElement.style || !rootRef || !rootRef.current) {
+      return; // --rp-options-max-height-default defaults to 300px
+    }
+
+    const { height, top } = rootRef.current.getBoundingClientRect();
+    // opening upwards case
+    if (optionsIsOpeningUpward && top < window.innerHeight) {
+      this.setState({ optionsMaxHeight: top });
+      return;
+    }
+
+    // opening downwards case
+    const optionsMaxHeight = window.innerHeight - top - height - 25;
+    if (!optionsIsOpeningUpward && optionsMaxHeight > 0) {
+      this.setState({ optionsMaxHeight });
+    }
+  }
 
   render() {
-    return <div>{this.props.children()}</div>;
+    const { optionsMaxHeight } = this.state;
+    return <div>{this.props.children({ optionsMaxHeight })}</div>;
   }
 }

--- a/source/components/Options.js
+++ b/source/components/Options.js
@@ -9,6 +9,7 @@ import type {
   // $FlowFixMe
   SyntheticEvent,
   Element,
+  ElementRef,
   Ref
 } from 'react';
 
@@ -40,7 +41,7 @@ type Props = {
   selectedOption?: any,
   selectedOptions?: Array<any>,
   skin?: ComponentType<any>,
-  targetRef?: Ref<*>,
+  targetRef?: ElementRef<*>,
   theme: ?Object, // if passed by user, it will take precedence over this.props.context.theme
   themeId: string,
   themeOverrides: Object,
@@ -90,6 +91,7 @@ class OptionsBase extends Component<Props, State> {
     if (this.props.isOpen) {
       document.addEventListener('keydown', this._handleKeyDown, false);
     }
+    this.calculateOptionsHeight();
   }
 
   componentWillReceiveProps(nextProps: Props) {
@@ -103,6 +105,20 @@ class OptionsBase extends Component<Props, State> {
 
   componentWillUnmount() {
     document.removeEventListener('keydown', this._handleKeyDown, false);
+  }
+
+  calculateOptionsHeight = () => {
+    if (!document.documentElement || !document.documentElement.style) {
+      return;
+    }
+    const { targetRef } = this.props;
+    let optionsMaxHeight = window.innerHeight;
+
+    if (targetRef && targetRef.current) {
+      const { offsetTop, offsetHeight } = targetRef.current;
+      optionsMaxHeight = window.innerHeight - offsetTop + offsetHeight;
+    }
+    document.documentElement.style.setProperty('--rp-options-max-height-default', `${optionsMaxHeight}px`);
   }
 
   close = () => {

--- a/source/components/Options.js
+++ b/source/components/Options.js
@@ -34,6 +34,7 @@ type Props = {
   options: Array<any>,
   optionRenderer?: Function,
   optionsRef?: ElementRef<any>,
+  optionsMaxHeight?: number,
   render?: Function,
   resetOnClose: boolean,
   // TODO: Why do we have two separate props for selection?
@@ -90,7 +91,6 @@ class OptionsBase extends Component<Props, State> {
     if (this.props.isOpen) {
       document.addEventListener('keydown', this._handleKeyDown, false);
     }
-    this.calculateOptionsHeight();
   }
 
   componentWillReceiveProps(nextProps: Props) {
@@ -104,20 +104,6 @@ class OptionsBase extends Component<Props, State> {
 
   componentWillUnmount() {
     document.removeEventListener('keydown', this._handleKeyDown, false);
-  }
-
-  calculateOptionsHeight = () => {
-    if (!document.documentElement || !document.documentElement.style) {
-      return;
-    }
-    const { targetRef } = this.props;
-    let optionsMaxHeight = window.innerHeight;
-
-    if (targetRef && targetRef.current) {
-      const { offsetTop, offsetHeight } = targetRef.current;
-      optionsMaxHeight = window.innerHeight - offsetTop + offsetHeight;
-    }
-    document.documentElement.style.setProperty('--rp-options-max-height-default', `${optionsMaxHeight}px`);
   }
 
   close = () => {

--- a/source/components/Options.js
+++ b/source/components/Options.js
@@ -10,7 +10,6 @@ import type {
   SyntheticEvent,
   Element,
   ElementRef,
-  Ref
 } from 'react';
 
 // internal utility functions
@@ -34,7 +33,7 @@ type Props = {
   onClose?: Function,
   options: Array<any>,
   optionRenderer?: Function,
-  optionsRef?: Ref<any>,
+  optionsRef?: ElementRef<any>,
   render?: Function,
   resetOnClose: boolean,
   // TODO: Why do we have two separate props for selection?

--- a/source/components/Select.js
+++ b/source/components/Select.js
@@ -143,15 +143,17 @@ class SelectBase extends Component<Props, State> {
       <GlobalListeners
         toggleOpen={this.toggleOpen}
         optionsIsOpen={this.state.isOpen}
+        optionsIsOpeningUpward={this.props.isOpeningUpward}
         optionsRef={this.optionsElement}
         rootRef={this.rootElement}
       >
-        {() => (
+        {({ optionsMaxHeight }) => (
           <SelectSkin
             isOpen={this.state.isOpen}
             rootRef={this.rootElement}
             inputRef={this.inputElement}
             optionsRef={this.optionsElement}
+            optionsMaxHeight={optionsMaxHeight}
             theme={this.state.composedTheme}
             getSelectedOption={this.getSelectedOption}
             handleInputClick={this.handleInputClick}

--- a/source/skins/simple/AutocompleteSkin.js
+++ b/source/skins/simple/AutocompleteSkin.js
@@ -1,6 +1,6 @@
 // @flow
 import React from 'react';
-import type { Ref, Element } from 'react';
+import type { ElementRef, Element } from 'react';
 
 // external libraries
 import _ from 'lodash';
@@ -22,7 +22,7 @@ type Props = {
   handleAutocompleteClick: Function,
   handleChange: Function,
   handleInputChange: Function,
-  inputRef: Ref<'input'>,
+  inputRef: ElementRef<any>,
   inputValue: string,
   isOpeningUpward: boolean,
   isOpen: boolean,
@@ -31,14 +31,14 @@ type Props = {
   maxVisibleOptions: number,
   onKeyDown: Function,
   options: Array<any>,
-  optionsRef: Ref<any>,
+  optionsRef: ElementRef<any>,
   placeholder: string,
   removeOption: Function,
   renderSelections: Function,
   renderOptions: Function,
-  rootRef: Ref<any>,
+  rootRef: ElementRef<any>,
   selectedOptions: Array<any>,
-  suggestionsRef: Ref<*>,
+  suggestionsRef: ElementRef<any>,
   theme: Object,
   themeId: string,
   toggleOpen: Function

--- a/source/skins/simple/AutocompleteSkin.js
+++ b/source/skins/simple/AutocompleteSkin.js
@@ -32,6 +32,7 @@ type Props = {
   onKeyDown: Function,
   options: Array<any>,
   optionsRef: ElementRef<any>,
+  optionsMaxHeight: number,
   placeholder: string,
   removeOption: Function,
   renderSelections: Function,
@@ -138,6 +139,7 @@ export const AutocompleteSkin = (props: Props) => {
         onChange={props.handleChange}
         options={filteredAndLimitedOptions}
         optionsRef={props.optionsRef}
+        optionsMaxHeight={props.optionsMaxHeight}
         render={props.renderOptions}
         resetOnClose
         selectedOptions={props.selectedOptions}

--- a/source/skins/simple/BubbleSkin.js
+++ b/source/skins/simple/BubbleSkin.js
@@ -1,6 +1,6 @@
 // @flow
 import React from 'react';
-import type { Node, Ref } from 'react';
+import type { Node, ElementRef } from 'react';
 
 // external libraries
 import classnames from 'classnames';
@@ -16,7 +16,7 @@ type Props = {
   isOpeningUpward: boolean,
   isTransparent: boolean,
   position: Object,
-  rootRef: Ref<*>,
+  rootRef: ElementRef<*>,
   theme: Object,
   themeId: string
 };

--- a/source/skins/simple/InfiniteScrollSkin.js
+++ b/source/skins/simple/InfiniteScrollSkin.js
@@ -1,6 +1,6 @@
 // @flow
 import React from 'react';
-import type { Ref, Element } from 'react';
+import type { ElementRef, Element } from 'react';
 
 // external libraries
 import classnames from 'classnames';
@@ -12,7 +12,7 @@ type Props = {
   hasMoreData: boolean,
   isLoading: boolean,
   renderItems: Function,
-  scrollContainerRef: Ref<*>,
+  scrollContainerRef: ElementRef<*>,
   theme: Object,
   themeId: string
 };

--- a/source/skins/simple/InputSkin.js
+++ b/source/skins/simple/InputSkin.js
@@ -1,6 +1,6 @@
 // @flow
 import React from 'react';
-import type { Ref, Element } from 'react';
+import type { ElementRef, Element } from 'react';
 
 // external libraries
 import classnames from 'classnames';
@@ -19,7 +19,7 @@ type Props = {
   disabled?: boolean,
   error?: string,
   label?: string | Element<any>,
-  inputRef: Ref<'input'>,
+  inputRef: ElementRef<'input'>,
   onBlur?: Function,
   onChange?: Function,
   onFocus?: Function,

--- a/source/skins/simple/OptionsSkin.js
+++ b/source/skins/simple/OptionsSkin.js
@@ -1,6 +1,6 @@
 // @flow
 import React from 'react';
-import type { Element, Ref } from 'react';
+import type { Element, ElementRef } from 'react';
 
 // external libraries
 import classnames from 'classnames';
@@ -24,11 +24,11 @@ type Props = {
   noResultsMessage: string | Element<any>,
   optionRenderer: Function,
   options: Array<any>,
-  optionsRef: Ref<*>,
+  optionsRef: ElementRef<*>,
   render: Function,
   selectedOption: any,
   setHighlightedOptionIndex: Function,
-  targetRef: Ref<*>,
+  targetRef: ElementRef<*>,
   theme: Object,
   themeId: string,
 };

--- a/source/skins/simple/OptionsSkin.js
+++ b/source/skins/simple/OptionsSkin.js
@@ -25,6 +25,7 @@ type Props = {
   optionRenderer: Function,
   options: Array<any>,
   optionsRef: ElementRef<*>,
+  optionsMaxHeight: number,
   render: Function,
   selectedOption: any,
   setHighlightedOptionIndex: Function,
@@ -52,6 +53,7 @@ export const OptionsSkin = (props: Props) => {
     targetRef,
     theme,
     themeId,
+    optionsMaxHeight,
   } = props;
 
   const highlightedOptionIndex = getHighlightedOptionIndex();
@@ -123,7 +125,7 @@ export const OptionsSkin = (props: Props) => {
       isFloating
       targetRef={targetRef}
     >
-      <ul ref={optionsRef} className={theme[themeId].ul}>{renderOptions()}</ul>
+      <ul style={{ maxHeight: `${optionsMaxHeight}px` }} ref={optionsRef} className={theme[themeId].ul}>{renderOptions()}</ul>
     </Bubble>
   );
 };

--- a/source/skins/simple/OptionsSkin.js
+++ b/source/skins/simple/OptionsSkin.js
@@ -108,6 +108,11 @@ export const OptionsSkin = (props: Props) => {
     return option;
   };
 
+  // Enforce max height of options dropdown if necessary
+  const optionsStyle = optionsMaxHeight == null ? null : {
+    maxHeight: `${optionsMaxHeight}px`
+  };
+
   return (
     <Bubble
       className={classnames([
@@ -125,7 +130,13 @@ export const OptionsSkin = (props: Props) => {
       isFloating
       targetRef={targetRef}
     >
-      <ul style={{ maxHeight: `${optionsMaxHeight}px` }} ref={optionsRef} className={theme[themeId].ul}>{renderOptions()}</ul>
+      <ul
+        style={optionsStyle}
+        ref={optionsRef}
+        className={theme[themeId].ul}
+      >
+        {renderOptions()}
+      </ul>
     </Bubble>
   );
 };

--- a/source/skins/simple/SelectSkin.js
+++ b/source/skins/simple/SelectSkin.js
@@ -1,6 +1,6 @@
 // @flow
 import React from 'react';
-import type { Element, Ref } from 'react';
+import type { Element, ElementRef } from 'react';
 
 // external libraries
 import classnames from 'classnames';
@@ -20,7 +20,7 @@ type Props = {
   getSelectedOption: Function,
   handleChange: Function,
   handleInputClick: Function,
-  inputRef: Ref<'input'>,
+  inputRef: ElementRef<'input'>,
   isOpen: boolean,
   isOpeningUpward: boolean,
   label: string | Element<any>,
@@ -32,9 +32,9 @@ type Props = {
     value: any
   }>,
   optionRenderer: Function,
-  optionsRef: Ref<any>,
+  optionsRef: ElementRef<any>,
   placeholder: string,
-  rootRef: Ref<*>,
+  rootRef: ElementRef<*>,
   theme: Object, // will take precedence over theme in context if passed
   themeId: string,
   toggleOpen: Function,

--- a/source/skins/simple/SelectSkin.js
+++ b/source/skins/simple/SelectSkin.js
@@ -33,6 +33,7 @@ type Props = {
   }>,
   optionRenderer: Function,
   optionsRef: ElementRef<any>,
+  optionsMaxHeight: number,
   placeholder: string,
   rootRef: ElementRef<*>,
   theme: Object, // will take precedence over theme in context if passed
@@ -73,6 +74,7 @@ export const SelectSkin = (props: Props) => {
         theme={theme}
         isOpen={props.isOpen}
         optionsRef={props.optionsRef}
+        optionsMaxHeight={props.optionsMaxHeight}
         options={props.options}
         isOpeningUpward={props.isOpeningUpward}
         onChange={props.handleChange}

--- a/source/skins/simple/TextAreaSkin.js
+++ b/source/skins/simple/TextAreaSkin.js
@@ -1,6 +1,6 @@
 // @flow
 import React from 'react';
-import type { Ref, Element } from 'react';
+import type { ElementRef, Element } from 'react';
 
 // external libraries
 import classnames from 'classnames';
@@ -24,7 +24,7 @@ type Props = {
   onFocus?: Function,
   placeholder?: string,
   rows: number,
-  textareaRef?: Ref<any>,
+  textareaRef?: ElementRef<'textarea'>,
   theme: Object,
   themeId: string,
   value: string

--- a/source/themes/simple/SimpleOptions.scss
+++ b/source/themes/simple/SimpleOptions.scss
@@ -9,6 +9,7 @@ $options-border-color: var(--rp-options-border-color, #c6cdd6) !default;
 $options-border-radius: var(--rp-options-border-radius, 2px) !default;
 $options-font-family: var(--rp-options-font-family, $theme-font-regular, sans-serif) !default;
 $options-font-size: var(--rp-options-font-size, 16px) !default;
+$options-max-height: var(--rp-options-max-height, var(--rp-options-max-height-default, 300px)) !default;
 $options-shadow: var(--rp-options-shadow, none) !default;
 
 // option
@@ -36,6 +37,9 @@ $options-arrow-size: var(--rp-options-arrow-size, 10px) !default;
 
 .options {
   & > div {
+    max-height: $options-max-height;
+    overflow-x: hidden;
+    overflow-y: auto;
     padding: 0;
   }
 

--- a/source/themes/simple/SimpleOptions.scss
+++ b/source/themes/simple/SimpleOptions.scss
@@ -9,7 +9,6 @@ $options-border-color: var(--rp-options-border-color, #c6cdd6) !default;
 $options-border-radius: var(--rp-options-border-radius, 2px) !default;
 $options-font-family: var(--rp-options-font-family, $theme-font-regular, sans-serif) !default;
 $options-font-size: var(--rp-options-font-size, 16px) !default;
-$options-max-height: var(--rp-options-max-height, var(--rp-options-max-height-default, 300px)) !default;
 $options-shadow: var(--rp-options-shadow, none) !default;
 
 // option
@@ -37,9 +36,6 @@ $options-arrow-size: var(--rp-options-arrow-size, 10px) !default;
 
 .options {
   & > div {
-    max-height: $options-max-height;
-    overflow-x: hidden;
-    overflow-y: auto;
     padding: 0;
   }
 
@@ -85,6 +81,8 @@ $options-arrow-size: var(--rp-options-arrow-size, 10px) !default;
   list-style: none;
   font-family: $options-font-family;
   font-size: $options-font-size;
+  overflow-x: hidden;
+  overflow-y: auto;
 }
 
 .option {

--- a/stories/ThemeProvider.stories.js
+++ b/stories/ThemeProvider.stories.js
@@ -55,7 +55,7 @@ import progressBarOverrides2 from './theme-overrides/customProgressBar.scss';
 // constants
 import { IDENTIFIERS } from '../source/components';
 
-const MNEMONICS = ['home', 'cat', 'dog', 'fish'];
+const MNEMONICS = ['home', 'cat', 'dog', 'fish', 'home', 'cat', 'dog', 'fish', 'home', 'cat', 'dog', 'fish'];
 
 const {
   AUTOCOMPLETE,
@@ -177,22 +177,35 @@ storiesOf('ThemeProvider', module)
         </div>
 
         <div style={{ margin: '50px' }}>
-          <Options
+          {/* <Options
             isOpen
             options={MNEMONICS}
             isOpeningUpward={false}
             noResults={false}
             skin={OptionsSkin}
+          /> */}
+        </div>
+
+        <div style={{ margin: '400px 100px 250px 100px', height: '225px' }}>
+          <Autocomplete
+            label="Autocomplete opening upward"
+            options={MNEMONICS}
+            placeholder="Enter mnemonic..."
+            maxSelections={12}
+            maxVisibleOptions={20}
+            invalidCharsRegex={/[^a-zA-Z]/g}
+            skin={AutocompleteSkin}
+            isOpeningUpward
           />
         </div>
 
         <div style={{ margin: '400px 100px 250px 100px', height: '225px' }}>
           <Autocomplete
-            label="Autocomplete with custom theme"
+            label="Autocomplete opening downward"
             options={MNEMONICS}
             placeholder="Enter mnemonic..."
             maxSelections={12}
-            maxVisibleOptions={5}
+            maxVisibleOptions={20}
             invalidCharsRegex={/[^a-zA-Z]/g}
             skin={AutocompleteSkin}
           />


### PR DESCRIPTION
**1.** This PR ensures that the maximum height of the `Options` dropdown is calculated based on `window.innerHeight` and the distance in pixels from the `top` or `bottom` of `Options` to the top or bottom of the user's viewport. This ensures that the drop down doesn't run off the screen when there are many options that have a greater height than `window.innerHeight`. The `max-height` for `Options` is recalculated during `scroll` and `resize` events.

**2.** This PR also fixes the flow types for refs that are passed as props between components and skins. We should have been using the flow type `ElementRef` instead of `Ref`, so the changes here make this swap.

**How to Test**
In order to test these changes, I recommend running `yarn storybook` and navigating to the `ThemeProvider` stories then selecting the `custom theme` story. From there scroll down to two instance of `Autocomplete` I've added where one opens upwards and one opens downwards. Scroll to different areas on the document and open them to see how `Options` responds.