### PR TITLE
Improve tooltip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ The history of all changes to react-polymorph.
 vNext
 =====
 
-Upcoming changes for the next release.
+- Adds a new prop `arrowRelativeToTip` to tooltips which allows to center the arrow relative to the size of the tooltip and not the parent element. [PR 113](https://github.com/input-output-hk/react-polymorph/pull/113)
+  - (BREAKING) `none` is no longer a valid option for `$bubble-border-color` and it should instead be `transparent`
+  - (BREAKING) Any library that directly calls the `arrow` mixin directly has to be updated to take into account the change in parameter to use `width` and `height` instead of a single `size`. If you use Bubble or any component that instead of a direct use of the mixin, no change is needed. 
 
 0.8.6
 =====

--- a/README.md
+++ b/README.md
@@ -621,6 +621,7 @@ type TooltipProps = {
   isBounded?: boolean,
   isOpeningUpward: boolean,
   isTransparent: boolean,
+  arrowRelativeToTip: boolean,
   skin?: ComponentType<any>,
   theme: ?Object,
   themeOverrides: Object,

--- a/source/components/Bubble.js
+++ b/source/components/Bubble.js
@@ -19,6 +19,7 @@ type Props = {
   isFloating: boolean,
   isOpeningUpward: boolean,
   isTransparent: boolean,
+  arrowRelativeToTip: boolean,
   skin?: ComponentType<any>,
   theme: ?Object, // takes precedence over them in context if passed
   themeId: string,
@@ -43,6 +44,7 @@ class BubbleBase extends Component<Props, State> {
     isFloating: false,
     isOpeningUpward: false,
     isTransparent: true,
+    arrowRelativeToTip: false,
     theme: null,
     themeId: IDENTIFIERS.BUBBLE,
     themeOverrides: {}

--- a/source/components/Tooltip.js
+++ b/source/components/Tooltip.js
@@ -17,6 +17,7 @@ type Props = {
   isBounded?: boolean,
   isOpeningUpward: boolean,
   isTransparent: boolean,
+  arrowRelativeToTip: boolean,
   skin?: ComponentType<any>,
   theme: ?Object, // will take precedence over theme in context if passed
   themeOverrides: Object, // custom css/scss from user that adheres to component's theme API
@@ -35,6 +36,7 @@ class TooltipBase extends Component<Props, State> {
     context: createEmptyContext(),
     isOpeningUpward: true,
     isTransparent: true,
+    arrowRelativeToTip: false,
     theme: null,
     themeId: IDENTIFIERS.TOOLTIP,
     themeOverrides: {}

--- a/source/skins/simple/BubbleSkin.js
+++ b/source/skins/simple/BubbleSkin.js
@@ -15,6 +15,7 @@ type Props = {
   isHidden: boolean,
   isOpeningUpward: boolean,
   isTransparent: boolean,
+  arrowRelativeToTip: boolean,
   position: Object,
   rootRef: ElementRef<*>,
   theme: Object,
@@ -22,7 +23,7 @@ type Props = {
 };
 
 export const BubbleSkin = (props: Props) => {
-  const { theme, themeId } = props;
+  const { arrowRelativeToTip, theme, themeId } = props;
 
   return (
     <div
@@ -46,8 +47,9 @@ export const BubbleSkin = (props: Props) => {
     >
       <div className={theme[themeId].bubble} data-bubble-container>
         {props.children}
+        {arrowRelativeToTip && <span className={theme[themeId].arrow} data-bubble-arrow />}
       </div>
-      <span className={theme[themeId].arrow} data-bubble-arrow />
+      {!arrowRelativeToTip && <span className={theme[themeId].arrow} data-bubble-arrow />}
     </div>
   );
 };

--- a/source/skins/simple/TooltipSkin.js
+++ b/source/skins/simple/TooltipSkin.js
@@ -21,6 +21,7 @@ type Props = {
   isBounded?: boolean,
   isOpeningUpward: boolean,
   isTransparent: boolean,
+  arrowRelativeToTip: boolean,
   theme: Object,
   themeId: string,
   tip: string | Element<any>
@@ -45,6 +46,7 @@ export const TooltipSkin = (props: Props) => {
         isOpeningUpward={props.isOpeningUpward}
         skin={BubbleSkin}
         isTransparent={props.isTransparent}
+        arrowRelativeToTip={props.arrowRelativeToTip}
       >
         {props.tip}
       </Bubble>

--- a/source/themes/simple/SimpleBubble.scss
+++ b/source/themes/simple/SimpleBubble.scss
@@ -24,6 +24,8 @@ $bubble-shadow: var(--rp-bubble-shadow, none) !default;
 // arrow
 $bubble-arrow: var(--rp-bubble-arrow, true) !default;
 $bubble-arrow-size: var(--rp-bubble-arrow-size, 10px) !default;
+$bubble-arrow-width: var(--rp-bubble-arrow-width, calc(2*#{$bubble-arrow-size})) !default;
+$bubble-arrow-height: var(--rp-bubble-arrow-height, $bubble-arrow-size) !default;
 
 
 .root {
@@ -41,7 +43,8 @@ $bubble-arrow-size: var(--rp-bubble-arrow-size, 10px) !default;
         up,
         $bubble-bg-color-transparent,
         $bubble-border-color-transparent,
-        $bubble-arrow-size
+        $bubble-arrow-width,
+        $bubble-arrow-height,
       );
     }
 
@@ -50,7 +53,8 @@ $bubble-arrow-size: var(--rp-bubble-arrow-size, 10px) !default;
         down,
         $bubble-bg-color-transparent,
         $bubble-border-color-transparent,
-        $bubble-arrow-size
+        $bubble-arrow-width,
+        $bubble-arrow-height,
       );
     }
 
@@ -59,7 +63,8 @@ $bubble-arrow-size: var(--rp-bubble-arrow-size, 10px) !default;
         up,
         $bubble-bg-color,
         $bubble-border-color,
-        $bubble-arrow-size
+        $bubble-arrow-width,
+        $bubble-arrow-height,
       );
     }
 
@@ -68,7 +73,8 @@ $bubble-arrow-size: var(--rp-bubble-arrow-size, 10px) !default;
         down,
         $bubble-bg-color,
         $bubble-border-color,
-        $bubble-arrow-size
+        $bubble-arrow-width,
+        $bubble-arrow-height,
       );
     }
 

--- a/source/themes/simple/SimpleOptions.scss
+++ b/source/themes/simple/SimpleOptions.scss
@@ -32,6 +32,8 @@ $option-checkmark-width: var(--rp-option-checkmark-width, 5px) !default;
 // arrow
 $options-arrow: var(--rp-options-arrow, true) !default;
 $options-arrow-size: var(--rp-options-arrow-size, 10px) !default;
+$options-arrow-width: var(--rp-options-arrow-width, calc(2*#{$options-arrow-size})) !default;
+$options-arrow-height: var(--rp-options-arrow-height, $options-arrow-size) !default;
 
 
 .options {
@@ -45,7 +47,8 @@ $options-arrow-size: var(--rp-options-arrow-size, 10px) !default;
         up,
         $option-bg-color,
         $options-border-color,
-        $options-arrow-size
+        $options-arrow-width,
+        $options-arrow-height,
       );
     }
 
@@ -55,7 +58,8 @@ $options-arrow-size: var(--rp-options-arrow-size, 10px) !default;
           up,
           $option-bg-color-highlighted !important,
           $options-border-color,
-          $options-arrow-size
+          $options-arrow-width,
+          $options-arrow-height,
         );
       }
       &.openUpward [data-bubble-arrow] {
@@ -64,7 +68,8 @@ $options-arrow-size: var(--rp-options-arrow-size, 10px) !default;
           down,
           $option-bg-color-highlighted !important,
           $options-border-color,
-          $options-arrow-size
+          $options-arrow-width,
+          $options-arrow-height,
         );
       }
     }
@@ -132,7 +137,8 @@ $options-arrow-size: var(--rp-options-arrow-size, 10px) !default;
           down,
           $option-bg-color,
           $options-border-color,
-          $options-arrow-size
+          $options-arrow-width,
+          $options-arrow-height,
         );
       }
 
@@ -141,7 +147,8 @@ $options-arrow-size: var(--rp-options-arrow-size, 10px) !default;
           down,
           $option-bg-color-highlighted,
           $options-border-color,
-          $options-arrow-size
+          $options-arrow-width,
+          $options-arrow-height,
         );
       }
     }

--- a/source/themes/simple/mixins/arrow.scss
+++ b/source/themes/simple/mixins/arrow.scss
@@ -1,43 +1,33 @@
-// CSS arrow box inspired from http://www.cssarrowplease.com/
-@mixin arrow($direction, $bg-color, $border-color, $size) {
-  &:after,
+// CSS arrow box inspired from http://apps.eky.hk/css-triangle-generator/
+
+@mixin arrow($direction, $bg-color, $border-color, $width, $height) {
   &:before {
-    @if $direction == up {
-      bottom: 100%;
-    }
-    border: solid transparent;
-    content: " ";
-    height: 0;
-    left: 50%;
-    pointer-events: none;
+    content: "";
     position: absolute;
-    @if $direction == down {
-      top: 100%;
-    }
-    width: 0;
+    z-index: -1;
+    @include arrow_internal($direction, $border-color, $width, $height);
   }
-
   &:after {
-    border-color: transparent;
-    @if $direction == up {
-      border-bottom-color: $bg-color;
-    }
-    @if $direction == down {
-      border-top-color: $bg-color;
-    }
-    border-width: calc(#{$size} - 1px);
-    margin-left: calc(0px - calc(#{$size} - 1px));
+    content: "";
+    position: absolute;
+    @include arrow_internal($direction, $bg-color, calc(#{$width} - 1px), calc(#{$height} - 1px));
   }
+}
 
-  &:before {
-    border-color: transparent;
-    @if $direction == up {
-      border-bottom-color: $border-color;
-    }
-    @if $direction == down {
-      border-top-color: $border-color;
-    }
-    border-width: $size;
-    margin-left: calc(0px - #{$size});
+@mixin arrow_internal($direction, $color, $width, $height) {
+  width: 0;
+  height: 0;
+  border-style: solid;
+  position: absolute;
+  left: calc(50% - #{$width/2} - 1px);
+  @if $direction == up {
+    border-width: 0 calc(#{$width/2}) $height calc(#{$width/2});
+    border-color: transparent transparent $color transparent;
+    bottom: 100%;
+  }
+  @if $direction == down {
+    border-width: $height calc(#{$width/2}) 0 calc(#{$width/2});
+    border-color: $color transparent transparent transparent;
+    top: 100%;
   }
 }

--- a/stories/Tooltip.stories.js
+++ b/stories/Tooltip.stories.js
@@ -88,6 +88,17 @@ storiesOf('Tooltip', module)
     </div>
   ))
 
+  .add('arrowRelativeToTip', () => (
+    <div className={styles.fitToSize}>
+      <Tooltip
+        arrowRelativeToTip
+        tip="small tip"
+      >
+        {'this is a really long string for demonstration purposes'}
+      </Tooltip>
+    </div>
+  ))
+
   .add('theme overrides', () => (
     <div className={styles.container}>
       <Tooltip

--- a/stories/Tooltip.stories.scss
+++ b/stories/Tooltip.stories.scss
@@ -12,3 +12,11 @@
   font-style: italic;
   text-decoration: underline;
 }
+
+.fitToSize {
+  padding: 150px;
+  :global(.SimpleBubble_bubble) {
+    // size tooltip to text contained inside
+    min-width: auto;
+  }
+}

--- a/stories/theme-customizations/Bubble.custom.scss
+++ b/stories/theme-customizations/Bubble.custom.scss
@@ -2,7 +2,7 @@
 
 $bubble-bg-color: #5dcdfc;
 $bubble-bg-color-transparent: rgba(94, 96, 102, 0.9);
-$bubble-border-color: none;
+$bubble-border-color: transparent;
 $bubble-border-color-transparent: transparent;
 $bubble-border-radius: 0;
 $bubble-border-width: 0;

--- a/stories/theme-overrides/customBubble.scss
+++ b/stories/theme-overrides/customBubble.scss
@@ -5,7 +5,7 @@
     background-color: #fff;
 
     [data-bubble-arrow] {
-      @include arrow(up, #fff, rgba(10, 145, 48, 0.8), 5px);
+      @include arrow(up, #fff, rgba(10, 145, 48, 0.8), 10px, 5px);
     }
 
     .bubble {


### PR DESCRIPTION
For Yoroi, our designer wants the following UI:
![image](https://user-images.githubusercontent.com/2608559/59162698-a71e9080-8b30-11e9-9d4b-8dbbdd4c5254.png)
where the pop-up and underline appear on-hover.

This requires the following two changes

## 1) Must be able to place arrow for tooltip centered in tooltip content

The current behavior in React-Polymorph is to center the arrow on the content. Since addresses are really long, this ends up looking like this
![image](https://user-images.githubusercontent.com/2608559/59162715-02e91980-8b31-11e9-8153-fbcf6926d69b.png)

## 2) Must be able to customize arrow width separately from arrow height

The current hack for displaying an arrow didn't allow for width/height to be different so I instead used a different hack that allows for this. I made the change background compatible so it should look pixel-for-pixel equivalent to the current implementation.