### PR TITLE
[DDW-665] Rewrite numeric input logic

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -49,6 +49,7 @@
     "no-underscore-dangle": 0,
     "no-console": 0,
     "no-mixed-operators": 0,
+    "no-restricted-globals": 0,
     "prefer-template": 0,
     "no-unused-vars": 1,
     "no-trailing-spaces": 1,

--- a/.travis.yaml
+++ b/.travis.yaml
@@ -1,0 +1,1 @@
+language: node_js

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ vNext
 
 Upcoming changes for the next release.
 
+### Breaking Changes
+
+- `NumericInput` component was completely rewritten to be more flexible and straight forward.
+  [PR 114](https://github.com/input-output-hk/react-polymorph/pull/114)
+
 0.8.6
 =====
 

--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ came up with that serves our purposes in the best way:
   each supported fraction digit). For `maximumFractionDigits == 3` this results in 
   `9007199254740991 / 10 ** 4 == 900719925474.099` being the biggest number that can be entered.
 - Only numeric digits `[0-9]` and dots `.` can be entered.
+- When invalid characters are pasted as input, nothing happens
 - When a second dot is entered it replaces the existing one and updates the fraction part accordingly
 - Commas cannot be deleted but the cursor should jump over them when DEL or BACKSPACE keys are used
 - The fraction dot can only be deleted if `minimumFractionDigits` is not defined or

--- a/README.md
+++ b/README.md
@@ -193,8 +193,8 @@ came up with that serves our purposes in the best way:
 - Only numeric digits `[0-9]` and dots `.` can be entered.
 - When a second dot is entered it replaces the existing one and updates the fraction part accordingly
 - Commas cannot be deleted but the cursor should jump over them when DEL or BACKSPACE keys are used
-- The fraction dot can always be deleted (which transforms the fraction part into integer digits)
-  except if the resulting number would exceed the numeric limits!
+- The fraction dot can only be deleted if `minimumFractionDigits` is not defined or
+  if the resulting number does not exceed the numeric limits!
 - If the fraction dot is deleted but the resulting number is too big the cursor jumps over the dot without deletion
 - If you insert a digit but the resulting number would exceed the numeric limit, nothing happens
 

--- a/README.md
+++ b/README.md
@@ -187,9 +187,9 @@ came up with that serves our purposes in the best way:
 - Only numeric inputs that are representable by Javascript numbers are valid. This is guarded by `Number.MIN_SAFE_INTEGER` 
   (-9007199254740991) and `Number.MAX_SAFE_INTEGER` (9007199254740991) but since also fractions need to 
   represented, the calculation for the maximum integer part goes like this:
-  `Number.MAX_SAFE_INTEGER / 10 ** maximumFractionDigits` (which basically means that one integer digit is lost for
+  `Number.MAX_SAFE_INTEGER / 10 ** (maximumFractionDigits + 1)` (which basically means that one integer digit is lost for
   each supported fraction digit). For `maximumFractionDigits == 3` this results in 
-  `9007199254740991 / 10 ** 3 == 9007199254740.99` being the biggest number that can be entered.
+  `9007199254740991 / 10 ** 4 == 900719925474.099` being the biggest number that can be entered.
 - Only numeric digits `[0-9]` and dots `.` can be entered.
 - When a second dot is entered it replaces the existing one and updates the fraction part accordingly
 - Commas cannot be deleted but the cursor should jump over them when DEL or BACKSPACE keys are used

--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ came up with that serves our purposes in the best way:
 - Commas cannot be deleted but the cursor should jump over them when DEL or BACKSPACE keys are used
 - The fraction dot can only be deleted if `minimumFractionDigits` is not defined or
   if the resulting number does not exceed the numeric limits!
+- It's possible to replace the whole number or parts of it (even the dot) by inserting another number.
 - If the fraction dot is deleted but the resulting number is too big the cursor jumps over the dot without deletion
 - If you insert a digit but the resulting number would exceed the numeric limit, nothing happens
 

--- a/__tests__/NumericInput.behavior.test.js
+++ b/__tests__/NumericInput.behavior.test.js
@@ -4,180 +4,54 @@ import { NumericInput } from '../source/components/NumericInput';
 import { mountInSimpleTheme } from './helpers/theming';
 
 describe('NumericInput onChange simulations', () => {
-  test('onChange updates state with valid amount', () => {
-    const wrapper = mountInSimpleTheme(
-      <NumericInput />
-    );
 
-    const component = wrapper.find('NumericInput').instance();
+  test('valid input triggers onChange listener', () => {
+    let changedValue;
+    const wrapper = mountInSimpleTheme(<NumericInput onChange={v => changedValue = v} />);
     const input = wrapper.find('input');
-
-    // valid input value
     input.simulate('change', { target: { value: '19.00' } });
-    expect(component.state.oldValue).toBe('19.00');
+    expect(changedValue).toBe(19.00);
   });
 
-  test('onChange creates error via invalid amount: value > maxValue', () => {
-    const wrapper = mountInSimpleTheme(
-      <NumericInput maxValue={1000} />
-    );
-
-    const component = wrapper.find('NumericInput').instance();
+  test('handles en-US localized input values', () => {
+    let changedValue;
+    const wrapper = mountInSimpleTheme(<NumericInput onChange={v => changedValue = v} />);
     const input = wrapper.find('input');
-
-    // invalid input value: value > maxValue
-    // state and className should reflect error
-    input.simulate('change', { target: { value: '1001.00' } });
-    expect(component.state.error).toBeTruthy();
-    expect(input.instance().className).toBe('input errored');
+    input.simulate('change', { target: { value: '9,999,999.00' } });
+    expect(changedValue).toBe(9999999.00);
   });
 
-  test('onChange creates error via invalid amount: value < minValue', () => {
-    const wrapper = mountInSimpleTheme(
-      <NumericInput minValue={500} />
-    );
-
-    const component = wrapper.find('NumericInput').instance();
+  test('invalid input does not trigger onChange listener', () => {
+    let onChangeHasBeenCalled = false;
+    const wrapper = mountInSimpleTheme(<NumericInput onChange={() => onChangeHasBeenCalled = true} />);
     const input = wrapper.find('input');
-
-    // invalid input value: value < minValue
-    // state and className should reflect error
-    input.simulate('change', { target: { value: '499.99' } });
-    expect(component.state.error).toBeTruthy();
-    expect(input.instance().className).toBe('input errored');
+    input.simulate('change', { target: { value: 'A.00' } });
+    expect(onChangeHasBeenCalled).toBe(false);
   });
 
-  test('onChange is passed invalid amount, maxBeforeDot is enforced correctly', () => {
+  test('enforces given minimumFractionDigits', () => {
     const wrapper = mountInSimpleTheme(
-      <NumericInput maxBeforeDot={3} />
+      <NumericInput numberLocaleOptions={{ minimumFractionDigits: 6 }} value={0} />
     );
-
-    const component = wrapper.find('NumericInput').instance();
     const input = wrapper.find('input');
-
-    // input value is valid: value has 3 integer places
-    input.simulate('change', { target: { value: '432.99' } });
-    expect(component.state.oldValue).toBe('432.99');
-
-    // input value is invalid: value has 4 integer places
-    // 6 should be dropped from the 1's place
-    input.simulate('change', { target: { value: '9876.99' } });
-    expect(component.state.oldValue).toBe('987.99');
+    expect(input.getDOMNode().value).toBe('0.000000');
   });
 
-  test('onChange is passed invalid amount, maxAfterDot is enforced correctly', () => {
+  test('enforces given maximumFractionDigits', () => {
     const wrapper = mountInSimpleTheme(
-      <NumericInput maxAfterDot={4} />
+      <NumericInput numberLocaleOptions={{ maximumFractionDigits: 2 }} value={0.123} />
     );
-
-    const component = wrapper.find('NumericInput').instance();
     const input = wrapper.find('input');
-
-    // simulate onChange with 4 decimal places (valid)
-    input.simulate('change', { target: { value: '65.7821' } });
-    expect(component.state.oldValue).toBe('65.7821');
-
-    // simulate onChange with 5 decimal places (invalid)
-    input.simulate('change', { target: { value: '85.98543' } });
-    // 3 should be dropped from the 5th decimal place
-    expect(component.state.oldValue).toBe('85.9854');
+    expect(input.getDOMNode().value).toBe('0.12');
   });
 
-  test('integers only - onChange is passed invalid amount, maxAfterDot is enforced correctly', () => {
+  test('dynamically adjusts minimumFractionDigits for ux', () => {
     const wrapper = mountInSimpleTheme(
-      <NumericInput maxAfterDot={0} />
+      <NumericInput numberLocaleOptions={{ minimumFractionDigits: 0 }} value={0} />
     );
-
-    const component = wrapper.find('NumericInput').instance();
     const input = wrapper.find('input');
-
-    // simulate onChange with only an integer (valid)
-    input.simulate('change', { target: { value: '1234' } });
-    expect(component.state.oldValue).toBe('1234');
-
-    // simulate onChange with floating point number (invalid)
-    input.simulate('change', { target: { value: '5678.985' } });
-    // should drop decimal & all numbers after decimal: '.985'
-    expect(component.state.oldValue).toBe('5678');
+    input.simulate('change', { target: { value: '0.' } });
+    expect(input.getDOMNode().value).toBe('0.0');
   });
 
-  test('onChange simulates amount exceeding maxValue, enforceMax is enforced', () => {
-    const wrapper = mountInSimpleTheme(
-      <NumericInput
-        enforceMax
-        maxValue={24999}
-        maxAfterDot={2}
-      />
-    );
-
-    const component = wrapper.find('NumericInput').instance();
-    const input = wrapper.find('input');
-
-    // valid input value: there should be no error in state or className
-    input.simulate('change', { target: { value: '24500.99' } });
-    expect(component.state.oldValue).toBe('24500.99');
-    expect(component.state.error).toBe('');
-    expect(input.instance().className).toBe('input');
-
-    // invalid input value: value exceeds maxValue
-    // integers should be adjusted to maxValue
-    // state and className should reflect error
-    input.simulate('change', { target: { value: '25000.00' } });
-    expect(component.state.oldValue).toBe('24999.00');
-    expect(component.state.error).toBeTruthy();
-    expect(input.instance().className).toBe('input errored');
-
-    // invalid input value: decimal value exceeds maxValue
-    // decimals should be adjusted to maxValue
-    // state and className should reflect error
-    input.simulate('change', { target: { value: '24999.99' } });
-    expect(component.state.oldValue).toBe('24999.00');
-    expect(component.state.error).toBeTruthy();
-    expect(input.instance().className).toBe('input errored');
-
-    // valid input value: should reset state and className
-    input.simulate('change', { target: { value: '50.00' } });
-    expect(component.state.error).toBe('');
-    expect(input.instance().className).toBe('input');
-  });
-
-  test('onChange simulates amount less than minValue, enforceMin is enforced', () => {
-    const wrapper = mountInSimpleTheme(
-      <NumericInput
-        enforceMin
-        minValue={99.99}
-        maxAfterDot={2}
-      />
-    );
-
-    const component = wrapper.find('NumericInput').instance();
-    const input = wrapper.find('input');
-
-    // simulate onChange with valid amount
-    // should be no error in state or className
-    input.simulate('change', { target: { value: '100.00' } });
-    expect(component.state.oldValue).toBe('100.00');
-    expect(component.state.error).toBe('');
-
-    // input value is invalid: value < minValue
-    // integers should be adjusted to minValue
-    // state and className should reflect error
-    input.simulate('change', { target: { value: '85.99' } });
-    expect(component.state.oldValue).toBe('99.99');
-    expect(component.state.error).toBeTruthy();
-    expect(input.instance().className).toBe('input errored');
-
-    // input value is invalid: decimal value is less than minValue
-    // decimals should be adjusted to minValue
-    // state and className should reflect error
-    input.simulate('change', { target: { value: '99.98' } });
-    expect(component.state.oldValue).toBe('99.99');
-    expect(component.state.error).toBeTruthy();
-    expect(input.instance().className).toBe('input errored');
-
-    // valid input value: should reset error in state and className
-    input.simulate('change', { target: { value: '150.00' } });
-    expect(component.state.error).toBe('');
-    expect(input.instance().className).toBe('input');
-  });
 });

--- a/__tests__/NumericInput.behavior.test.js
+++ b/__tests__/NumericInput.behavior.test.js
@@ -6,27 +6,29 @@ import { mountInSimpleTheme } from './helpers/theming';
 describe('NumericInput onChange simulations', () => {
 
   test('valid input triggers onChange listener', () => {
-    let changedValue;
-    const wrapper = mountInSimpleTheme(<NumericInput onChange={v => changedValue = v} />);
+    const onChangeMock = jest.fn();
+    const wrapper = mountInSimpleTheme(<NumericInput onChange={onChangeMock} />);
     const input = wrapper.find('input');
-    input.simulate('change', { target: { value: '19.00' } });
-    expect(changedValue).toBe(19.00);
+    input.simulate('change', { nativeEvent: { target: { value: '19.00' }}});
+    expect(onChangeMock.mock.calls[0][0]).toBe(19.00);
   });
 
   test('handles en-US localized input values', () => {
-    let changedValue;
-    const wrapper = mountInSimpleTheme(<NumericInput onChange={v => changedValue = v} />);
+    const onChangeMock = jest.fn();
+    const wrapper = mountInSimpleTheme(<NumericInput onChange={onChangeMock} />);
     const input = wrapper.find('input');
-    input.simulate('change', { target: { value: '9,999,999.00' } });
-    expect(changedValue).toBe(9999999.00);
+    input.simulate('change', { nativeEvent: { target: { value: '9,999,999.00' }}});
+    expect(onChangeMock.mock.calls[0][0]).toBe(9999999.00);
   });
 
   test('invalid input does not trigger onChange listener', () => {
-    let onChangeHasBeenCalled = false;
-    const wrapper = mountInSimpleTheme(<NumericInput onChange={() => onChangeHasBeenCalled = true} />);
+    const onChangeMock = jest.fn();
+    const wrapper = mountInSimpleTheme(
+      <NumericInput onChange={onChangeMock} />
+    );
     const input = wrapper.find('input');
-    input.simulate('change', { target: { value: 'A.00' } });
-    expect(onChangeHasBeenCalled).toBe(false);
+    input.simulate('change', { nativeEvent: { target: { value: 'A.00' }}});
+    expect(onChangeMock.mock.calls.length).toBe(0);
   });
 
   test('enforces given minimumFractionDigits', () => {
@@ -43,15 +45,6 @@ describe('NumericInput onChange simulations', () => {
     );
     const input = wrapper.find('input');
     expect(input.getDOMNode().value).toBe('0.12');
-  });
-
-  test('dynamically adjusts minimumFractionDigits for ux', () => {
-    const wrapper = mountInSimpleTheme(
-      <NumericInput numberLocaleOptions={{ minimumFractionDigits: 0 }} value={0} />
-    );
-    const input = wrapper.find('input');
-    input.simulate('change', { target: { value: '0.' } });
-    expect(input.getDOMNode().value).toBe('0.0');
   });
 
 });

--- a/__tests__/NumericInput.behavior.test.js
+++ b/__tests__/NumericInput.behavior.test.js
@@ -9,7 +9,7 @@ describe('NumericInput onChange simulations', () => {
     const onChangeMock = jest.fn();
     const wrapper = mountInSimpleTheme(<NumericInput onChange={onChangeMock} />);
     const input = wrapper.find('input');
-    input.simulate('change', { nativeEvent: { target: { value: '19.00' }}});
+    input.simulate('change', { nativeEvent: { target: { value: '19.00' } } });
     expect(onChangeMock.mock.calls[0][0]).toBe(19.00);
   });
 
@@ -17,7 +17,7 @@ describe('NumericInput onChange simulations', () => {
     const onChangeMock = jest.fn();
     const wrapper = mountInSimpleTheme(<NumericInput onChange={onChangeMock} />);
     const input = wrapper.find('input');
-    input.simulate('change', { nativeEvent: { target: { value: '9,999,999.00' }}});
+    input.simulate('change', { nativeEvent: { target: { value: '9,999,999.00' } } });
     expect(onChangeMock.mock.calls[0][0]).toBe(9999999.00);
   });
 
@@ -27,7 +27,7 @@ describe('NumericInput onChange simulations', () => {
       <NumericInput onChange={onChangeMock} />
     );
     const input = wrapper.find('input');
-    input.simulate('change', { nativeEvent: { target: { value: 'A.00' }}});
+    input.simulate('change', { nativeEvent: { target: { value: 'A.00' } } });
     expect(onChangeMock.mock.calls.length).toBe(0);
   });
 

--- a/source/components/NumericInput.js
+++ b/source/components/NumericInput.js
@@ -5,7 +5,6 @@ import type { ComponentType, SyntheticInputEvent, Element, ElementRef } from 're
 
 // external libraries
 import createRef from 'create-react-ref/lib/createRef';
-import { flow } from 'lodash';
 
 // internal utility functions
 import { createEmptyContext, withTheme } from './HOC/withTheme';
@@ -21,87 +20,72 @@ type Props = {
   className?: string,
   context: ThemeContextProp,
   disabled?: boolean,
-  enforceMax: boolean,
-  label?: string | Element<any>,
-  enforceMin: boolean,
   error?: string,
+  label?: string | Element<any>,
+  locale: string,
+  numberLocaleOptions?: Number$LocaleOptions,
   onBlur?: Function,
   onChange?: Function,
   onFocus?: Function,
-  maxAfterDot?: number,
-  maxBeforeDot?: number,
-  maxValue?: number,
-  minValue?: number,
-  readOnly?: boolean,
   placeholder?: string,
-  setError?: Function,
+  readOnly?: boolean,
   skin?: ComponentType<any>,
-  theme: ?Object, // will take precedence over theme in context if passed
+  theme: ?Object,
   themeId: string,
   themeOverrides: Object,
-  value: string
+  value: ?number,
 };
 
 type State = {
   composedTheme: Object,
-  caretPosition: number,
-  separatorsCount: number,
   error: string,
-  oldValue: string
+  minimumFractionDigits: number,
+  inputCaretPosition: number,
 };
 
 class NumericInputBase extends Component<Props, State> {
-  // declare ref types
+
   inputElement: { current: null | ElementRef<'input'> };
 
-  // define static properties
   static displayName = 'NumericInput';
+
   static defaultProps = {
     context: createEmptyContext(),
-    enforceMax: false,
-    enforceMin: false,
+    locale: 'en-US',
     readOnly: false,
     theme: null,
     themeId: IDENTIFIERS.INPUT,
     themeOverrides: {},
-    value: ''
+    value: null,
   };
 
   constructor(props: Props) {
     super(props);
-    const { context, minValue, maxBeforeDot, maxAfterDot, themeId, theme, themeOverrides } = props;
-
-    const minValueIsNum = typeof minValue === 'number';
-    // if minValue is a number and user supplied maxBeforeDot and/or maxAfterDot
-    if (minValue && minValueIsNum && (maxBeforeDot || maxAfterDot)) {
-      // check combination of values for validity
-      this._validateLimitProps(minValue, maxBeforeDot, maxAfterDot);
-    }
-
-    // define ref
+    const { context, numberLocaleOptions, themeId, theme, themeOverrides } = props;
     this.inputElement = createRef();
-
+    const minimumFractionDigits = numberLocaleOptions ? numberLocaleOptions.minimumFractionDigits : 0;
     this.state = {
       composedTheme: composeTheme(
         addThemeId(theme || context.theme, themeId),
         addThemeId(themeOverrides, themeId),
         context.ROOT_THEME_API
       ),
-      caretPosition: 0,
-      separatorsCount: 0,
       error: '',
-      oldValue: ''
+      minimumFractionDigits: minimumFractionDigits ? minimumFractionDigits : 0,
+      inputCaretPosition: 0,
     };
   }
 
   componentDidMount() {
     const { inputElement } = this;
-    // check for autoFocus prop
-    if (this.props.autoFocus) this.focus();
-
-    // Set last input caret position on updates
-    if (inputElement && inputElement.current) {
-      this.setState({ caretPosition: inputElement.current.selectionStart });
+    const { autoFocus } = this.props;
+    if (autoFocus) {
+      this.focus();
+      if (inputElement && inputElement.current) {
+        this.setState({
+          inputCaretPosition: inputElement.current.selectionStart
+        });
+      }
     }
   }
 
@@ -109,48 +93,136 @@ class NumericInputBase extends Component<Props, State> {
     didThemePropsChange(this.props, nextProps, this.setState.bind(this));
   }
 
-  componentDidUpdate(prevProps: Props, prevState: State) {
-    const { inputElement } = this;
-    const isInputElementActive = inputElement && inputElement.current === document.activeElement;
-    if (!isInputElementActive) { return; }
-    const input = inputElement.current;
-    let { caretPosition } = this.state;
-    // Update the input selection to match
-    if (input && input.selectionStart !== caretPosition) {
-      // Take comma separators into account for caret position
-      if (
-        this.state.separatorsCount !== prevState.separatorsCount &&
-        this.state.separatorsCount - prevState.separatorsCount <= 1 &&
-        this.state.separatorsCount - prevState.separatorsCount >= -1
-      ) {
-        caretPosition =
-          this.state.caretPosition +
-          (this.state.separatorsCount - prevState.separatorsCount);
-      }
-      // Update the input selection with the new caretPosition
-      input.selectionStart = caretPosition;
-      input.selectionEnd = caretPosition;
-    }
+  componentDidUpdate() {
+    this.setInputCaretPosition(this.state.inputCaretPosition);
   }
 
   onChange = (event: SyntheticInputEvent<Element<'input'>>) => {
     event.preventDefault();
-    const { onChange, disabled } = this.props;
+    const { value, onChange, disabled } = this.props;
     if (disabled) { return; }
+    const { selectionStart } = event.target;
+    const result = this.processValueChange(event.target.value, selectionStart);
+    const hasValueChanged = value !== result.value;
+    if (hasValueChanged && onChange) { onChange(result.value, event); }
+    this.setState({
+      inputCaretPosition: result.caretPosition,
+      minimumFractionDigits: result.minimumFractionDigits,
+    });
+  };
 
-    const { value, selectionStart } = event.target;
+  processValueChange(newValue: string, newCaretPosition: number): {
+    value: ?number,
+    caretPosition: number,
+    minimumFractionDigits: number,
+  } {
+    const { value, locale } = this.props;
 
-    // it is crucial to remove whitespace from input value with String.trim()
-    const processedValue = this._processValue(
-      value.trim(),
-      selectionStart,
-    );
+    // Options
+    let minimumFractionDigits = this.getMinimumFractionDigits();
+    const numberLocaleOptions = this.getDynamicLocaleOptions();
 
-    // if the processed value is the same, then the user probably entered
-    // invalid input such as nonnumeric characters, do not call onChange
-    if (processedValue === this.state.oldValue) { return; }
+    // Current value
+    const currentNumber = value;
+    const currentValue = value != null ? value.toLocaleString(locale, numberLocaleOptions) : '';
+    const currentNumberOfDots = getNumberOfDots(currentValue);
+    const hadDotBefore = currentNumberOfDots > 0;
 
-    if (onChange) { onChange(processedValue, event); }
+    // New value
+    const newNumberOfDots = getNumberOfDots(newValue);
+    const hasDotsNow = newNumberOfDots > 0;
+
+    // Case: Everything was deleted -> reset everything
+    if (newValue === '') {
+      return {
+        value: null,
+        caretPosition: 0,
+        minimumFractionDigits: 0,
+      };
+    }
+
+    // Case: One additional decimal point was added somewhere
+    if (hadDotBefore && newNumberOfDots === 2) {
+      const oldFirstDotIndex = currentValue.indexOf('.');
+      const newFirstDotIndex = newValue.indexOf('.');
+      const wasDotAddedBeforeOldOne = newFirstDotIndex < oldFirstDotIndex;
+      const newCleanedValue = removeCharAtPosition(
+        newValue,
+        wasDotAddedBeforeOldOne ? newValue.lastIndexOf('.') : oldFirstDotIndex
+      );
+      return {
+        value: getValueAsNumber(newCleanedValue),
+        caretPosition: newCleanedValue.indexOf('.') + 1,
+        minimumFractionDigits
+      };
+    }
+
+    // Case: Decimal point was deleted -> remove dynamic minimum fraction digits
+    if (hadDotBefore && !hasDotsNow) {
+      return {
+        value: getValueAsNumber(newValue),
+        caretPosition: currentValue.indexOf('.') + 1,
+        minimumFractionDigits: 0,
+      };
+    }
+
+    // Case: Dot was added to integer number -> ensure that we show at least one fraction digit
+    if (!hadDotBefore && hasDotsNow) {
+      return {
+        value: getValueAsNumber(newValue),
+        caretPosition: newValue.indexOf('.') + 1,
+        minimumFractionDigits: 1,
+      };
+    }
+
+    // Case: A comma was deleted -> jump cursor over comma
+    if (getNumberOfCommas(newValue) < getNumberOfCommas(currentValue)) {
+      return {
+        value: currentNumber,
+        caretPosition: newCaretPosition,
+        minimumFractionDigits
+      };
+    }
+
+    // Case: Number digits have been changed
+    const newNumber = getValueAsNumber(newValue);
+    if (newNumber != null) {
+      // Take the localized formatting into account for the caret position
+      const localizedNewNumber = newNumber.toLocaleString(locale, numberLocaleOptions);
+      const numberOfCommasDiff = getNumberOfCommas(localizedNewNumber) - getNumberOfCommas(newValue);
+      return {
+        value: newNumber,
+        caretPosition: Math.max(newCaretPosition + numberOfCommasDiff, 0),
+        minimumFractionDigits
+      };
+    }
+
+    // Case: Invalid change has been made -> ignore it
+    return {
+      value: currentNumber,
+      caretPosition: newCaretPosition,
+      minimumFractionDigits
+    };
+  }
+
+  getMinimumFractionDigits(): number {
+    const { numberLocaleOptions } = this.props;
+    const minimumFractionDigitsProp = numberLocaleOptions ? numberLocaleOptions.minimumFractionDigits : null;
+    return Math.max(this.state.minimumFractionDigits, minimumFractionDigitsProp || 0);
+  }
+
+  getDynamicLocaleOptions(): Number$LocaleOptions {
+    return Object.assign({}, this.props.numberLocaleOptions, {
+      minimumFractionDigits: this.getMinimumFractionDigits(),
+    });
+  }
+
+  setInputCaretPosition = (position: number) => {
+    const { inputElement } = this;
+    if (!inputElement.current) return;
+    const input = inputElement.current;
+    input.selectionStart = position;
+    input.selectionEnd = position;
   };
 
   focus = () => {
@@ -159,321 +231,18 @@ class NumericInputBase extends Component<Props, State> {
     inputElement.current.focus();
   };
 
-  _validateLimitProps(minValue?: number, maxBeforeDot?: number, maxAfterDot?: number) {
-    if (typeof minValue !== 'number') return;
-    const maxBeforeDotIsNum = typeof maxBeforeDot === 'number';
-    const maxAfterDotIsNum = typeof maxAfterDot === 'number';
-    // if minValue is a float, it will split at the decimal
-    // trailing zeros are dropped with parseFloat
-    const minValParts = parseFloat(minValue).toString().split('.');
-
-    // if minValParts array has length of 2, it is a float
-    if (minValParts.length >= 2) {
-      const minValBeforeDot = minValParts[0];
-      const minValAfterDot = minValParts[1];
-
-      // if the number of integers in minValue is greater than maxBeforeDot
-      if (maxBeforeDot && maxBeforeDotIsNum && (minValBeforeDot.length > maxBeforeDot)) {
-        // the combo is incompatible, throw error
-        const error = `
-          minValue: ${minValue} exceeds the limit of maxBeforeDot: ${maxBeforeDot}.
-          Adjust the values of these properties.
-        `;
-        throw new Error(error);
-      // if the number of decimal spaces in minValue is greater than maxBeforeDot
-      } else if (maxAfterDot && maxAfterDotIsNum && (minValAfterDot.length > maxAfterDot)) {
-        const error = `
-          minValue: ${minValue} exceeds the limit of maxAfterDot: ${maxAfterDot}.
-          Adjust the values of these properties.
-        `;
-        throw new Error(error);
-      }
-    }
-  }
-
-  _setError = (error: string) => {
-    const { setError } = this.props;
-
-    // checks for setError func from FormField component
-    // if this NumericInput instance is rendered within FormField's render prop,
-    // FormField's local state.error will also be set via props.setError
-    if (setError) setError(error);
-    // also set (this: NumericInput)'s state.error
-    this.setState({ error });
-  };
-
-  _processValue(value: string, position: number) {
-    return flow([
-      this._enforceNumericValue,
-      this._parseToParts,
-      this._enforceValueLimits,
-      this._separate
-    ]).call(this, value, position);
-  }
-
-  _enforceNumericValue(value: string, position: number) {
-    const regex = /^[0-9.,]+$/;
-    const lastInsertedCharacter = value.substring(position - 1, position);
-
-    // Do not allow manual input of commas
-    if (lastInsertedCharacter === ',') {
-      return {
-        value: removeCharAtPosition(value, position - 1),
-        position: position - 1,
-      };
-    }
-
-    const isValueRegular = regex.test(value);
-    const { maxBeforeDot } = this.props;
-    let handledValue;
-    const lastValidValue = this.state.oldValue;
-
-    if (!isValueRegular && value !== '') {
-      // input contains invalid value
-      // e.g. 1,00AAbasdasd.asdasd123123
-      // - reject it and show last valid value
-      handledValue = lastValidValue || '0.000000';
-      position -= 1;
-    } else if (!this._isNumeric(value)) {
-      // input contains comma separated number
-      // e.g. 1,000,000.123456
-      // - make sure commas and caret are at correct position
-      const splitedValue = value.split('.');
-
-      // check if input value contains more than one decimal
-      if (splitedValue.length === 3) {
-        const splitedOldValue = lastValidValue.split('.');
-        let beforeDot = splitedValue[0] + splitedValue[1];
-        // variable for value before the decimal containing a comma. Ex: 1,425
-        let beforeDotWithoutComma = beforeDot;
-
-        // if comma exists, remove before comparing length in next if-else statement
-        if (beforeDot.includes(',')) {
-          const beforeComma = beforeDot.slice(0, beforeDot.indexOf(','));
-          const afterComma = beforeDot.slice(beforeDot.indexOf(',') + 1);
-          beforeDotWithoutComma = beforeComma + afterComma;
-        }
-        if (
-          (!beforeDot.includes(',') && splitedOldValue[0].length < beforeDot.length) ||
-          (beforeDot.includes(',') && splitedOldValue[0].length < beforeDotWithoutComma.length)
-        ) {
-          // dot is in decimal part
-          position -= 1;
-          handledValue = beforeDot + '.' + splitedValue[2];
-          beforeDot = beforeDot.replace(/,/g, '');
-          // prevent replace dot if length before dot is greater then max before dot length
-          if (maxBeforeDot && beforeDot.length > maxBeforeDot) {
-            handledValue = lastValidValue;
-          }
-        } else {
-          handledValue =
-            splitedValue[0] + '.' + splitedValue[1] + splitedValue[2];
-          // Second dot was entered after current one -> stay in same position (swallow dot)
-          if (position > beforeDot.length + 1) {
-            position -= 1;
-          }
-        }
-      } else if (
-        splitedValue.length === 2 &&
-        splitedValue[0] === '' &&
-        splitedValue[1] === ''
-      ) {
-        // special case when dot is inserted in an empty input
-        // - return 0.|00000
-        handledValue = '0.000000';
-        position = 2; // position caret after the dot
-      } else if (value !== '') {
-        // special case when user selects part of an input value and hits ',' key
-        // - reject it and show last valid value
-        handledValue = lastValidValue;
-      }
-    }
-
-    return !this._isNumeric(value)
-      ? { value: handledValue, position }
-      : { value, position };
-  }
-
-  _parseToParts(data: { value: string, position: number }) {
-    const value = data.value;
-    let position = data.position;
-
-    // show placeholder on select all and delete/backspace key action
-    if (!value) return;
-
-    let beforeDot;
-    let afterDot;
-
-    if (data.value.length > 1 && value.split('.').length < 2) {
-      // handle numbers deletion from both integer and decimal parts at once
-      beforeDot = value.substring(0, position) || '0';
-      afterDot = value.substring(position, value.length);
-    } else {
-      // split float number to integer and decimal part - regular way
-      const splitedValue = value.split('.');
-      beforeDot = splitedValue[0] ? splitedValue[0] : '0';
-      afterDot = splitedValue[1] ? splitedValue[1] : '000000';
-    }
-
-    // remove leading zero and update caret position
-    if (value.charAt(0) === '0' && parseInt(beforeDot.replace(/,/g, ''), 10) > 0) {
-      beforeDot = parseInt(beforeDot.replace(/,/g, ''), 10);
-      if (position !== 2) {
-        position = 0;
-      } else {
-        position = 1;
-      }
-    } else if (parseInt(beforeDot.replace(/,/g, ''), 10) === 0) {
-      beforeDot = parseInt(beforeDot.replace(/,/g, ''), 10);
-    }
-
-    return { value, position, parts: { beforeDot, afterDot } };
-  }
-
-  // enforces props.maxValue and props.minValue
-  _enforceValueLimits(data: {
-    value: string,
-    position: number,
-    parts: {
-      beforeDot: string,
-      afterDot: string
-    }
-  }) {
-    if (!data) return;
-
-    const { minValue, maxValue, enforceMax, enforceMin, maxAfterDot } = this.props;
-    const { position } = data;
-
-    // enforce props.maxBeforeDot and props.maxAfterDot
-    const valueWithDecimalRestrictions = this._enforceDecimalRestrictions(data);
-
-    // creates floating point number equal to valueWithDecimalRestrictions (string)
-    // will be used for value comparisons against props.maxValue and props.minValue if applicable
-    const valueWithoutSeparators = parseFloat(valueWithDecimalRestrictions.replace(/,/g, ''));
-
-    // if input value is greater than props.maxValue, throw error
-    if (maxValue && valueWithoutSeparators > maxValue) {
-      const formattedMaxVal = maxValue.toFixed(maxAfterDot || 6).toString();
-      this._setError(`Maximum amount is ${formattedMaxVal}`);
-
-      // if user passes enforceMax=true, restrict input value to props.maxValue
-      if (enforceMax) {
-        this.setState({ caretPosition: position });
-        return formattedMaxVal;
-      }
-    // if input value is below props.minValue, throw error
-    } else if (minValue && valueWithoutSeparators < minValue) {
-      const formattedMinVal = minValue.toFixed(maxAfterDot || 6).toString();
-      this._setError(`Minimum amount is ${formattedMinVal}`);
-
-      // if props.enforceMin=true, restrict input value to props.minValue
-      if (enforceMin) {
-        this.setState({ caretPosition: position });
-        return formattedMinVal;
-      }
-      // if input value has no errors, clear state.error
-    } else if (this.state.error !== '') {
-      this._setError('');
-    }
-
-    // update caret in state
-    this.setState({ caretPosition: position });
-
-    // input value w/ decimal restrictions is passed along
-    // to this._separate without value restrictions
-    return valueWithDecimalRestrictions;
-  }
-
-  // enforces props.maxBeforeDot and props.maxAfterDot
-  _enforceDecimalRestrictions(data: {
-    value: string,
-    position: number,
-    parts: {
-      beforeDot: string,
-      afterDot: string
-    }
-  }) {
-    const { maxBeforeDot, maxAfterDot } = this.props;
-    let { beforeDot } = data.parts;
-    let { afterDot } = data.parts;
-
-    // preventing numbers with more than maxBeforeDot units
-    // - return first maxBeforeDot numbers (with comma separators)
-    if (maxBeforeDot && beforeDot) {
-      // max number of commas depending on max number of characters before dot
-      const numberOfCommas =
-        maxBeforeDot % 3 > 0
-          ? parseInt(maxBeforeDot / 3, 10)
-          : parseInt(maxBeforeDot / 3, 10) - 1;
-      const maxBeforeDotWithSeparator = maxBeforeDot + numberOfCommas;
-      if (beforeDot.length > maxBeforeDotWithSeparator) {
-        beforeDot = beforeDot.substring(0, maxBeforeDotWithSeparator);
-      }
-    }
-
-    // remove commas from decimal part
-    // (e.g. 123,23,2.002000 -> dot after 2.character reproduce 12.3,23,2)
-    afterDot = afterDot.replace(/,/g, '');
-    // preventing numbers with more than maxAfterDot units - return first maxAfterDot numbers
-    if (maxAfterDot && afterDot && afterDot.length > maxAfterDot) {
-      afterDot = afterDot.substring(0, maxAfterDot);
-    }
-
-    // if decimal number has less than maxAfterDot numbers add trailing zeros
-    let afterDotLength = afterDot ? afterDot.length : 0;
-    if (maxAfterDot && afterDotLength < maxAfterDot) {
-      for (afterDotLength; afterDotLength < maxAfterDot; afterDotLength++) {
-        afterDot += '0';
-      }
-    }
-    // if maxAfterDot is 0, drop decimal & numbers after decimal, return int
-    if (maxAfterDot === 0) { return beforeDot; }
-
-    // return input value w/decimal restrictions as a string
-    return beforeDot + '.' + afterDot;
-  }
-
-  _separate(value: string) {
-    this.setState({ oldValue: value });
-    // value will not contain '.' if maxAfterDot is 0, return early
-    if (value && !value.includes('.')) { return value; }
-    if (!value) { this.setState({ separatorsCount: 0 }); }
-    if (value) {
-      const splitedValue = value.split('.');
-      const separatedValue = splitedValue[0]
-        .replace(/,/g, '')
-        .split('')
-        .reverse()
-        .join('')
-        .replace(/(\d{3}\B)/g, '$1,')
-        .split('')
-        .reverse()
-        .join('');
-      const newSeparatorsCount = (separatedValue.match(/,/g) || []).length;
-      this.setState({ separatorsCount: newSeparatorsCount });
-      return separatedValue + '.' + splitedValue[1];
-    }
-  }
-
-  _isNumeric(value: string) {
-    const replacedValue = value.replace(/,/g, '');
-    // eslint-disable-next-line no-restricted-globals
-    return !isNaN(parseFloat(replacedValue)) && isFinite(replacedValue);
-  }
-
   render() {
     // destructuring props ensures only the "...rest" get passed down
     const {
+      context,
+      error,
+      locale,
+      numberLocaleOptions,
+      onChange,
       skin,
       theme,
       themeOverrides,
-      onChange,
-      error,
-      context,
-      maxValue,
-      minValue,
-      maxBeforeDot,
-      maxAfterDot,
+      value,
       ...rest
     } = this.props;
 
@@ -481,10 +250,11 @@ class NumericInputBase extends Component<Props, State> {
 
     return (
       <InputSkin
-        error={error || this.state.error}
+        error={error}
         inputRef={this.inputElement}
         onChange={this.onChange}
         theme={this.state.composedTheme}
+        value={value != null ? value.toLocaleString(locale, this.getDynamicLocaleOptions()) : ''}
         {...rest}
       />
     );
@@ -492,3 +262,32 @@ class NumericInputBase extends Component<Props, State> {
 }
 
 export const NumericInput = withTheme(NumericInputBase);
+
+// ========= HELPERS ==========
+
+const NUMERIC_INPUT_REGEX = /^([0-9,]+)?(\.([0-9]+)?)?$/;
+
+const isValidNumericInput = (value: string): boolean => NUMERIC_INPUT_REGEX.test(value);
+
+const isParsableNumberString = (value: string): boolean => !isNaN(parseFloat(value)) && isFinite(value);
+
+const removeCommas = (value: string): string => value.replace(/,/g, '');
+
+function parseStringToNumber(value: string): ?number {
+  const cleanedValue = removeCommas(value);
+  if (!isValidNumericInput(cleanedValue)) return null;
+  if (!isParsableNumberString(cleanedValue)) return null;
+  return parseFloat(cleanedValue);
+}
+
+function getValueAsNumber(value: string | number): ?number {
+  return typeof value === 'string' ? parseStringToNumber(value) : value;
+}
+
+function getNumberOfCommas(value: string): number {
+  return (value.match(/,/g) || []).length;
+}
+
+function getNumberOfDots(value: string): number {
+  return (value.match(/\./g) || []).length;
+}

--- a/source/components/NumericInput.js
+++ b/source/components/NumericInput.js
@@ -97,8 +97,12 @@ class NumericInputBase extends Component<Props, State> {
     didThemePropsChange(this.props, nextProps, this.setState.bind(this));
   }
 
-  componentDidUpdate() {
-    this.setInputCaretPosition(this.state.inputCaretPosition);
+  componentDidUpdate(prevProps: Props, prevState: State) {
+    const { value } = this.props;
+    const { inputCaretPosition } = this.state;
+    if (value !== prevProps.value || inputCaretPosition !== prevState.inputCaretPosition) {
+      this.setInputCaretPosition(inputCaretPosition);
+    }
   }
 
   onChange = (event: SyntheticInputEvent<Element<'input'>>) => {

--- a/source/components/NumericInput.js
+++ b/source/components/NumericInput.js
@@ -136,7 +136,7 @@ class NumericInputBase extends Component<Props, State> {
     const { fallbackInputValue } = this.state;
 
     /**
-     * ========= HANDLE EDGE-CASES =============
+     * ========= HANDLE HARD EDGE-CASES =============
      */
 
     // Case: Everything was deleted -> reset state
@@ -183,7 +183,6 @@ class NumericInputBase extends Component<Props, State> {
     let newValue = valueToProcess;
     let newCaretPosition = changedCaretPosition;
     const newNumberOfDots = getNumberOfDots(newValue);
-    const hasDotsNow = newNumberOfDots > 0;
 
     // Case: A second decimal point was added somewhere
     if (hadDotBefore && newNumberOfDots === 2) {
@@ -355,10 +354,6 @@ const isParsableNumberString = (value: string, requiredPrecision: number): boole
 
 const removeCommas = (value: string): string => value.replace(/,/g, '');
 
-const removeDots = (value: string): string => value.replace(/\./g, '');
-
-const removeTrailingZeros = (value: string) => value.replace(/0+$/g, '');
-
 function parseStringToNumber(value: string, requiredPrecision: number): ?number {
   const cleanedValue = removeCommas(value);
   if (!isValidNumericInput(cleanedValue)) return null;
@@ -401,8 +396,4 @@ function truncateToPrecision(value: string, precision: number): string {
   if (decimalPointIndex === -1) return value;
   const fractionDigits = removeCommas(getFractionDigits(value));
   return getIntegerDigits(value) + '.' + fractionDigits.substring(0, precision);
-}
-
-function normalizeValue(value: string) {
-  return removeDots(removeTrailingZeros(removeCommas(value)));
 }

--- a/source/components/NumericInput.js
+++ b/source/components/NumericInput.js
@@ -231,12 +231,9 @@ class NumericInputBase extends Component<Props, State> {
     // Case: Invalid change has been made -> ignore it
 
     if (newNumber == null || !isStable) {
-      const numerOfNewDigitsInserted = (
-        normalizeValue(newValue).length - normalizeValue(currentValue).length
-      );
       return {
         value: currentNumber,
-        caretPosition: changedCaretPosition - numerOfNewDigitsInserted,
+        caretPosition: changedCaretPosition - 1,
         minimumFractionDigits
       };
     }
@@ -398,5 +395,5 @@ function truncateToPrecision(value: string, precision: number): string {
 }
 
 function normalizeValue(value: string) {
-  return removeTrailingZeros(removeDots(removeCommas(value)));
+  return removeDots(removeTrailingZeros(removeCommas(value)));
 }

--- a/source/components/NumericInput.js
+++ b/source/components/NumericInput.js
@@ -371,8 +371,8 @@ const isValidNumericInput = (value: string): boolean => NUMERIC_INPUT_REGEX.test
 const isParsableNumberString = (value: string, requiredPrecision: number): boolean => (
   // The number of digits is limited in Javascript - so the required precision influence
   // the possible number of integer digits (only 15 digits can be safely represented in total)
-  parseFloat(value) >= (Number.MIN_SAFE_INTEGER / 10 ** requiredPrecision) &&
-  parseFloat(value) <= (Number.MAX_SAFE_INTEGER / 10 ** requiredPrecision) &&
+  parseFloat(value) >= (Number.MIN_SAFE_INTEGER / 10 ** (requiredPrecision + 1)) &&
+  parseFloat(value) <= (Number.MAX_SAFE_INTEGER / 10 ** (requiredPrecision + 1)) &&
   !isNaN(parseFloat(value)) &&
   isFinite(value)
 );

--- a/source/components/NumericInput.js
+++ b/source/components/NumericInput.js
@@ -261,7 +261,10 @@ class NumericInputBase extends Component<Props, State> {
     }
 
     // Case: Dot was deleted with minimum fraction digits constrain defined
-    if (this.getMinimumFractionDigitsProp() != null && hadDotBefore && !newNumberOfDots) {
+    const isInsert = inputType === 'insertText';
+    const hasFractions = this.getMinimumFractionDigitsProp() != null;
+    const wasDotRemoved = hadDotBefore && !newNumberOfDots;
+    if (wasDotRemoved && hasFractions && !isInsert) {
       return {
         caretPosition: newCaretPosition + deleteCaretCorrection,
         fallbackInputValue: '',

--- a/source/components/NumericInput.js
+++ b/source/components/NumericInput.js
@@ -33,7 +33,6 @@ type Props = {
   theme: ?Object,
   themeId: string,
   themeOverrides: Object,
-  useDynamicDigitCalculation: boolean,
   value: ?number,
 };
 
@@ -59,7 +58,6 @@ class NumericInputBase extends Component<Props, State> {
     theme: null,
     themeId: IDENTIFIERS.INPUT,
     themeOverrides: {},
-    useDynamicDigitCalculation: false,
     value: null,
   };
 
@@ -135,7 +133,7 @@ class NumericInputBase extends Component<Props, State> {
     const changedCaretPosition = event.target.selectionStart;
     const valueToProcess = event.target.value;
     const { inputType } = event;
-    const { value, useDynamicDigitCalculation } = this.props;
+    const { value } = this.props;
     const { fallbackInputValue } = this.state;
     const isBackwardDelete = inputType === 'deleteContentBackward';
     const isForwardDelete = inputType === 'deleteContentForward';
@@ -221,13 +219,7 @@ class NumericInputBase extends Component<Props, State> {
     const dynamicMinimumFractionDigits = Math.min(
       Math.max(propsMinimumFractionDigits, numberOfFractionDigits), maximumFractionDigits
     );
-    const dynamicMaxFractionDigits = Math.max(
-      dynamicMinimumFractionDigits, numberOfFractionDigits
-    );
-    const fractionDigits = (
-      useDynamicDigitCalculation ? dynamicMaxFractionDigits : maximumFractionDigits
-    );
-    const newNumber = getValueAsNumber(newValue, fractionDigits);
+    const newNumber = getValueAsNumber(newValue, maximumFractionDigits);
 
     // Case: Dot was added at the beginning of number
 
@@ -265,8 +257,7 @@ class NumericInputBase extends Component<Props, State> {
     }
 
     // Case: Dot was deleted with minimum fraction digits constrain defined
-
-    if (propsMinimumFractionDigits != null && hadDotBefore && !newNumberOfDots) {
+    if (this.getMinimumFractionDigitsProp() != null && hadDotBefore && !newNumberOfDots) {
       return {
         caretPosition: newCaretPosition + deleteCaretCorrection,
         fallbackInputValue: '',
@@ -291,12 +282,15 @@ class NumericInputBase extends Component<Props, State> {
     };
   }
 
-  getMinimumFractionDigits(): number {
+  getMinimumFractionDigitsProp(): number | null {
     const { numberLocaleOptions } = this.props;
-    const minimumFractionDigitsProp = (
-      numberLocaleOptions ? numberLocaleOptions.minimumFractionDigits : null
-    );
-    return minimumFractionDigitsProp || 0;
+    if (!numberLocaleOptions) return null;
+    const { minimumFractionDigits } = numberLocaleOptions;
+    return minimumFractionDigits || null;
+  }
+
+  getMinimumFractionDigits(): number {
+    return this.getMinimumFractionDigitsProp() || 0;
   }
 
   getDynamicMinimumFractionDigits(): number {

--- a/source/components/NumericInput.js
+++ b/source/components/NumericInput.js
@@ -139,6 +139,7 @@ class NumericInputBase extends Component<Props, State> {
     const { fallbackInputValue } = this.state;
     const isBackwardDelete = inputType === 'deleteContentBackward';
     const isForwardDelete = inputType === 'deleteContentForward';
+    const deleteCaretCorrection = isBackwardDelete ? 0 : 1;
 
     /**
      * ========= HANDLE HARD EDGE-CASES =============
@@ -263,15 +264,25 @@ class NumericInputBase extends Component<Props, State> {
       };
     }
 
+    // Case: Dot was deleted with minimum fraction digits constrain defined
+
+    if (propsMinimumFractionDigits != null && hadDotBefore && !newNumberOfDots) {
+      return {
+        caretPosition: newCaretPosition + deleteCaretCorrection,
+        fallbackInputValue: '',
+        minimumFractionDigits: dynamicMinimumFractionDigits,
+        value: currentNumber,
+      };
+    }
+
     // Case: Valid change has been made
 
     const localizedNewNumber = newNumber.toLocaleString(LOCALE, numberLocaleOptions);
     const hasNumberChanged = value !== newNumber;
     const commasDiff = getNumberOfCommas(localizedNewNumber) - getNumberOfCommas(newValue);
     const haveCommasChanged = commasDiff > 0;
-    const commaDeleteCaretCorrection = isBackwardDelete ? 0 : 1;
     const onlyCommasChanged = !hasNumberChanged && haveCommasChanged;
-    const caretCorrection = onlyCommasChanged ? commaDeleteCaretCorrection : commasDiff;
+    const caretCorrection = onlyCommasChanged ? deleteCaretCorrection : commasDiff;
     return {
       caretPosition: Math.max(newCaretPosition + caretCorrection, 0),
       fallbackInputValue: '',

--- a/source/components/NumericInput.js
+++ b/source/components/NumericInput.js
@@ -146,6 +146,7 @@ class NumericInputBase extends Component<Props, State> {
     const { fallbackInputValue } = this.state;
     const isBackwardDelete = inputType === 'deleteContentBackward';
     const isForwardDelete = inputType === 'deleteContentForward';
+    const isDeletion = isForwardDelete || isBackwardDelete;
     const deleteCaretCorrection = isBackwardDelete ? 0 : 1;
 
     /**
@@ -243,7 +244,6 @@ class NumericInputBase extends Component<Props, State> {
 
     // Case: Invalid change has been made -> ignore it
     if (newNumber == null) {
-      const isDeletion = isForwardDelete || isBackwardDelete;
       const deleteAdjustment = isBackwardDelete ? 0 : 1; // special cases when deleting dot
       const insertAdjustment = -1; // don't move caret if numbers are "inserted"
       return {
@@ -255,12 +255,11 @@ class NumericInputBase extends Component<Props, State> {
     }
 
     // Case: Dot was added at the end of number
-
-    if (newValue.charAt(newValue.length - 1) === '.') {
+    if (!isDeletion && newValue.charAt(newValue.length - 1) === '.') {
       return {
         value: null,
         caretPosition: changedCaretPosition,
-        fallbackInputValue: newValue, // render new value as-is
+        fallbackInputValue: newValue,
         minimumFractionDigits: 0,
       };
     }

--- a/source/components/NumericInput.js
+++ b/source/components/NumericInput.js
@@ -219,9 +219,7 @@ class NumericInputBase extends Component<Props, State> {
      * ========= PROCESS CLEANED INPUT =============
      */
 
-    const newNumber = getValueAsNumber(
-      newValue, getFractionDigits(newValue).length
-    );
+    const newNumber = getValueAsNumber(newValue, maximumFractionDigits);
     const localizedNewValue = this.getLocalizedNumber(newNumber);
     const isStable = normalizeValue(newValue) === normalizeValue(localizedNewValue);
 

--- a/source/components/NumericInput.js
+++ b/source/components/NumericInput.js
@@ -49,6 +49,7 @@ const LOCALE = 'en-US';
 class NumericInputBase extends Component<Props, State> {
 
   inputElement: { current: null | ElementRef<'input'> };
+  _hasInputBeenChanged: boolean = false;
 
   static displayName = 'NumericInput';
 
@@ -100,9 +101,12 @@ class NumericInputBase extends Component<Props, State> {
   componentDidUpdate(prevProps: Props, prevState: State) {
     const { value } = this.props;
     const { inputCaretPosition } = this.state;
-    if (value !== prevProps.value || inputCaretPosition !== prevState.inputCaretPosition) {
+    const hasValueBeenChanged = value !== prevProps.value;
+    const hasCaretBeenChanged = inputCaretPosition !== prevState.inputCaretPosition;
+    if (this._hasInputBeenChanged || hasValueBeenChanged || hasCaretBeenChanged) {
       this.setInputCaretPosition(inputCaretPosition);
     }
+    this._hasInputBeenChanged = false;
   }
 
   onChange = (event: SyntheticInputEvent<Element<'input'>>) => {
@@ -111,6 +115,7 @@ class NumericInputBase extends Component<Props, State> {
     if (disabled) { return; }
     const result = this.processValueChange(event.nativeEvent);
     if (result) {
+      this._hasInputBeenChanged = true;
       const hasValueChanged = value !== result.value;
       if (hasValueChanged && onChange) {
         onChange(result.value, event);

--- a/source/components/NumericInput.js
+++ b/source/components/NumericInput.js
@@ -202,15 +202,6 @@ class NumericInputBase extends Component<Props, State> {
       };
     }
 
-    // Case: A comma was deleted -> jump cursor over comma
-    if (getNumberOfCommas(newValue) < getNumberOfCommas(currentValue)) {
-      return {
-        value: currentNumber,
-        caretPosition: newCaretPosition,
-        minimumFractionDigits
-      };
-    }
-
     // Case: Number digits have been changed
     const newNumber = getValueAsNumber(newValue);
     if (newNumber != null) {

--- a/source/components/NumericInput.js
+++ b/source/components/NumericInput.js
@@ -138,6 +138,15 @@ class NumericInputBase extends Component<Props, State> {
     /**
      * ========= HANDLE HARD EDGE-CASES =============
      */
+    // Case: invalid characters entered -> refuse!
+    if (!isValidNumericInput(valueToProcess)) {
+      return {
+        caretPosition: changedCaretPosition - 1,
+        fallbackInputValue,
+        minimumFractionDigits: this.state.minimumFractionDigits,
+        value,
+      };
+    }
 
     // Case: Everything was deleted -> reset state
     if (valueToProcess === '') {
@@ -202,16 +211,6 @@ class NumericInputBase extends Component<Props, State> {
       newValue = '0' + newValue;
     }
 
-    // Case: Dot was added at the end of number
-    if (newValue.charAt(newValue.length - 1) === '.') {
-      return {
-        value: null,
-        caretPosition: changedCaretPosition,
-        fallbackInputValue: newValue, // render dot at the end
-        minimumFractionDigits: 0,
-      };
-    }
-
     newValue = truncateToPrecision(newValue, maximumFractionDigits);
 
     /**
@@ -237,6 +236,18 @@ class NumericInputBase extends Component<Props, State> {
         fallbackInputValue,
         minimumFractionDigits: dynamicMinimumFractionDigits,
         value: currentNumber,
+      };
+    }
+
+    // Case: Dot was added at the end of number
+
+    const isDotAtTheEnd = newValue.charAt(newValue.length - 1) === '.';
+    if (isDotAtTheEnd) {
+      return {
+        value: null,
+        caretPosition: changedCaretPosition,
+        fallbackInputValue: newValue, // render new value as-is
+        minimumFractionDigits: 0,
       };
     }
 

--- a/source/components/NumericInput.js
+++ b/source/components/NumericInput.js
@@ -38,7 +38,6 @@ type Props = {
 
 type State = {
   composedTheme: Object,
-  error: string,
   minimumFractionDigits: number,
   inputCaretPosition: number,
 };
@@ -63,15 +62,16 @@ class NumericInputBase extends Component<Props, State> {
     super(props);
     const { context, numberLocaleOptions, themeId, theme, themeOverrides } = props;
     this.inputElement = createRef();
-    const minimumFractionDigits = numberLocaleOptions ? numberLocaleOptions.minimumFractionDigits : 0;
+    const minimumFractionDigits = (
+      numberLocaleOptions ? numberLocaleOptions.minimumFractionDigits : 0
+    );
     this.state = {
       composedTheme: composeTheme(
         addThemeId(theme || context.theme, themeId),
         addThemeId(themeOverrides, themeId),
         context.ROOT_THEME_API
       ),
-      error: '',
-      minimumFractionDigits: minimumFractionDigits ? minimumFractionDigits : 0,
+      minimumFractionDigits: minimumFractionDigits || 0,
       inputCaretPosition: 0,
     };
   }
@@ -119,7 +119,7 @@ class NumericInputBase extends Component<Props, State> {
     const { value, locale } = this.props;
 
     // Options
-    let minimumFractionDigits = this.getMinimumFractionDigits();
+    const minimumFractionDigits = this.getMinimumFractionDigits();
     const numberLocaleOptions = this.getDynamicLocaleOptions();
 
     // Current value
@@ -189,7 +189,9 @@ class NumericInputBase extends Component<Props, State> {
     if (newNumber != null) {
       // Take the localized formatting into account for the caret position
       const localizedNewNumber = newNumber.toLocaleString(locale, numberLocaleOptions);
-      const numberOfCommasDiff = getNumberOfCommas(localizedNewNumber) - getNumberOfCommas(newValue);
+      const numberOfCommasDiff = (
+        getNumberOfCommas(localizedNewNumber) - getNumberOfCommas(newValue)
+      );
       return {
         value: newNumber,
         caretPosition: Math.max(newCaretPosition + numberOfCommasDiff, 0),
@@ -207,7 +209,9 @@ class NumericInputBase extends Component<Props, State> {
 
   getMinimumFractionDigits(): number {
     const { numberLocaleOptions } = this.props;
-    const minimumFractionDigitsProp = numberLocaleOptions ? numberLocaleOptions.minimumFractionDigits : null;
+    const minimumFractionDigitsProp = (
+      numberLocaleOptions ? numberLocaleOptions.minimumFractionDigits : null
+    );
     return Math.max(this.state.minimumFractionDigits, minimumFractionDigitsProp || 0);
   }
 
@@ -269,7 +273,9 @@ const NUMERIC_INPUT_REGEX = /^([0-9,]+)?(\.([0-9]+)?)?$/;
 
 const isValidNumericInput = (value: string): boolean => NUMERIC_INPUT_REGEX.test(value);
 
-const isParsableNumberString = (value: string): boolean => !isNaN(parseFloat(value)) && isFinite(value);
+const isParsableNumberString = (value: string): boolean => (
+  !isNaN(parseFloat(value)) && isFinite(value)
+);
 
 const removeCommas = (value: string): string => value.replace(/,/g, '');
 

--- a/source/components/NumericInput.js
+++ b/source/components/NumericInput.js
@@ -116,7 +116,7 @@ class NumericInputBase extends Component<Props, State> {
       this.setState({
         inputCaretPosition: result.caretPosition,
         minimumFractionDigits: result.minimumFractionDigits,
-        fallbackInputValue: result.fallbackInputValue || '',
+        fallbackInputValue: result.fallbackInputValue,
       });
     }
   };
@@ -198,12 +198,6 @@ class NumericInputBase extends Component<Props, State> {
       newCaretPosition = newValue.indexOf('.') + 1;
     }
 
-    console.log(newValue);
-    const numberOfFractionDigits = getFractionDigits(newValue).length;
-    const dynamicMinimumFractionDigits = Math.min(
-      Math.max(propsMinimumFractionDigits, numberOfFractionDigits), maximumFractionDigits
-    );
-
     // Add leading zero if dot was inserted at start
     if (newValue.charAt(0) === '.') {
       newValue = '0' + newValue;
@@ -224,23 +218,26 @@ class NumericInputBase extends Component<Props, State> {
     /**
      * ========= PROCESS CLEANED INPUT =============
      */
+    const numberOfFractionDigits = getFractionDigits(newValue).length;
+    const dynamicMinimumFractionDigits = Math.min(
+      Math.max(propsMinimumFractionDigits, numberOfFractionDigits), maximumFractionDigits
+    );
     const dynamicMaxFractionDigits = Math.max(
-      dynamicMinimumFractionDigits, getFractionDigits(removeTrailingZeros(newValue)).length
+      dynamicMinimumFractionDigits, numberOfFractionDigits
     );
     const fractionDigits = (
       useDynamicDigitCalculation ? dynamicMaxFractionDigits : maximumFractionDigits
     );
     const newNumber = getValueAsNumber(newValue, fractionDigits);
-    const localizedNewValue = this.getLocalizedNumber(newNumber);
-    const isStable = normalizeValue(newValue) === normalizeValue(localizedNewValue);
 
     // Case: Invalid change has been made -> ignore it
 
-    if (newNumber == null || !isStable) {
+    if (newNumber == null) {
       return {
-        value: currentNumber,
         caretPosition: changedCaretPosition - 1,
+        fallbackInputValue,
         minimumFractionDigits: dynamicMinimumFractionDigits,
+        value: currentNumber,
       };
     }
 
@@ -251,9 +248,10 @@ class NumericInputBase extends Component<Props, State> {
       getNumberOfCommas(localizedNewNumber) - getNumberOfCommas(newValue)
     );
     return {
-      value: newNumber,
       caretPosition: Math.max(newCaretPosition + numberOfCommasDiff, 0),
+      fallbackInputValue: '',
       minimumFractionDigits: dynamicMinimumFractionDigits,
+      value: newNumber,
     };
   }
 

--- a/source/components/NumericInput.js
+++ b/source/components/NumericInput.js
@@ -379,8 +379,8 @@ export const NumericInput = withTheme(NumericInputBase);
 
 // ========= HELPERS ==========
 
-const VALID_INPUT_REGEX = /^([0-9,\+\-\.]+)?$/;
-const NUMERIC_INPUT_REGEX = /^([\+|\-])?([0-9,]+)?(\.([0-9]+)?)?$/;
+const VALID_INPUT_REGEX = /^([0-9,+\-.]+)?$/;
+const NUMERIC_INPUT_REGEX = /^([+|-])?([0-9,]+)?(\.([0-9]+)?)?$/;
 
 const isValidNumericInput = (value: string): boolean => NUMERIC_INPUT_REGEX.test(value);
 

--- a/source/utils/types.js
+++ b/source/utils/types.js
@@ -4,3 +4,8 @@ import type { ElementRef } from 'react';
 export type ReactElementRef<ElementType = HTMLElement> = {
   current: null | ElementRef<ElementType>
 }
+
+export interface InputEvent {
+  target: HTMLInputElement,
+  inputType: string,
+}

--- a/stories/NumericInput.stories.js
+++ b/stories/NumericInput.stories.js
@@ -57,16 +57,6 @@ storiesOf('NumericInput', module)
       />
     ))
   )
-  .add('dynamic maximumFractionDigits (6)',
-    withState({ value: 0 }, store => (
-      <NumericInput
-        onChange={value => store.set({ value })}
-        numberLocaleOptions={{ maximumFractionDigits: 6 }}
-        useDynamicDigitCalculation
-        value={store.state.value}
-      />
-    ))
-  )
   .add('autoFocus',
     withState({ value: null }, store => (
       <NumericInput

--- a/stories/NumericInput.stories.js
+++ b/stories/NumericInput.stories.js
@@ -24,61 +24,72 @@ storiesOf('NumericInput', module)
   // ====== Stories ======
 
   .add('plain',
-    withState({ value: '' }, store => (
+    withState({ value: null }, store => (
       <NumericInput
-        value={store.state.value}
-        maxBeforeDot={6}
-        maxAfterDot={6}
         onChange={value => store.set({ value })}
+        value={store.state.value}
       />
     ))
   )
-
-  .add('label',
-    withState({ value: '' }, store => (
+  .add('value (9999.99)',
+    withState({ value: 9999.99 }, store => (
       <NumericInput
-        label="Amount"
-        value={store.state.value}
-        maxBeforeDot={6}
-        maxAfterDot={6}
         onChange={value => store.set({ value })}
+        value={store.state.value}
       />
     ))
   )
-
-  .add('placeholder',
-    withState({ value: '' }, store => (
+  .add('minimumFractionDigits (6)',
+    withState({ value: 0 }, store => (
       <NumericInput
-        value={store.state.value}
-        placeholder="18.000000"
-        maxBeforeDot={6}
-        maxAfterDot={6}
         onChange={value => store.set({ value })}
+        numberLocaleOptions={{ minimumFractionDigits: 6 }}
+        value={store.state.value}
       />
     ))
   )
-
+  .add('maximumFractionDigits (6)',
+    withState({ value: 0 }, store => (
+      <NumericInput
+        onChange={value => store.set({ value })}
+        numberLocaleOptions={{ maximumFractionDigits: 6 }}
+        value={store.state.value}
+      />
+    ))
+  )
   .add('autoFocus',
-    withState({ value: '' }, store => (
+    withState({ value: null }, store => (
       <NumericInput
         autoFocus
-        label="With autoFocus"
-        value={store.state.value}
-        placeholder="18.000000"
-        maxBeforeDot={6}
-        maxAfterDot={6}
         onChange={value => store.set({ value })}
+        value={store.state.value}
+      />
+    ))
+  )
+  .add('label',
+    withState({ value: null }, store => (
+      <NumericInput
+        label="Amount"
+        onChange={value => store.set({ value })}
+        value={store.state.value}
+      />
+    ))
+  )
+  .add('placeholder',
+    withState({ value: null }, store => (
+      <NumericInput
+        value={store.state.value}
+        onChange={value => store.set({ value })}
+        placeholder="18.000000"
       />
     ))
   )
 
   .add('onFocus / onBlur',
-    withState({ value: '', focused: false, blurred: false }, store => (
+    withState({ value: null, focused: false, blurred: false }, store => (
       <NumericInput
         value={store.state.value}
         placeholder="onFocus / onBlur"
-        maxBeforeDot={6}
-        maxAfterDot={6}
         onChange={value => store.set({ value })}
         onFocus={() => store.set({ focused: true, blurred: false })}
         onBlur={() => store.set({ blurred: true, focused: false })}
@@ -87,7 +98,7 @@ storiesOf('NumericInput', module)
   )
 
   .add('with error',
-    withState({ value: '' }, store => (
+    withState({ value: null }, store => (
       <NumericInput
         label="Amount"
         error="Please enter a valid amount"
@@ -98,109 +109,25 @@ storiesOf('NumericInput', module)
     ))
   )
 
-  .add('maxBeforeDot(3) and maxAfterDot(4)',
-    withState({ value: '' }, store => (
-      <NumericInput
-        label="Amount"
-        value={store.state.value}
-        placeholder="000.0000"
-        maxBeforeDot={3}
-        maxAfterDot={4}
-        onChange={value => store.set({ value })}
-      />
-    ))
-  )
-
-  .add('maxBeforeDot(3) and maxAfterDot(0)',
-    withState({ value: '' }, store => (
-      <NumericInput
-        label="Integers Only"
-        value={store.state.value}
-        placeholder="123"
-        maxBeforeDot={3}
-        maxAfterDot={0}
-        onChange={value => store.set({ value })}
-      />
-    ))
-  )
-
-  .add('maxValue(30000) - unenforced',
-    withState({ value: '' }, store => (
-      <NumericInput
-        label="Amount"
-        value={store.state.value}
-        placeholder="0.000000"
-        maxValue={30000}
-        onChange={value => store.set({ value })}
-      />
-    ))
-  )
-
-  .add('minValue(50) - unenforced',
-    withState({ value: '' }, store => (
-      <NumericInput
-        label="Amount"
-        value={store.state.value}
-        placeholder="0.000000"
-        minValue={50}
-        maxAfterDot={6}
-        onChange={value => store.set({ value })}
-      />
-    ))
-  )
-
-  .add('maxValue(30000), minValue(50) - unenforced',
-    withState({ value: '' }, store => (
-      <NumericInput
-        label="Amount"
-        value={store.state.value}
-        placeholder="0.000000"
-        maxValue={30000}
-        minValue={50}
-        maxAfterDot={6}
-        onChange={value => store.set({ value })}
-      />
-    ))
-  )
-
-  .add('maxValue(30000), minValue(50), enforceMax=true, enforceMin=true',
-    withState({ value: '' }, store => (
-      <NumericInput
-        label="Amount"
-        value={store.state.value}
-        placeholder="50.000000"
-        maxValue={30000}
-        minValue={50}
-        maxAfterDot={6}
-        enforceMax
-        enforceMin
-        onChange={value => store.set({ value })}
-      />
-    ))
-  )
-
-  .add('theme overrides, minValue(50)',
-    withState({ value: '' }, store => (
+  .add('theme overrides',
+    withState({ value: null }, store => (
       <NumericInput
         label="Composed Theme"
-        minValue={50}
         themeOverrides={themeOverrides}
         value={store.state.value}
         placeholder="0.000000"
-        maxAfterDot={6}
         onChange={value => store.set({ value })}
       />
     ))
   )
 
   .add('Custom Theme',
-    withState({ value: '' }, store => (
+    withState({ value: null }, store => (
       <NumericInput
         label="Amount"
         theme={CustomInputTheme}
         value={store.state.value}
         placeholder="0.000000"
-        maxAfterDot={6}
         onChange={value => store.set({ value })}
       />
     ))

--- a/stories/NumericInput.stories.js
+++ b/stories/NumericInput.stories.js
@@ -57,6 +57,16 @@ storiesOf('NumericInput', module)
       />
     ))
   )
+  .add('dynamic maximumFractionDigits (6)',
+    withState({ value: 0 }, store => (
+      <NumericInput
+        onChange={value => store.set({ value })}
+        numberLocaleOptions={{ maximumFractionDigits: 6 }}
+        useDynamicDigitCalculation
+        value={store.state.value}
+      />
+    ))
+  )
   .add('autoFocus',
     withState({ value: null }, store => (
       <NumericInput


### PR DESCRIPTION
This PR rewrites and simplifies the logic of the `NumericInput` component.

Fixes #112 and fixes #51

## Breaking API changes:
  - `value` must be a number and `onChange` also returns numbers (not strings) now
  - All formatting configuration is now handled with the prop `numberLocaleOptions` which are the options for [Number::toLocaleString](https://developer.mozilla.org/de/docs/Web/JavaScript/Reference/Global_Objects/Number/toLocaleString), which makes this component more standards compliant and will also allow us to implement i18n later on without too much hassle.
- The numeric input component does **not handle errors or enforce min/max values anymore** - since error messages created by the numeric input would never be useful in an localized context (and the enforced versions, which dont allow out-of-bound numbers to be entered at all, are not very useful UX wise -> because it's better to see the "invalid" number + a user defined error)

## Specification

Since there is no standard on how to build numeric input components, here is the specification we came up with that serves our purposes in the best way: 

- Only numeric inputs that are representable by Javascript numbers are valid. This is guarded by `Number.MIN_SAFE_INTEGER` 
  (-9007199254740991) and `Number.MAX_SAFE_INTEGER` (9007199254740991) but since also fractions need to 
  represented, the calculation for the maximum integer part goes like this:
  `Number.MAX_SAFE_INTEGER / 10 ** (maximumFractionDigits + 1)` (which basically means that one integer digit is lost for
  each supported fraction digit). For `maximumFractionDigits == 3` this results in 
  `9007199254740991 / 10 ** 4 == 900719925474.099` being the biggest number that can be entered.
- Only numeric digits `[0-9]` and dots `.` can be entered.
- When a second dot is entered it replaces the existing one and updates the fraction part accordingly
- Commas cannot be deleted but the cursor should jump over them when DEL or BACKSPACE keys are used
- The fraction dot can only be deleted if `minimumFractionDigits` is not defined or
  if the resulting number does not exceed the numeric limits!
- It should be possible to replace the whole number or parts of it (even the dot) by inserting another number.
- If the fraction dot is deleted but the resulting number is too big the cursor jumps over the dot without deletion
- If you insert a digit but the resulting number would exceed the numeric limit, nothing happens


## How to Test

Discuss this change in the corresponding [daedalus-qa thread](https://input-output-rnd.slack.com/archives/GGKFXSKC6/p1560350401014900)

- Use the storybook build below (Github PR checks)
- Enter any numeric number and choose different scenarios in storybook

![screenshot 2019-06-12 um 16 43 12](https://user-images.githubusercontent.com/172414/59360919-44481780-8d31-11e9-9e59-41922d345e2f.png)