### PR TITLE
Release/0.8.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ Upcoming changes for the next release.
 0.8.5
 =====
 
+### Fixes
+
+- Resets scroll position of Options when Autocomplete or Select transition from opened to closed.
+  [PR 109](https://github.com/input-output-hk/react-polymorph/pull/109)
+
 ### Chores
 
 - Automatic storybook builds & previews have been setup with netlify.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ vNext
 
 Upcoming changes for the next release.
 
+0.8.5
+=====
+
 ### Chores
 
 - Automatic storybook builds & previews have been setup with netlify.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,16 @@ Upcoming changes for the next release.
 
 ### Chores
 
-- Automatic storybook builds & previews have been setup with netlify
+- Automatic storybook builds & previews have been setup with netlify.
   [PR 107](https://github.com/input-output-hk/react-polymorph/pull/107)
+
+0.8.4
+=====
+
+### Fixes
+
+- Fixes bug where Options does not close properly when scroll event occurs.
+  [PR 108](https://github.com/input-output-hk/react-polymorph/pull/108)
 
 0.8.3
 =====

--- a/__tests__/__snapshots__/Autocomplete.test.js.snap
+++ b/__tests__/__snapshots__/Autocomplete.test.js.snap
@@ -40,6 +40,8 @@ exports[`Autocomplete renders correctly 1`] = `
       >
         <ul
           className="ul"
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
           style={
             Object {
               "maxHeight": "300px",
@@ -134,6 +136,8 @@ exports[`Autocomplete renders with a placeholder 1`] = `
       >
         <ul
           className="ul"
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
           style={
             Object {
               "maxHeight": "300px",
@@ -231,6 +235,8 @@ exports[`Autocomplete renders with an error 1`] = `
       >
         <ul
           className="ul"
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
           style={
             Object {
               "maxHeight": "300px",
@@ -332,6 +338,8 @@ exports[`Autocomplete renders with label 1`] = `
       >
         <ul
           className="ul"
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
           style={
             Object {
               "maxHeight": "300px",
@@ -425,6 +433,8 @@ exports[`Autocomplete uses render prop - renderOptions 1`] = `
       >
         <ul
           className="ul"
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
           style={
             Object {
               "maxHeight": "300px",
@@ -502,6 +512,8 @@ exports[`Autocomplete uses render prop - renderSelections 1`] = `
       >
         <ul
           className="ul"
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
           style={
             Object {
               "maxHeight": "300px",

--- a/__tests__/__snapshots__/Select.test.js.snap
+++ b/__tests__/__snapshots__/Select.test.js.snap
@@ -35,6 +35,8 @@ exports[`Select isOpen={true} 1`] = `
       >
         <ul
           className="ul"
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
           style={
             Object {
               "maxHeight": "300px",
@@ -152,6 +154,8 @@ exports[`Select isOpeningUpward={true} 1`] = `
       >
         <ul
           className="ul"
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
           style={
             Object {
               "maxHeight": "300px",
@@ -269,6 +273,8 @@ exports[`Select renders correctly 1`] = `
       >
         <ul
           className="ul"
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
           style={
             Object {
               "maxHeight": "300px",
@@ -390,6 +396,8 @@ exports[`Select renders with an error 1`] = `
       >
         <ul
           className="ul"
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
           style={
             Object {
               "maxHeight": "300px",
@@ -507,6 +515,8 @@ exports[`Select renders with disabled options 1`] = `
       >
         <ul
           className="ul"
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
           style={
             Object {
               "maxHeight": "300px",
@@ -612,6 +622,8 @@ exports[`Select renders with placeholder 1`] = `
       >
         <ul
           className="ul"
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
           style={
             Object {
               "maxHeight": "300px",
@@ -729,6 +741,8 @@ exports[`Select uses render prop - optionRenderer 1`] = `
       >
         <ul
           className="ul"
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
           style={
             Object {
               "maxHeight": "300px",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-polymorph",
   "description": "React components with highly customizable logic, markup and styles.",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "scripts": {
     "build": "cross-env npm run clean && npm run sass && npm run js",
     "clean": "rimraf ./lib",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-polymorph",
   "description": "React components with highly customizable logic, markup and styles.",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "scripts": {
     "build": "cross-env npm run clean && npm run sass && npm run js",
     "clean": "rimraf ./lib",

--- a/source/components/Autocomplete.js
+++ b/source/components/Autocomplete.js
@@ -120,7 +120,13 @@ class AutocompleteBase extends Component<Props, State> {
 
   close = () => this.setState({ isOpen: false });
 
-  toggleOpen = () => this.setState({ isOpen: !this.state.isOpen });
+  toggleOpen = () => {
+    if (this.state.isOpen && this.optionsElement && this.optionsElement.current) {
+      // set Options scroll position to top on close
+      this.optionsElement.current.scrollTop = 0;
+    }
+    this.setState({ isOpen: !this.state.isOpen });
+  }
 
   toggleMouseLocation = () => (
     this.setState({ mouseIsOverOptions: !this.state.mouseIsOverOptions })

--- a/source/components/Autocomplete.js
+++ b/source/components/Autocomplete.js
@@ -41,12 +41,13 @@ type Props = {
 };
 
 type State = {
-  inputValue: string,
+  composedTheme: Object,
   error: string,
-  selectedOptions: Array<any>,
   filteredOptions: Array<any>,
   isOpen: boolean,
-  composedTheme: Object
+  inputValue: string,
+  mouseIsOverOptions: boolean,
+  selectedOptions: Array<any>,
 };
 
 class AutocompleteBase extends Component<Props, State> {
@@ -98,6 +99,7 @@ class AutocompleteBase extends Component<Props, State> {
       filteredOptions:
         sortAlphabetically && options ? options.sort() : options || [],
       isOpen: false,
+      mouseIsOverOptions: false,
       composedTheme: composeTheme(
         addThemeId(theme || context.theme, themeId),
         addThemeId(themeOverrides, themeId),
@@ -119,6 +121,10 @@ class AutocompleteBase extends Component<Props, State> {
   close = () => this.setState({ isOpen: false });
 
   toggleOpen = () => this.setState({ isOpen: !this.state.isOpen });
+
+  toggleMouseLocation = () => (
+    this.setState({ mouseIsOverOptions: !this.state.mouseIsOverOptions })
+  );
 
   handleAutocompleteClick = () => {
     const { inputElement } = this;
@@ -237,6 +243,7 @@ class AutocompleteBase extends Component<Props, State> {
 
     return (
       <GlobalListeners
+        mouseIsOverOptions={this.state.mouseIsOverOptions}
         optionsIsOpen={this.state.isOpen}
         optionsIsOpeningUpward={this.props.isOpeningUpward}
         optionsRef={this.optionsElement}
@@ -262,6 +269,7 @@ class AutocompleteBase extends Component<Props, State> {
             selectedOptions={this.state.selectedOptions}
             suggestionsRef={this.suggestionsElement}
             theme={this.state.composedTheme}
+            toggleMouseLocation={this.toggleMouseLocation}
             toggleOpen={this.toggleOpen}
             {...rest}
           />

--- a/source/components/HOC/GlobalListeners.js
+++ b/source/components/HOC/GlobalListeners.js
@@ -14,6 +14,7 @@ import {
 
 type Props = {
   children: Function,
+  mouseIsOverOptions: boolean,
   optionsIsOpen: boolean,
   optionsIsOpeningUpward: boolean,
   optionsRef?: ElementRef<*>,
@@ -117,7 +118,7 @@ export class GlobalListeners extends Component<Props, State> {
   _handleDocumentScroll = () => this._removeListenersAndToggle();
 
   _addCalculateMaxHeightListeners = () => {
-    const scrollListener = ['scroll', debounce(this._calculateOptionsMaxHeight, 300)];
+    const scrollListener = ['scroll', debounce(this._calculateOptionsMaxHeight, 300, { leading: true }), true];
     const resizeListener = ['resize', debounce(this._calculateOptionsMaxHeight, 300)];
     document.addEventListener(...scrollListener);
     window.addEventListener(...resizeListener);
@@ -127,7 +128,16 @@ export class GlobalListeners extends Component<Props, State> {
   // from Options rootRef to edge of window (up or down) else Options run off page
   _calculateOptionsMaxHeight = () => {
     const { documentElement } = document;
-    const { rootRef, optionsIsOpeningUpward } = this.props;
+    const {
+      rootRef,
+      optionsIsOpeningUpward,
+      optionsIsOpen,
+      toggleOpen,
+      mouseIsOverOptions,
+    } = this.props;
+
+    // checks if Options are open & being scrolled upon via mouse position prior to toggling closed
+    optionsIsOpen && !mouseIsOverOptions && toggleOpen();
 
     if (!documentElement || !documentElement.style || !rootRef || !rootRef.current) {
       return;

--- a/source/components/Options.js
+++ b/source/components/Options.js
@@ -45,6 +45,7 @@ type Props = {
   theme: ?Object, // if passed by user, it will take precedence over this.props.context.theme
   themeId: string,
   themeOverrides: Object,
+  toggleMouseLocation?: Function,
   toggleOpen?: Function
 };
 

--- a/source/components/Options.js
+++ b/source/components/Options.js
@@ -108,7 +108,7 @@ class OptionsBase extends Component<Props, State> {
   }
 
   close = () => {
-    const { onClose, resetOnClose, toggleOpen, isOpen } = this.props;
+    const { isOpen, onClose, resetOnClose, toggleOpen  } = this.props;
     if (isOpen && toggleOpen) toggleOpen();
     this.setState({
       highlightedOptionIndex: resetOnClose ? 0 : this.state.highlightedOptionIndex

--- a/source/components/Options.js
+++ b/source/components/Options.js
@@ -108,7 +108,7 @@ class OptionsBase extends Component<Props, State> {
   }
 
   close = () => {
-    const { isOpen, onClose, resetOnClose, toggleOpen  } = this.props;
+    const { isOpen, onClose, resetOnClose, toggleOpen } = this.props;
     if (isOpen && toggleOpen) toggleOpen();
     this.setState({
       highlightedOptionIndex: resetOnClose ? 0 : this.state.highlightedOptionIndex

--- a/source/components/Select.js
+++ b/source/components/Select.js
@@ -37,7 +37,8 @@ type Props = {
 
 type State = {
   composedTheme: Object,
-  isOpen: boolean
+  isOpen: boolean,
+  mouseIsOverOptions: boolean,
 };
 
 class SelectBase extends Component<Props, State> {
@@ -76,7 +77,8 @@ class SelectBase extends Component<Props, State> {
         addThemeId(themeOverrides, themeId),
         context.ROOT_THEME_API
       ),
-      isOpen: false
+      isOpen: false,
+      mouseIsOverOptions: false,
     };
   }
 
@@ -98,6 +100,10 @@ class SelectBase extends Component<Props, State> {
   focus = () => this.toggleOpen();
 
   toggleOpen = () => this.setState({ isOpen: !this.state.isOpen });
+
+  toggleMouseLocation = () => (
+    this.setState({ mouseIsOverOptions: !this.state.mouseIsOverOptions })
+  );
 
   handleInputClick = (event: SyntheticMouseEvent<>) => {
     event.stopPropagation();
@@ -141,11 +147,12 @@ class SelectBase extends Component<Props, State> {
 
     return (
       <GlobalListeners
-        toggleOpen={this.toggleOpen}
+        mouseIsOverOptions={this.state.mouseIsOverOptions}
         optionsIsOpen={this.state.isOpen}
         optionsIsOpeningUpward={this.props.isOpeningUpward}
         optionsRef={this.optionsElement}
         rootRef={this.rootElement}
+        toggleOpen={this.toggleOpen}
       >
         {({ optionsMaxHeight }) => (
           <SelectSkin
@@ -159,6 +166,7 @@ class SelectBase extends Component<Props, State> {
             handleInputClick={this.handleInputClick}
             handleChange={this.handleChange}
             toggleOpen={this.toggleOpen}
+            toggleMouseLocation={this.toggleMouseLocation}
             {...rest}
           />
         )}

--- a/source/components/Select.js
+++ b/source/components/Select.js
@@ -99,7 +99,13 @@ class SelectBase extends Component<Props, State> {
   // toggle options open because Select's input is read only
   focus = () => this.toggleOpen();
 
-  toggleOpen = () => this.setState({ isOpen: !this.state.isOpen });
+  toggleOpen = () => {
+    if (this.state.isOpen && this.optionsElement && this.optionsElement.current) {
+      // set Options scroll position to top on close
+      this.optionsElement.current.scrollTop = 0;
+    }
+    this.setState({ isOpen: !this.state.isOpen });
+  }
 
   toggleMouseLocation = () => (
     this.setState({ mouseIsOverOptions: !this.state.mouseIsOverOptions })

--- a/source/skins/simple/AutocompleteSkin.js
+++ b/source/skins/simple/AutocompleteSkin.js
@@ -42,7 +42,8 @@ type Props = {
   suggestionsRef: ElementRef<any>,
   theme: Object,
   themeId: string,
-  toggleOpen: Function
+  toggleMouseLocation: Function,
+  toggleOpen: Function,
 };
 
 export const AutocompleteSkin = (props: Props) => {
@@ -145,6 +146,7 @@ export const AutocompleteSkin = (props: Props) => {
         selectedOptions={props.selectedOptions}
         skin={OptionsSkin}
         targetRef={props.suggestionsRef}
+        toggleMouseLocation={props.toggleMouseLocation}
         toggleOpen={props.toggleOpen}
       />
     </div>

--- a/source/skins/simple/OptionsSkin.js
+++ b/source/skins/simple/OptionsSkin.js
@@ -32,6 +32,7 @@ type Props = {
   targetRef: ElementRef<*>,
   theme: Object,
   themeId: string,
+  toggleMouseLocation: Function,
 };
 
 export const OptionsSkin = (props: Props) => {
@@ -45,6 +46,7 @@ export const OptionsSkin = (props: Props) => {
     isSelectedOption,
     noResults,
     noResultsMessage,
+    optionsMaxHeight,
     optionRenderer,
     options,
     optionsRef,
@@ -53,7 +55,7 @@ export const OptionsSkin = (props: Props) => {
     targetRef,
     theme,
     themeId,
-    optionsMaxHeight,
+    toggleMouseLocation,
   } = props;
 
   const highlightedOptionIndex = getHighlightedOptionIndex();
@@ -134,6 +136,8 @@ export const OptionsSkin = (props: Props) => {
         style={optionsStyle}
         ref={optionsRef}
         className={theme[themeId].ul}
+        onMouseEnter={toggleMouseLocation}
+        onMouseLeave={toggleMouseLocation}
       >
         {renderOptions()}
       </ul>

--- a/source/skins/simple/SelectSkin.js
+++ b/source/skins/simple/SelectSkin.js
@@ -39,6 +39,7 @@ type Props = {
   theme: Object, // will take precedence over theme in context if passed
   themeId: string,
   toggleOpen: Function,
+  toggleMouseLocation: Function,
   value: string
 };
 
@@ -82,6 +83,7 @@ export const SelectSkin = (props: Props) => {
         selectedOption={selectedOption}
         noResults={!props.options.length}
         targetRef={props.inputRef}
+        toggleMouseLocation={props.toggleMouseLocation}
         toggleOpen={props.toggleOpen}
       />
     </div>


### PR DESCRIPTION
This PR resets the scroll position of the `Options` dropdown / pop-up to `scrollTop = 0` when either the `Autocomplete` or `Select` components transition from open to closed.