### PR TITLE
[DDW-658] Custom select value and Stepper component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,10 @@ vNext
 
 Upcoming changes for the next release.
 
-###Features
+### Features
 
-- Provide custum value renderer on Select component to override default input value format
-  Add Stepper component
+- Adds selected option render prop on Select component to override default input value format.
+  Adds Stepper component, theme, skin, and stories.
   [PR 115](https://github.com/input-output-hk/react-polymorph/pull/115)
 
 0.8.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ vNext
 
 Upcoming changes for the next release.
 
+###Features
+
+- Provide custum value renderer on Select component to override default input value format
+  Add Stepper component
+  [PR 115](https://github.com/input-output-hk/react-polymorph/pull/115)
+
 0.8.6
 =====
 

--- a/__tests__/Select.test.js
+++ b/__tests__/Select.test.js
@@ -119,7 +119,7 @@ test('Select uses render prop - valueRenderer', () => {
           <div>{option.value}</div>
         </div>
       )}
-       valueRenderer={option => (
+      selectionRenderer={option => (
         <div>
           <div>{option.label}</div>
           <div>{option.value}</div>

--- a/__tests__/Select.test.js
+++ b/__tests__/Select.test.js
@@ -20,6 +20,12 @@ const COUNTRIES_DISABLED_OPTIONS = [
   { value: 'EN-en', label: 'USA' }
 ];
 
+const WALLETS = [
+  { value: '100,100 ADA', label: 'Main wallet' },
+  { value: '10,100.2 ADA', label: 'Spending money' },
+  { value: '500,1000 ADA', label: 'Savings' },
+];
+
 test('Select renders correctly', () => {
   const component = renderInSimpleTheme(
     <Select options={COUNTRIES} />
@@ -94,6 +100,29 @@ test('Select uses render prop - optionRenderer', () => {
         <div>
           <span>German: {option.label}</span>
           <span>English: {option.value}</span>
+        </div>
+      )}
+    />
+  );
+
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+test('Select uses render prop - valueRenderer', () => {
+  const component = renderInSimpleTheme(
+    <Select
+      options={WALLETS}
+      optionRenderer={option => (
+        <div>
+          <div>{option.label}</div>
+          <div>{option.value}</div>
+        </div>
+      )}
+       valueRenderer={option => (
+        <div>
+          <div>{option.label}</div>
+          <div>{option.value}</div>
         </div>
       )}
     />

--- a/__tests__/Stepper.test.js
+++ b/__tests__/Stepper.test.js
@@ -1,0 +1,45 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+
+import { Stepper } from '../source/components/Stepper';
+import { renderInSimpleTheme } from './helpers/theming';
+
+const STEPS = ['Wallet', 'Stake pool', 'Delegation', 'Activation'];
+
+test('Stepper renders correctly', () => {
+  const component = renderInSimpleTheme(
+    <Stepper
+      options={STEPS}
+      activeStep={3}
+    />
+  );
+
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+test('Stepper renders with custom label', () => {
+  const component = renderInSimpleTheme(
+    <Stepper
+      activeStep={3}
+      label="Setup progress"
+      options={STEPS}
+    />
+  );
+
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+test('Stepper renders without label', () => {
+  const component = renderInSimpleTheme(
+    <Stepper
+      activeStep={3}
+      labelDisabled
+      options={STEPS}
+    />
+  );
+
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});

--- a/__tests__/__snapshots__/Select.test.js.snap
+++ b/__tests__/__snapshots__/Select.test.js.snap
@@ -849,3 +849,112 @@ exports[`Select uses render prop - optionRenderer 1`] = `
   </div>
 </div>
 `;
+
+exports[`Select uses render prop - valueRenderer 1`] = `
+<div>
+  <div
+    className="select"
+  >
+    <div
+      className="selectInput"
+    >
+      <div
+        className="root"
+      >
+        
+        <div
+          className="inputWrapper"
+        >
+          <div
+            className="customValueWrapper"
+          >
+            <input
+              className="input"
+              onChange={[Function]}
+              onClick={[Function]}
+              readOnly={true}
+              value=""
+            />
+            <div
+              className="customValueBlock"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className="options firstOptionHighlighted root isFloating isHidden"
+      style={null}
+    >
+      <div
+        className="bubble"
+        data-bubble-container={true}
+      >
+        <ul
+          className="ul"
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          style={
+            Object {
+              "maxHeight": "300px",
+            }
+          }
+        >
+          <li
+            aria-hidden={true}
+            className="option highlightedOption"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            role="presentation"
+          >
+            <div>
+              <div>
+                Main wallet
+              </div>
+              <div>
+                100,100 ADA
+              </div>
+            </div>
+          </li>
+          <li
+            aria-hidden={true}
+            className="option"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            role="presentation"
+          >
+            <div>
+              <div>
+                Spending money
+              </div>
+              <div>
+                10,100.2 ADA
+              </div>
+            </div>
+          </li>
+          <li
+            aria-hidden={true}
+            className="option"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            role="presentation"
+          >
+            <div>
+              <div>
+                Savings
+              </div>
+              <div>
+                500,1000 ADA
+              </div>
+            </div>
+          </li>
+        </ul>
+      </div>
+      <span
+        className="arrow"
+        data-bubble-arrow={true}
+      />
+    </div>
+  </div>
+</div>
+`;

--- a/__tests__/__snapshots__/Stepper.test.js.snap
+++ b/__tests__/__snapshots__/Stepper.test.js.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Stepper renders correctly 1`] = `null`;
+
+exports[`Stepper renders with custom label 1`] = `null`;
+
+exports[`Stepper renders without label 1`] = `null`;

--- a/source/components/Input.js
+++ b/source/components/Input.js
@@ -31,6 +31,8 @@ type Props = {
   placeholder?: string,
   readOnly: boolean,
   setError?: Function,
+  selectedOption?: any,
+  selectionRenderer?: Function,
   skin?: ComponentType<any>,
   theme: ?Object, // will take precedence over theme in context if passed
   themeId: string,

--- a/source/components/Select.js
+++ b/source/components/Select.js
@@ -32,7 +32,8 @@ type Props = {
   theme: ?Object, // will take precedence over theme in context if passed
   themeId: string,
   themeOverrides: Object,
-  value: string
+  value: string,
+  valueRenderer?: Function,
 };
 
 type State = {

--- a/source/components/Select.js
+++ b/source/components/Select.js
@@ -28,12 +28,12 @@ type Props = {
   optionRenderer?: Function,
   options: Array<any>,
   placeholder?: string,
+  selectionRenderer?: Function,
   skin?: ComponentType<any>,
   theme: ?Object, // will take precedence over theme in context if passed
   themeId: string,
   themeOverrides: Object,
   value: string,
-  valueRenderer?: Function,
 };
 
 type State = {

--- a/source/components/Stepper.js
+++ b/source/components/Stepper.js
@@ -1,0 +1,75 @@
+// @flow
+import React, { Component } from 'react';
+import type { ComponentType } from 'react';
+
+// internal utility functions
+import { createEmptyContext, withTheme } from './HOC/withTheme';
+import { composeTheme, addThemeId, didThemePropsChange } from '../utils/themes';
+
+// import constants
+import { IDENTIFIERS } from '.';
+import type { ThemeContextProp } from './HOC/withTheme';
+
+type Props = {
+  className?: string,
+  context: ThemeContextProp,
+  label?: string,
+  labelDisabled?: boolean,
+  steps: Array<string>,
+  activeStep?: number,
+  skin?: ComponentType<any>,
+  theme: ?Object, // will take precedence over theme in context if passed
+  themeId: string,
+  themeOverrides: Object,
+  onStepClick?: Function,
+};
+
+type State = {
+  composedTheme: Object
+};
+
+class StepperBase extends Component<Props, State> {
+  // define static properties
+  static displayName = 'Stepper';
+  static defaultProps = {
+    context: createEmptyContext(),
+    theme: null,
+    themeId: IDENTIFIERS.STEPPER,
+    themeOverrides: {}
+  };
+
+  constructor(props: Props) {
+    super(props);
+
+    const { context, themeId, theme, themeOverrides } = props;
+
+    this.state = {
+      composedTheme: composeTheme(
+        addThemeId(theme || context.theme, themeId),
+        addThemeId(themeOverrides, themeId),
+        context.ROOT_THEME_API
+      )
+    };
+  }
+
+  componentWillReceiveProps(nextProps: Props) {
+    didThemePropsChange(this.props, nextProps, this.setState.bind(this));
+  }
+
+  render() {
+    // destructuring props ensures only the "...rest" get passed down
+    const {
+      skin,
+      theme,
+      themeOverrides,
+      context,
+      ...rest
+    } = this.props;
+
+    const StepperSkin = skin || context.skins[this.props.themeId];
+
+    return <StepperSkin theme={this.state.composedTheme} {...rest} />;
+  }
+}
+
+export const Stepper = withTheme(StepperBase);

--- a/source/components/Stepper.js
+++ b/source/components/Stepper.js
@@ -11,17 +11,17 @@ import { IDENTIFIERS } from '.';
 import type { ThemeContextProp } from './HOC/withTheme';
 
 type Props = {
+  activeStep?: number,
   className?: string,
   context: ThemeContextProp,
   label?: string,
   labelDisabled?: boolean,
-  steps: Array<string>,
-  activeStep?: number,
+  onStepClick?: Function,
   skin?: ComponentType<any>,
+  steps: Array<string>,
   theme: ?Object, // will take precedence over theme in context if passed
   themeId: string,
   themeOverrides: Object,
-  onStepClick?: Function,
 };
 
 type State = {

--- a/source/components/index.js
+++ b/source/components/index.js
@@ -17,6 +17,7 @@ export const IDENTIFIERS = {
   PROGRESS_BAR: 'progressbar',
   RADIO: 'radio',
   SELECT: 'select',
+  STEPPER: 'stepper',
   SWITCH: 'switch',
   TEXT_AREA: 'textarea',
   TOGGLER: 'toggler',

--- a/source/skins/simple/InputSkin.js
+++ b/source/skins/simple/InputSkin.js
@@ -27,11 +27,11 @@ type Props = {
   onKeyPress?: Function,
   placeholder?: string,
   readOnly?: boolean,
+  selectedOption: any,
   theme: Object,
   themeId: string,
   value: string,
   valueRenderer: Function,
-  selectedOption: any,
 };
 
 export const InputSkin = (props: Props) => {

--- a/source/skins/simple/InputSkin.js
+++ b/source/skins/simple/InputSkin.js
@@ -27,17 +27,15 @@ type Props = {
   onKeyPress?: Function,
   placeholder?: string,
   readOnly?: boolean,
-  selectedOption: any,
+  selectedOption?: any,
   theme: Object,
   themeId: string,
   value: string,
-  valueRenderer: Function,
+  selectionRenderer?: Function,
 };
 
 export const InputSkin = (props: Props) => {
-  const isValueRenderer = props.valueRenderer && isFunction(props.valueRenderer);
-
-  const inputRenderer = () => (
+  const renderInput = () => (
     <input
       ref={props.inputRef}
       {...pickDOMProps(props)}
@@ -50,19 +48,22 @@ export const InputSkin = (props: Props) => {
     />
   );
 
-  const valueRenderer = option => {
-    // check if user has passed render prop "valueRenderer"
-    if (isValueRenderer) {
-      return (
-        <div className={props.theme[props.themeId].customValueWrapper}>
-          {inputRenderer()}
-          <div className={props.theme[props.themeId].customValueBlock}>
-            {option && props.valueRenderer(option)}
-          </div>
-        </div>
-      );
+  const useSelectionRenderer = option => (
+    <div className={props.theme[props.themeId].customValueWrapper}>
+      {renderInput()}
+      <div className={props.theme[props.themeId].customValueBlock}>
+        {option && props.selectionRenderer && props.selectionRenderer(option)}
+      </div>
+    </div>
+  );
+
+  const render = () => {
+    // check if user has passed render prop "selectionRenderer"
+    const hasSelectionRenderer = props.selectionRenderer && isFunction(props.selectionRenderer);
+    if (hasSelectionRenderer) {
+      return useSelectionRenderer(props.selectedOption);
     }
-    return inputRenderer();
+    return renderInput();
   };
 
   return (
@@ -74,9 +75,7 @@ export const InputSkin = (props: Props) => {
       inputRef={props.inputRef}
       skin={FormFieldSkin}
       theme={props.theme}
-      render={() => (
-        valueRenderer(props.selectedOption)
-      )}
+      render={render}
     />
   );
 };

--- a/source/skins/simple/InputSkin.js
+++ b/source/skins/simple/InputSkin.js
@@ -4,6 +4,7 @@ import type { ElementRef, Element } from 'react';
 
 // external libraries
 import classnames from 'classnames';
+import { isFunction } from 'lodash';
 
 // components
 import { FormField } from '../../components/FormField';
@@ -28,29 +29,54 @@ type Props = {
   readOnly?: boolean,
   theme: Object,
   themeId: string,
-  value: string
+  value: string,
+  valueRenderer: Function,
+  selectedOption: any,
 };
 
-export const InputSkin = (props: Props) => (
-  <FormField
-    className={props.className}
-    disabled={props.disabled}
-    label={props.label}
-    error={props.error}
-    inputRef={props.inputRef}
-    skin={FormFieldSkin}
-    theme={props.theme}
-    render={() => (
-      <input
-        ref={props.inputRef}
-        {...pickDOMProps(props)}
-        className={classnames([
-          props.theme[props.themeId].input,
-          props.disabled ? props.theme[props.themeId].disabled : null,
-          props.error ? props.theme[props.themeId].errored : null
-        ])}
-        readOnly={props.readOnly}
-      />
-    )}
-  />
-);
+export const InputSkin = (props: Props) => {
+  const isValueRenderer = props.valueRenderer && isFunction(props.valueRenderer);
+
+  const inputRenderer = () => (
+    <input
+      ref={props.inputRef}
+      {...pickDOMProps(props)}
+      className={classnames([
+        props.theme[props.themeId].input,
+        props.disabled ? props.theme[props.themeId].disabled : null,
+        props.error ? props.theme[props.themeId].errored : null,
+      ])}
+      readOnly={props.readOnly}
+    />
+  );
+
+  const valueRenderer = option => {
+    // check if user has passed render prop "valueRenderer"
+    if (isValueRenderer) {
+      return (
+        <div className={props.theme[props.themeId].customValueWrapper}>
+          {inputRenderer()}
+          <div className={props.theme[props.themeId].customValueBlock}>
+            {option && props.valueRenderer(option)}
+          </div>
+        </div>
+      );
+    }
+    return inputRenderer();
+  };
+
+  return (
+    <FormField
+      className={props.className}
+      disabled={props.disabled}
+      label={props.label}
+      error={props.error}
+      inputRef={props.inputRef}
+      skin={FormFieldSkin}
+      theme={props.theme}
+      render={() => (
+        valueRenderer(props.selectedOption)
+      )}
+    />
+  );
+};

--- a/source/skins/simple/SelectSkin.js
+++ b/source/skins/simple/SelectSkin.js
@@ -36,12 +36,12 @@ type Props = {
   optionsMaxHeight: number,
   placeholder: string,
   rootRef: ElementRef<*>,
+  selectionRenderer?: Function,
   theme: Object, // will take precedence over theme in context if passed
   themeId: string,
   toggleOpen: Function,
   toggleMouseLocation: Function,
   value: string,
-  valueRenderer?: Function,
 };
 
 export const SelectSkin = (props: Props) => {
@@ -69,7 +69,7 @@ export const SelectSkin = (props: Props) => {
           onClick={props.handleInputClick}
           placeholder={props.placeholder}
           error={props.error}
-          valueRenderer={props.valueRenderer}
+          selectionRenderer={props.selectionRenderer}
           readOnly
           selectedOption={selectedOption}
         />

--- a/source/skins/simple/SelectSkin.js
+++ b/source/skins/simple/SelectSkin.js
@@ -40,13 +40,15 @@ type Props = {
   themeId: string,
   toggleOpen: Function,
   toggleMouseLocation: Function,
-  value: string
+  value: string,
+  valueRenderer?: Function,
 };
 
 export const SelectSkin = (props: Props) => {
   const selectedOption = props.getSelectedOption();
   const inputValue = selectedOption ? selectedOption.label : '';
   const { theme, themeId } = props;
+
   return (
     <div
       ref={props.rootRef}
@@ -67,7 +69,9 @@ export const SelectSkin = (props: Props) => {
           onClick={props.handleInputClick}
           placeholder={props.placeholder}
           error={props.error}
+          valueRenderer={props.valueRenderer}
           readOnly
+          selectedOption={selectedOption}
         />
       </div>
       <Options

--- a/source/skins/simple/StepperSkin.js
+++ b/source/skins/simple/StepperSkin.js
@@ -6,14 +6,14 @@ import { map } from 'lodash';
 import classnames from 'classnames';
 
 type Props = {
+  activeStep?: number,
   className: string,
   label?: string,
   labelDisabled?: boolean,
+  onStepClick?: Function,
   steps: Array<string>,
-  activeStep?: number,
   theme: Object,
   themeId: string,
-  onStepClick?: Function,
 };
 
 export const StepperSkin = (props: Props) => {

--- a/source/skins/simple/StepperSkin.js
+++ b/source/skins/simple/StepperSkin.js
@@ -1,0 +1,77 @@
+// @flow
+import React from 'react';
+
+// external libraries
+import { map } from 'lodash';
+import classnames from 'classnames';
+
+type Props = {
+  className: string,
+  label?: string,
+  labelDisabled?: boolean,
+  steps: Array<string>,
+  activeStep?: number,
+  theme: Object,
+  themeId: string,
+  onStepClick?: Function,
+};
+
+export const StepperSkin = (props: Props) => {
+  let label;
+  if (!props.steps) return null;
+
+  if (!props.labelDisabled) {
+    const calculatedLabel = props.activeStep && `STEP ${props.activeStep} OF ${props.steps.length}`;
+    label = props.label ? props.label : calculatedLabel;
+  }
+
+  return (
+    <div
+      role="presentation"
+      aria-hidden
+      className={classnames([
+        props.className,
+        props.theme[props.themeId].root,
+      ])}
+    >
+      <div className={props.theme[props.themeId].wrapper}>
+        {label && (
+          <div
+            className={props.theme[props.themeId].label}
+          >
+            <h3>{label}</h3>
+          </div>
+        )}
+        <ul className={props.theme[props.themeId].stepsWrapper}>
+          {map(props.steps, (step, index) => {
+            let classname;
+            if ((index + 1) < props.activeStep) {
+              classname = 'finished';
+            } else if ((index + 1) === props.activeStep) {
+              classname = 'active';
+            } else {
+              classname = 'disabled';
+            }
+
+            return (
+              <li
+                key={index}
+                className={props.theme[props.themeId][classname]}
+                style={{ width: `${100 / props.steps.length}%` }}
+                role="presentation"
+                aria-hidden
+                onClick={event => {
+                  if (props.onStepClick) {
+                    props.onStepClick(index, event);
+                  }
+                }}
+              >
+                {step}
+              </li>
+            );
+          })}
+        </ul>
+      </div>
+    </div>
+  );
+};

--- a/source/skins/simple/StepperSkin.js
+++ b/source/skins/simple/StepperSkin.js
@@ -1,9 +1,11 @@
 // @flow
 import React from 'react';
+// $FlowFixMe
+import type { SyntheticMouseEvent } from 'react';
 
 // external libraries
-import { map } from 'lodash';
 import classnames from 'classnames';
+import { map, isFunction } from 'lodash';
 
 type Props = {
   activeStep?: number,
@@ -53,6 +55,12 @@ export const StepperSkin = (props: Props) => {
               classname = 'disabled';
             }
 
+            const handleStepClick = (event: SyntheticMouseEvent) => {
+              if (props.onStepClick && isFunction(props.onStepClick)) {
+                props.onStepClick(step, index, event);
+              }
+            };
+
             return (
               <li
                 key={index}
@@ -60,11 +68,7 @@ export const StepperSkin = (props: Props) => {
                 style={{ width: `${100 / props.steps.length}%` }}
                 role="presentation"
                 aria-hidden
-                onClick={event => {
-                  if (props.onStepClick) {
-                    props.onStepClick(index, event);
-                  }
-                }}
+                onClick={handleStepClick}
               >
                 {step}
               </li>

--- a/source/skins/simple/index.js
+++ b/source/skins/simple/index.js
@@ -14,6 +14,7 @@ import { OptionsSkin } from './OptionsSkin';
 import { ProgressBarSkin } from './ProgressBarSkin';
 import { RadioSkin } from './RadioSkin';
 import { SelectSkin } from './SelectSkin';
+import { StepperSkin } from './StepperSkin';
 import { SwitchSkin } from './SwitchSkin';
 import { TextAreaSkin } from './TextAreaSkin';
 import { TogglerSkin } from './TogglerSkin';
@@ -34,6 +35,7 @@ export const SimpleSkins = {
   [IDENTIFIERS.PROGRESS_BAR]: ProgressBarSkin,
   [IDENTIFIERS.RADIO]: RadioSkin,
   [IDENTIFIERS.SELECT]: SelectSkin,
+  [IDENTIFIERS.STEPPER]: StepperSkin,
   [IDENTIFIERS.SWITCH]: SwitchSkin,
   [IDENTIFIERS.TEXT_AREA]: TextAreaSkin,
   [IDENTIFIERS.TOGGLER]: TogglerSkin,

--- a/source/themes/API/index.js
+++ b/source/themes/API/index.js
@@ -17,6 +17,7 @@ import { OPTIONS_THEME_API } from './options';
 import { PROGRESS_BAR_THEME_API } from './progressbar';
 import { RADIO_THEME_API } from './radio';
 import { SELECT_THEME_API } from './select';
+import { STEPPER_THEME_API } from './stepper';
 import { SWITCH_THEME_API } from './switch';
 import { TEXT_AREA_THEME_API } from './textarea';
 import { TOGGLER_THEME_API } from './toggler';
@@ -40,6 +41,7 @@ export const ROOT_THEME_API = {
   [IDENTIFIERS.PROGRESS_BAR]: PROGRESS_BAR_THEME_API,
   [IDENTIFIERS.RADIO]: RADIO_THEME_API,
   [IDENTIFIERS.SELECT]: SELECT_THEME_API,
+  [IDENTIFIERS.STEPPER]: STEPPER_THEME_API,
   [IDENTIFIERS.SWITCH]: SWITCH_THEME_API,
   [IDENTIFIERS.TEXT_AREA]: TEXT_AREA_THEME_API,
   [IDENTIFIERS.TOGGLER]: TOGGLER_THEME_API,

--- a/source/themes/API/stepper.js
+++ b/source/themes/API/stepper.js
@@ -1,0 +1,9 @@
+// @flow
+export const STEPPER_THEME_API = {
+  root: '',
+  label: '',
+  stepsWrapper: '',
+  active: '',
+  finished: '',
+  disabled: ''
+};

--- a/source/themes/simple/SimpleInput.scss
+++ b/source/themes/simple/SimpleInput.scss
@@ -74,3 +74,27 @@ $input-placeholder-font-family: var(--rp-input-placeholder-font-family, $theme-f
 }
 
 // END SPECIAL STATES ---------- //
+
+// BEGIN CUSTOM VALUE RENDERER ---------- //
+
+.customValueWrapper {
+  input {
+    color: transparent !important;
+    background-color: transparent !important;
+    position: absolute;
+    z-index: 2;
+  }
+
+  .customValueBlock {
+    background-color: $input-bg-color;
+    height: 48px;
+    left: 0;
+    max-height: 48px;
+    position: relative;
+    top: 0;
+    width: 100%;
+    z-index: 1;
+  }
+}
+
+// END CUSTOM VALUE RENDERER ---------- //

--- a/source/themes/simple/SimpleSelect.scss
+++ b/source/themes/simple/SimpleSelect.scss
@@ -63,6 +63,7 @@ $select-arrow-url-open: var(--rp-select-arrow-url-open, url("#{$theme-assets-pat
     left: $select-arrow-left;
     height: $select-arrow-height;
     width: $select-arrow-width;
+    z-index: 2;
   }
 }
 

--- a/source/themes/simple/SimpleStepper.scss
+++ b/source/themes/simple/SimpleStepper.scss
@@ -1,0 +1,109 @@
+@import "theme";
+
+// OVERRIDABLE CONFIGURATION VARIABLES
+
+// Main
+$stepper-main-color: var(--rp-stepper-main-color, rgba(68, 91, 124, 1)) !default;
+$stepper-main-color-light: var(--rp-stepper-main-color-light, rgba(68, 91, 124, 0.1)) !default;
+$stepper-label-color: var(--rp-stepper-label-color, rgba(94, 96, 102, 1)) !default;
+$stepper-label-color-light: var(--rp-stepper-label-color-light, rgba(94, 96, 102, 0.3)) !default;
+
+// Label
+$stepper-label-font-family: var(--rp-stepper-label-font-family, $theme-font-medium, sans-serif) !default;
+$stepper-label-font-size: var(--rp-stepper-label-font-size, 12px) !default;
+$stepper-label-margin: var(--rp-stepper-label-margin, 0) !default;
+$stepper-label-text-align: var(--rp-stepper-label-text-align, center) !default;
+$stepper-label-text-color: var(--rp-stepper-label-text-color, $stepper-label-color) !default;
+
+// Bullets
+$stepper-bullet-background-color-active: var(--rp-stepper-bullet-background-color-active, $stepper-main-color) !default;
+$stepper-bullet-background-color-disabled: var(--rp-stepper-bullet-background-color-disabled, #fff) !default;
+$stepper-bullet-border: var(--rp-stepper-bullet-border, 2px solid var(--rp-stepper-bullet-border-color, $stepper-main-color-light)) !default;
+$stepper-bullet-border-color-active: var(--rp-stepper-bullet-border-color-active, $stepper-main-color) !default;
+$stepper-bullet-border-color-disabled: var(--rp-stepper-bullet-border-color-disabled, $stepper-main-color-light) !default;
+$stepper-bullet-border-radius: var(--rp-stepper-bullet-border-radius, 50%) !default;
+$stepper-bullet-height: var(--rpstepper-bullet-height, 16px) !default;
+$stepper-bullet-width: var(--rpstepper-bullet-width, 16px) !default;
+
+// Steps - bar
+$stepper-steps-bar-color-active: var(--rpstepper-steps-bar-color-active, $stepper-main-color) !default;
+$stepper-steps-bar-color-disabled: var(--rpstepper-steps-bar-color-disabled, $stepper-main-color-light) !default;
+$stepper-steps-bar-height: var(--rpstepper-steps-bar-height, 4px) !default;
+$stepper-steps-bar-top-position: var(--rpstepper-steps-bar-top-position, 8px) !default;
+
+// Steps - label
+$stepper-step-label-bottom-margin: var(--rpstepper-stepper-step-label-bottom-margin, 10px) !default;
+$stepper-step-label-color: var(--rp-stepper-step-label-color, $stepper-label-color) !default;
+$stepper-step-label-color-light: var(--rp-stepper-step-label-color-light, $stepper-label-color-light) !default;
+$stepper-step-label-font-family: var(--rpstepper-step-label-font-family, $theme-font-medium) !default;
+
+.wrapper {
+  width: 100%;
+
+  .label {
+    color: $stepper-label-text-color;
+    font-family: $stepper-label-font-family;
+    font-size: $stepper-label-font-size;
+    line-height: 1.83;
+    margin: $stepper-label-margin;
+    text-align: $stepper-label-text-align;
+  }
+  
+  .stepsWrapper {
+    li {
+      color: $stepper-step-label-color-light;
+      float: left;
+      font-family: $stepper-step-label-font-family;
+      list-style-type: none;
+      position: relative;
+      text-align: center;
+
+      &:before {
+        background-color: $stepper-bullet-background-color-disabled;
+        content: " ";
+        display: block;
+        border: $stepper-bullet-border;
+        border-radius: $stepper-bullet-border-radius;
+        height: $stepper-bullet-height;
+        margin: 0 auto $stepper-step-label-bottom-margin;
+        width: $stepper-bullet-width;
+      }
+
+      &:after {
+        background-color: $stepper-steps-bar-color-disabled;
+        content: "";
+        height: $stepper-steps-bar-height;
+        left: -50%;
+        position: absolute;
+        top: $stepper-steps-bar-top-position;
+        width: 100%;
+        z-index: -1;
+      }
+
+      &:first-child:after {
+        content: none;
+      }
+
+      &.active,
+      &.finished {
+        color: $stepper-step-label-color;
+
+        &:before {
+          border-color: $stepper-bullet-border-color-active;
+        }
+
+        &:after {
+          background-color: $stepper-bullet-background-color-active;
+          border-color: $stepper-bullet-border-color-active;
+        }
+      }
+
+      &.finished {
+        &:before {
+          background-color: $stepper-bullet-background-color-active; 
+        }
+      }
+    }
+  }
+}
+

--- a/source/themes/simple/SimpleStepper.scss
+++ b/source/themes/simple/SimpleStepper.scss
@@ -2,20 +2,22 @@
 
 // OVERRIDABLE CONFIGURATION VARIABLES
 
-// Main
+// main-color
 $stepper-main-color: var(--rp-stepper-main-color, rgba(68, 91, 124, 1)) !default;
 $stepper-main-color-light: var(--rp-stepper-main-color-light, rgba(68, 91, 124, 0.1)) !default;
+
+// label-color
 $stepper-label-color: var(--rp-stepper-label-color, rgba(94, 96, 102, 1)) !default;
 $stepper-label-color-light: var(--rp-stepper-label-color-light, rgba(94, 96, 102, 0.3)) !default;
 
-// Label
+// label
 $stepper-label-font-family: var(--rp-stepper-label-font-family, $theme-font-medium, sans-serif) !default;
 $stepper-label-font-size: var(--rp-stepper-label-font-size, 12px) !default;
 $stepper-label-margin: var(--rp-stepper-label-margin, 0) !default;
 $stepper-label-text-align: var(--rp-stepper-label-text-align, center) !default;
 $stepper-label-text-color: var(--rp-stepper-label-text-color, $stepper-label-color) !default;
 
-// Bullets
+// bullet
 $stepper-bullet-background-color-active: var(--rp-stepper-bullet-background-color-active, $stepper-main-color) !default;
 $stepper-bullet-background-color-disabled: var(--rp-stepper-bullet-background-color-disabled, #fff) !default;
 $stepper-bullet-border: var(--rp-stepper-bullet-border, 2px solid var(--rp-stepper-bullet-border-color, $stepper-main-color-light)) !default;
@@ -25,13 +27,13 @@ $stepper-bullet-border-radius: var(--rp-stepper-bullet-border-radius, 50%) !defa
 $stepper-bullet-height: var(--rpstepper-bullet-height, 16px) !default;
 $stepper-bullet-width: var(--rpstepper-bullet-width, 16px) !default;
 
-// Steps - bar
+// steps-bar
 $stepper-steps-bar-color-active: var(--rpstepper-steps-bar-color-active, $stepper-main-color) !default;
 $stepper-steps-bar-color-disabled: var(--rpstepper-steps-bar-color-disabled, $stepper-main-color-light) !default;
 $stepper-steps-bar-height: var(--rpstepper-steps-bar-height, 4px) !default;
 $stepper-steps-bar-top-position: var(--rpstepper-steps-bar-top-position, 8px) !default;
 
-// Steps - label
+// step-label
 $stepper-step-label-bottom-margin: var(--rpstepper-stepper-step-label-bottom-margin, 10px) !default;
 $stepper-step-label-color: var(--rp-stepper-step-label-color, $stepper-label-color) !default;
 $stepper-step-label-color-light: var(--rp-stepper-step-label-color-light, $stepper-label-color-light) !default;

--- a/source/themes/simple/index.js
+++ b/source/themes/simple/index.js
@@ -20,6 +20,7 @@ import SimpleOptions from './SimpleOptions.scss';
 import SimpleProgressBar from './SimpleProgressBar.scss';
 import SimpleRadio from './SimpleRadio.scss';
 import SimpleSelect from './SimpleSelect.scss';
+import SimpleStepper from './SimpleStepper.scss';
 import SimpleSwitch from './SimpleSwitch.scss';
 import SimpleTextArea from './SimpleTextArea.scss';
 import SimpleToggler from './SimpleToggler.scss';
@@ -47,6 +48,7 @@ export const SimpleTheme = {
   [IDENTIFIERS.PROGRESS_BAR]: SimpleProgressBar,
   [IDENTIFIERS.RADIO]: SimpleRadio,
   [IDENTIFIERS.SELECT]: SimpleSelect,
+  [IDENTIFIERS.STEPPER]: SimpleStepper,
   [IDENTIFIERS.SWITCH]: SimpleSwitch,
   [IDENTIFIERS.TEXT_AREA]: SimpleTextArea,
   [IDENTIFIERS.TOGGLER]: SimpleToggler,

--- a/stories/Select.stories.js
+++ b/stories/Select.stories.js
@@ -50,6 +50,12 @@ const COUNTRIES_WITH_DISABLED_OPTIONS = [
   { value: 'EN-en', label: 'USA' }
 ];
 
+const WALLETS = [
+  { value: '100,100 ADA', label: 'Main wallet' },
+  { value: '10,100.2 ADA', label: 'Spending money' },
+  { value: '500,1000 ADA', label: 'Savings' },
+];
+
 storiesOf('Select', module)
 
   .addDecorator(decorateWithSimpleTheme)
@@ -215,5 +221,30 @@ storiesOf('Select', module)
             Reopen modal
           </button>
         )
+    ))
+  )
+
+  .add('custom value labels template',
+    withState({ value: '' }, store => (
+      <Select
+        value={store.state.value}
+        onChange={value => store.set({ value })}
+        options={WALLETS}
+        optionRenderer={option => (
+          <div
+            className={styles.customOptionStyle}
+            role="presentation"
+          >
+            <div className={styles.label}>{option.label}</div>
+            <div className={styles.value}>{option.value}</div>
+          </div>
+        )}
+        valueRenderer={option => (
+          <div className={styles.customValueStyle}>
+            <div className={styles.label}>{option.label}</div>
+            <div className={styles.value}>{option.value}</div>
+          </div>
+        )}
+      />
     ))
   );

--- a/stories/Select.stories.js
+++ b/stories/Select.stories.js
@@ -224,7 +224,7 @@ storiesOf('Select', module)
     ))
   )
 
-  .add('custom selected value template',
+  .add('custom selected option renderer',
     withState({ value: '' }, store => (
       <Select
         value={store.state.value}
@@ -240,7 +240,7 @@ storiesOf('Select', module)
             <div className={styles.value}>{option.value}</div>
           </div>
         )}
-        valueRenderer={option => (
+        selectionRenderer={option => (
           <div className={styles.customValueStyle}>
             <div className={styles.label}>{option.label}</div>
             <div className={styles.value}>{option.value}</div>

--- a/stories/Select.stories.js
+++ b/stories/Select.stories.js
@@ -224,7 +224,7 @@ storiesOf('Select', module)
     ))
   )
 
-  .add('custom value labels template',
+  .add('custom selected value template',
     withState({ value: '' }, store => (
       <Select
         value={store.state.value}

--- a/stories/Select.stories.js
+++ b/stories/Select.stories.js
@@ -229,6 +229,7 @@ storiesOf('Select', module)
       <Select
         value={store.state.value}
         onChange={value => store.set({ value })}
+        placeholder="Select Wallet"
         options={WALLETS}
         optionRenderer={option => (
           <div

--- a/stories/Select.stories.scss
+++ b/stories/Select.stories.scss
@@ -74,3 +74,35 @@
   top: 100px;
 }
 
+.customValueStyle {
+  color: #5e6066;
+  font-family: var(--rp-options-font-family, $theme-font-regular, sans-serif) !important;
+  max-height: inherit;
+  padding: 7px 20px 0;
+
+  .label {
+    font-size: 14px;
+    line-height: 1.43;
+  }
+
+  .value {
+    font-size: 12px;
+    line-height: 1.33;
+    opacity: 0.5;
+  }
+}
+
+.customOptionStyle {
+  color: #5e6066;
+
+  .label {
+    font-size: 14px;
+    line-height: 1.43;
+  }
+
+  .value {
+    font-size: 12px;
+    line-height: 1.33;
+    opacity: 0.5;
+  }
+}

--- a/stories/Stepper.stories.js
+++ b/stories/Stepper.stories.js
@@ -1,0 +1,68 @@
+// @flow
+import React from 'react';
+
+// storybook
+import { storiesOf } from '@storybook/react';
+
+// components
+import { Stepper } from '../source/components/Stepper';
+
+// themes
+import CustomStepperTheme from './theme-customizations/Stepper.custom.scss';
+
+// custom styles & theme overrides
+import themeOverrides from './theme-overrides/customStepper.scss';
+import { IDENTIFIERS } from '../source/components';
+
+// helpers
+import { decorateWithSimpleTheme } from './helpers/theming';
+
+const STEPS = ['Wallet', 'Stake pool', 'Delegation', 'Activation'];
+
+storiesOf('Stepper', module)
+
+  .addDecorator(decorateWithSimpleTheme)
+
+  // ====== Stories ======
+
+  .add('plain', () => (
+    <Stepper
+      steps={STEPS}
+      activeStep={2}
+    />
+  ))
+
+  .add('with custom label text', () => (
+    <Stepper
+      label="Setup progress"
+      steps={STEPS}
+      activeStep={2}
+    />
+  ))
+
+  .add('without label', () => (
+    <Stepper
+      labelDisabled
+      steps={STEPS}
+      activeStep={2}
+    />
+  ))
+
+  .add('theme overrides', () => (
+    <Stepper
+      themeOverrides={themeOverrides}
+      themeId={IDENTIFIERS.STEPPER}
+      label="Setup progress"
+      steps={STEPS}
+      activeStep={2}
+    />
+  ))
+
+  .add('custom theme', () => (
+    <Stepper
+      themeId={IDENTIFIERS.STEPPER}
+      theme={CustomStepperTheme}
+      steps={STEPS}
+      activeStep={2}
+    />
+  ));

--- a/stories/Stepper.stories.js
+++ b/stories/Stepper.stories.js
@@ -3,6 +3,7 @@ import React from 'react';
 
 // storybook
 import { storiesOf } from '@storybook/react';
+import { withState } from '@dump247/storybook-state';
 
 // components
 import { Stepper } from '../source/components/Stepper';
@@ -47,6 +48,17 @@ storiesOf('Stepper', module)
       activeStep={2}
     />
   ))
+
+  .add('onStepClick',
+    withState({ activeStep: 1 },
+      store => (
+        <Stepper
+          steps={STEPS}
+          activeStep={store.state.activeStep}
+          onStepClick={(step, index) => store.set({ activeStep: index + 1 })}
+        />
+      ))
+  )
 
   .add('theme overrides', () => (
     <Stepper

--- a/stories/index.js
+++ b/stories/index.js
@@ -15,6 +15,7 @@ import './Options.stories';
 import './ProgressBar.stories';
 import './Radio.stories';
 import './Select.stories';
+import './Stepper.stories';
 import './Switch.stories';
 import './TextArea.stories';
 import './Toggler.stories';

--- a/stories/theme-customizations/Stepper.custom.scss
+++ b/stories/theme-customizations/Stepper.custom.scss
@@ -1,0 +1,36 @@
+// Stepper theme customizations
+
+// Main
+$stepper-main-color: var(--rp-stepper-main-color, rgba(10, 145, 48, 1)) !default;
+$stepper-main-color-light: var(--rp-stepper-main-color-light, rgba(10, 145, 48, 0.1)) !default;
+$stepper-label-color: var(--rp-stepper-label-color, rgba(94, 96, 102, 1)) !default;
+$stepper-label-color-light: var(--rp-stepper-label-color-light, rgba(94, 96, 102, 0.3)) !default;
+
+// Label
+$stepper-label-font-size: var(--rp-stepper-label-font-size, 12px) !default;
+$stepper-label-margin: var(--rp-stepper-label-margin, 0) !default;
+$stepper-label-text-align: var(--rp-stepper-label-text-align, center) !default;
+$stepper-label-text-color: var(--rp-stepper-label-text-color, $stepper-label-color) !default;
+
+// Bullets
+$stepper-bullet-background-color-active: var(--rp-stepper-bullet-background-color-active, $stepper-main-color) !default;
+$stepper-bullet-background-color-disabled: var(--rp-stepper-bullet-background-color-disabled, #fff) !default;
+$stepper-bullet-border: var(--rp-stepper-bullet-border, 2px solid var(--rp-stepper-bullet-border-color, $stepper-main-color-light)) !default;
+$stepper-bullet-border-color-active: var(--rp-stepper-bullet-border-color-active, $stepper-main-color) !default;
+$stepper-bullet-border-color-disabled: var(--rp-stepper-bullet-border-color-disabled, $stepper-main-color-light) !default;
+$stepper-bullet-border-radius: var(--rp-stepper-bullet-border-radius, 50%) !default;
+$stepper-bullet-height: var(--rpstepper-bullet-height, 16px) !default;
+$stepper-bullet-width: var(--rpstepper-bullet-width, 16px) !default;
+
+// Steps - bar
+$stepper-steps-bar-color-active: var(--rpstepper-steps-bar-color-active, $stepper-main-color) !default;
+$stepper-steps-bar-color-disabled: var(--rpstepper-steps-bar-color-disabled, $stepper-main-color-light) !default;
+$stepper-steps-bar-height: var(--rpstepper-steps-bar-height, 4px) !default;
+$stepper-steps-bar-top-position: var(--rpstepper-steps-bar-top-position, 8px) !default;
+
+// Steps - label
+$stepper-step-label-bottom-margin: var(--rpstepper-stepper-step-label-bottom-margin, 10px) !default;
+$stepper-step-label-color: var(--rp-stepper-step-label-color, $stepper-label-color) !default;
+$stepper-step-label-color-light: var(--rp-stepper-step-label-color-light, $stepper-label-color-light) !default;
+
+@import "../../source/themes/simple/SimpleStepper";

--- a/stories/theme-overrides/customStepper.scss
+++ b/stories/theme-overrides/customStepper.scss
@@ -1,0 +1,63 @@
+.root {
+  .label {
+    color: rgba(10, 145, 48, 1);
+    font-size: 16px;
+    margin: 15px 0;
+    text-align: center;
+  }
+  
+  .stepsWrapper {
+    li {
+      list-style-type: none;
+      float: left;
+      position: relative;
+      text-align: center;
+      color: rgba(10, 145, 48, 0.3);
+
+      &:before {
+        content: " ";
+        border-radius: 30%;
+        width: 16px;
+        height: 16px;
+        border: 2px solid rgba(10, 145, 48, 1);
+        display: block;
+        margin: 0 auto 10px;
+        background-color: #fff;
+      }
+
+      &:after {
+        content: "";
+        position: absolute;
+        width: 100%;
+        height: 4px;
+        background-color: rgba(10, 145, 48, 0.1);
+        top: 8px;
+        left: -50%;
+        z-index: -1;
+      }
+
+      &:first-child:after {
+        content: none;
+      }
+
+      &.active,
+      &.finished {
+        color: rgba(10, 145, 48, 1);
+        &:before {
+          border-color: rgba(10, 145, 48, 1);
+        }
+        &:after {
+          border-color: rgba(10, 145, 48, 1);
+          background-color: rgba(10, 145, 48, 1);
+        }
+      }
+
+      &.finished {
+        &:before {
+          background-color: rgba(10, 145, 48, 1); 
+        }
+      }
+    }
+  }
+}
+

--- a/stories/theme-overrides/customStepper.scss
+++ b/stories/theme-overrides/customStepper.scss
@@ -8,31 +8,31 @@
   
   .stepsWrapper {
     li {
-      list-style-type: none;
+      color: rgba(10, 145, 48, 0.3);
       float: left;
+      list-style-type: none;
       position: relative;
       text-align: center;
-      color: rgba(10, 145, 48, 0.3);
 
       &:before {
-        content: " ";
-        border-radius: 30%;
-        width: 16px;
-        height: 16px;
-        border: 2px solid rgba(10, 145, 48, 1);
-        display: block;
-        margin: 0 auto 10px;
         background-color: #fff;
+        border: 2px solid rgba(10, 145, 48, 1);
+        border-radius: 30%;
+        content: " ";
+        display: block;
+        height: 16px;
+        margin: 0 auto 10px;
+        width: 16px;
       }
 
       &:after {
-        content: "";
-        position: absolute;
-        width: 100%;
-        height: 4px;
         background-color: rgba(10, 145, 48, 0.1);
-        top: 8px;
+        content: "";
+        height: 4px;
         left: -50%;
+        position: absolute;
+        top: 8px;
+        width: 100%;
         z-index: -1;
       }
 
@@ -47,8 +47,8 @@
           border-color: rgba(10, 145, 48, 1);
         }
         &:after {
-          border-color: rgba(10, 145, 48, 1);
           background-color: rgba(10, 145, 48, 1);
+          border-color: rgba(10, 145, 48, 1);
         }
       }
 


### PR DESCRIPTION
This PR introduces Custom select value renderer that can replace selected value default input rendered value. Also this PR introduces Stepper component as steps progress bar indicator.

## How to Test

- Custom Select value (`Select -> custom select value template`) - Select any select option and both label and value should appear as selected value
- Go to `Stepper` section and walk through different scenarios.

 **Note:**  Both tests are related to https://zpl.io/aBRGAeA step 1 _"choose wallet"_ step

## Screenshots

_Custom Select Value_

<img width="1184" alt="Custom select value" src="https://user-images.githubusercontent.com/18653950/59414373-ab151180-8dc1-11e9-9e4a-b1b84dd16eb0.png">


_Stepper Component_

<img width="1181" alt="Stepper Component" src="https://user-images.githubusercontent.com/18653950/59414398-b9fbc400-8dc1-11e9-992b-932aaccb0f4f.png">
