### PR TITLE
Release/0.8.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ vNext
 
 Upcoming changes for the next release.
 
+0.8.6
+=====
+
+### Fixes
+
+- Adds 20px extra space between the top of Options pop-up bubble and the top of the window.
+  This prevents the Options bubble from slightly running underneath the application menu bar at the top of the window.
+  [PR 110](https://github.com/input-output-hk/react-polymorph/pull/110)
+
 0.8.5
 =====
 

--- a/source/components/HOC/GlobalListeners.js
+++ b/source/components/HOC/GlobalListeners.js
@@ -146,7 +146,7 @@ export class GlobalListeners extends Component<Props, State> {
     const { height, top } = rootRef.current.getBoundingClientRect();
     // opening upwards case
     if (optionsIsOpeningUpward && top < window.innerHeight) {
-      this.setState({ optionsMaxHeight: top });
+      this.setState({ optionsMaxHeight: top - 20 });
       return;
     }
 


### PR DESCRIPTION
This is a patch to be used in the next version of Daedalus which adds an extra `20px` space between the top of the `Options` pop-up bubble and the top of the `window`. On certain operating systems, the `Options` pop-up bubble was running underneath the application menu bar (grey bar at the top of the window). This is not an issue regarding the dynamic responsiveness of `Options` that was addressed in [PR 102]([DDW-609] Fix Options Drop Down Max Height for Small Screens). It's just a small adjustment.