### PR TITLE
[DDW-604] Add Disabled Text Color CSS Var for Simple Button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## vNext
 
+### Chores
+
+- Adds CSS variable in SimpleButton's theme allowing configuration of button text color when disabled.
+  [PR 103](https://github.com/input-output-hk/react-polymorph/pull/103)
+
 ### Fixes
 
 - Sets max height of Options drop down based on window height and offset of Options' target ref.

--- a/source/themes/simple/SimpleButton.scss
+++ b/source/themes/simple/SimpleButton.scss
@@ -17,6 +17,7 @@ $button-height: var(--rp-button-height, auto) !default;
 $button-line-height: var(--rp-button-line-height, normal) !default;
 $button-padding: var(--rp-button-padding, 15px 20px) !default;
 $button-text-color: var(--rp-button-text-color, #fff) !default;
+$button-text-color-disabled: var(--rp-button-text-color-disabled, #fff);
 $button-text-transform: var(--rp-button-text-transform, none) !default;
 $button-width: var(--rp-button-width, 100%) !default;
 
@@ -54,6 +55,7 @@ $button-width: var(--rp-button-width, 100%) !default;
 
 .disabled {
   background-color: $button-bg-color-disabled;
+  color: $button-text-color-disabled;
   cursor: $button-cursor-disabled;
 }
 

--- a/stories/ThemeProvider.stories.js
+++ b/stories/ThemeProvider.stories.js
@@ -13,7 +13,6 @@ import { Modal } from '../source/components/Modal';
 import { TextArea } from '../source/components/TextArea';
 import { Autocomplete } from '../source/components/Autocomplete';
 import { Radio } from '../source/components/Radio';
-import { Options } from '../source/components/Options';
 import { Button } from '../source/components/Button';
 import { ProgressBar } from '../source/components/ProgressBar';
 import { Flex } from '../source/components/layout/Flex';
@@ -28,7 +27,6 @@ import { TextAreaSkin } from '../source/skins/simple/TextAreaSkin';
 import { TogglerSkin } from '../source/skins/simple/TogglerSkin';
 import { AutocompleteSkin } from '../source/skins/simple/AutocompleteSkin';
 import { RadioSkin } from '../source/skins/simple/RadioSkin';
-import { OptionsSkin } from '../source/skins/simple/OptionsSkin';
 import { ButtonSkin } from '../source/skins/simple/ButtonSkin';
 import { CheckboxSkin } from '../source/skins/simple/CheckboxSkin';
 import { ProgressBarSkin } from '../source/skins/simple/ProgressBarSkin';
@@ -176,17 +174,7 @@ storiesOf('ThemeProvider', module)
           />
         </div>
 
-        <div style={{ margin: '50px' }}>
-          {/* <Options
-            isOpen
-            options={MNEMONICS}
-            isOpeningUpward={false}
-            noResults={false}
-            skin={OptionsSkin}
-          /> */}
-        </div>
-
-        <div style={{ margin: '400px 100px 250px 100px', height: '225px' }}>
+        <div style={{ margin: '100px', height: '225px' }}>
           <Autocomplete
             label="Autocomplete opening upward"
             options={MNEMONICS}
@@ -199,7 +187,7 @@ storiesOf('ThemeProvider', module)
           />
         </div>
 
-        <div style={{ margin: '400px 100px 250px 100px', height: '225px' }}>
+        <div style={{ margin: '0 100px 400px 100px', height: '225px' }}>
           <Autocomplete
             label="Autocomplete opening downward"
             options={MNEMONICS}


### PR DESCRIPTION
Adds CSS variable in `SimpleButton.scss` allowing configuration of button text color when button state is `disabled`. This is needed in Daedalus for the new theme utility function and also makes sense to have here in general.

Cleans up commented out code, unused imports, and margins that were overlooked in the changes from PR 102 (added dynamic sizing of Options `max-height`).