### PR TITLE
[bugfix] Use fit-content on checkbox

### DIFF
--- a/source/themes/simple/SimpleCheckbox.scss
+++ b/source/themes/simple/SimpleCheckbox.scss
@@ -27,6 +27,7 @@ $checkbox-label-text-color-disabled: var(--rp-checkbox-label-text-color-disabled
 .root {
   display: flex;
   position: relative;
+  width: fit-content;
 }
 
 .input {


### PR DESCRIPTION
Both in Yoroi and in Daedalus, any area in the screen to the right of a checkbox triggers a toggle on-click. 

# Gif

![daedalus_bug](https://user-images.githubusercontent.com/2608559/60132835-47361400-97d7-11e9-8b99-06e94f58a956.gif)

# Explanation

This is because the width of checkbox root expands to fit the space
<img width="587" alt="image" src="https://user-images.githubusercontent.com/2608559/60132682-f9211080-97d6-11e9-970e-9ceb132e3df9.png">
