### PR TITLE
[DDW-754] handle standalone fraction dot correctly

### DIFF
--- a/source/components/NumericInput.js
+++ b/source/components/NumericInput.js
@@ -354,6 +354,12 @@ class NumericInputBase extends Component<Props, State> {
     inputElement.current.focus();
   };
 
+  onBlur = () => {
+    this.setState({
+      fallbackInputValue: null,
+    });
+  };
+
   render() {
     // destructuring props ensures only the "...rest" get passed down
     const {
@@ -382,6 +388,7 @@ class NumericInputBase extends Component<Props, State> {
         onChange={this.onChange}
         theme={this.state.composedTheme}
         value={inputValue}
+        onBlur={this.onBlur}
         {...rest}
       />
     );

--- a/source/components/NumericInput.js
+++ b/source/components/NumericInput.js
@@ -406,9 +406,9 @@ export const NumericInput = withTheme(NumericInputBase);
 
 // ========= HELPERS ==========
 
-const VALID_INPUT_SIGNS_REGEX = /^([0-9,+\-.]+)?$/;
-const VALID_INPUT_NO_SIGNS_REGEX = /^([0-9,.]+)?$/;
-const NUMERIC_INPUT_REGEX = /^([+|-])?([0-9,]+)?(\.([0-9]+)?)?$/;
+const VALID_INPUT_SIGNS_REGEX = /^([-])?[0-9,.]+$/;
+const VALID_INPUT_NO_SIGNS_REGEX = /^[0-9,.]+$/;
+const NUMERIC_INPUT_REGEX = /^([-])?([0-9,]+)?(\.([0-9]+)?)?$/;
 
 const isValidNumericInput = (value: string): boolean => NUMERIC_INPUT_REGEX.test(value);
 

--- a/source/components/NumericInput.js
+++ b/source/components/NumericInput.js
@@ -40,7 +40,7 @@ type State = {
   composedTheme: Object,
   minimumFractionDigits: number,
   inputCaretPosition: number,
-  fallbackInputValue: string,
+  fallbackInputValue: ?string,
 };
 
 // TODO: make this configurable (generalize handling commas and dots in other languages!)
@@ -77,7 +77,7 @@ class NumericInputBase extends Component<Props, State> {
       ),
       minimumFractionDigits: minimumFractionDigits || 0,
       inputCaretPosition: 0,
-      fallbackInputValue: '',
+      fallbackInputValue: null,
     };
   }
 
@@ -136,14 +136,14 @@ class NumericInputBase extends Component<Props, State> {
   processValueChange(event: InputEvent): ?{
     value: ?number,
     caretPosition: number,
-    fallbackInputValue?: string,
+    fallbackInputValue?: ?string,
     minimumFractionDigits: number,
   } {
     const changedCaretPosition = event.target.selectionStart;
     const valueToProcess = event.target.value;
     const { inputType } = event;
     const { value } = this.props;
-    const { fallbackInputValue } = this.state;
+    const fallbackInputValue = this.state.fallbackInputValue || '';
     const isBackwardDelete = inputType === 'deleteContentBackward';
     const isForwardDelete = inputType === 'deleteContentForward';
     const isDeletion = isForwardDelete || isBackwardDelete;
@@ -167,7 +167,7 @@ class NumericInputBase extends Component<Props, State> {
       return {
         value: null,
         caretPosition: 0,
-        fallbackInputValue: '',
+        fallbackInputValue: null,
         minimumFractionDigits: 0,
       };
     }
@@ -235,9 +235,9 @@ class NumericInputBase extends Component<Props, State> {
     if (valueToProcess === '.') {
       const hasMinFractions = dynamicMinimumFractionDigits > 0;
       return {
-        value: hasMinFractions ? 0 : null,
+        value: 0,
         caretPosition: 2,
-        fallbackInputValue: hasMinFractions ? '' : '0.',
+        fallbackInputValue: hasMinFractions ? null : '0.',
         minimumFractionDigits: dynamicMinimumFractionDigits,
       };
     }
@@ -245,7 +245,7 @@ class NumericInputBase extends Component<Props, State> {
     // Case: Dot was added at the beginning of number
     if (newValue.charAt(0) === '.') {
       return {
-        value: null,
+        value: newNumber,
         caretPosition: changedCaretPosition,
         fallbackInputValue: newValue, // render new value as-is
         minimumFractionDigits: dynamicMinimumFractionDigits,
@@ -267,7 +267,7 @@ class NumericInputBase extends Component<Props, State> {
     // Case: Dot was added at the end of number
     if (!isDeletion && newValue.charAt(newValue.length - 1) === '.') {
       return {
-        value: null,
+        value: newNumber,
         caretPosition: changedCaretPosition,
         fallbackInputValue: newValue,
         minimumFractionDigits: 0,
@@ -281,7 +281,7 @@ class NumericInputBase extends Component<Props, State> {
     if (wasDotRemoved && hasFractions && !isInsert) {
       return {
         caretPosition: newCaretPosition + deleteCaretCorrection,
-        fallbackInputValue: '',
+        fallbackInputValue: null,
         minimumFractionDigits: dynamicMinimumFractionDigits,
         value: currentNumber,
       };
@@ -297,7 +297,7 @@ class NumericInputBase extends Component<Props, State> {
     const caretCorrection = onlyCommasChanged ? deleteCaretCorrection : commasDiff;
     return {
       caretPosition: Math.max(newCaretPosition + caretCorrection, 0),
-      fallbackInputValue: '',
+      fallbackInputValue: null,
       minimumFractionDigits: dynamicMinimumFractionDigits,
       value: newNumber,
     };
@@ -368,9 +368,10 @@ class NumericInputBase extends Component<Props, State> {
 
     const InputSkin = skin || context.skins[IDENTIFIERS.INPUT];
 
-    const inputValue = value != null ?
-      this.getLocalizedNumber(value) :
-      this.state.fallbackInputValue;
+    const localizedInput = value != null ? this.getLocalizedNumber(value) : '';
+    const inputValue = this.state.fallbackInputValue ?
+      this.state.fallbackInputValue :
+      localizedInput;
 
     return (
       <InputSkin

--- a/source/components/NumericInput.js
+++ b/source/components/NumericInput.js
@@ -406,8 +406,8 @@ export const NumericInput = withTheme(NumericInputBase);
 
 // ========= HELPERS ==========
 
-const VALID_INPUT_SIGNS_REGEX = /^([-])?[0-9,.]+$/;
-const VALID_INPUT_NO_SIGNS_REGEX = /^[0-9,.]+$/;
+const VALID_INPUT_SIGNS_REGEX = /^([-])?([0-9,.]+)?$/;
+const VALID_INPUT_NO_SIGNS_REGEX = /^([0-9,.]+)?$/;
 const NUMERIC_INPUT_REGEX = /^([-])?([0-9,]+)?(\.([0-9]+)?)?$/;
 
 const isValidNumericInput = (value: string): boolean => NUMERIC_INPUT_REGEX.test(value);

--- a/source/components/NumericInput.js
+++ b/source/components/NumericInput.js
@@ -246,7 +246,7 @@ class NumericInputBase extends Component<Props, State> {
     if (newValue.charAt(0) === '.') {
       return {
         value: newNumber,
-        caretPosition: changedCaretPosition,
+        caretPosition: 2,
         minimumFractionDigits: dynamicMinimumFractionDigits,
       };
     }
@@ -272,7 +272,7 @@ class NumericInputBase extends Component<Props, State> {
       return {
         value: newNumber,
         caretPosition: changedCaretPosition,
-        fallbackInputValue: localizedNewNumber + '.',
+        fallbackInputValue: propsMinimumFractionDigits > 0 ? null : localizedNewNumber + '.',
         minimumFractionDigits: 0,
       };
     }

--- a/source/components/NumericInput.js
+++ b/source/components/NumericInput.js
@@ -149,6 +149,7 @@ class NumericInputBase extends Component<Props, State> {
     const isBackwardDelete = inputType === 'deleteContentBackward';
     const isForwardDelete = inputType === 'deleteContentForward';
     const isDeletion = isForwardDelete || isBackwardDelete;
+    const isInsert = inputType === 'insertText';
     const deleteCaretCorrection = isBackwardDelete ? 0 : 1;
     const validInputRegex = allowSigns ? VALID_INPUT_SIGNS_REGEX : VALID_INPUT_NO_SIGNS_REGEX;
     const valueHasLeadingZero = /^0[1-9]/.test(valueToProcess);
@@ -248,9 +249,10 @@ class NumericInputBase extends Component<Props, State> {
 
     // Case: Dot was added at the beginning of number
     if (newValue.charAt(0) === '.') {
+      const newCaretPos = isInsert ? 2 : 1;
       return {
         value: newNumber,
-        caretPosition: 2,
+        caretPosition: newCaretPos,
         minimumFractionDigits: dynamicMinimumFractionDigits,
       };
     }
@@ -282,7 +284,6 @@ class NumericInputBase extends Component<Props, State> {
     }
 
     // Case: Dot was deleted with minimum fraction digits constrain defined
-    const isInsert = inputType === 'insertText';
     const hasFractions = this.getMinimumFractionDigitsProp() != null;
     const wasDotRemoved = hadDotBefore && !newNumberOfDots;
     if (wasDotRemoved && hasFractions && !isInsert) {

--- a/source/components/NumericInput.js
+++ b/source/components/NumericInput.js
@@ -264,12 +264,16 @@ class NumericInputBase extends Component<Props, State> {
       };
     }
 
+    const localizedNewNumber = newNumber.toLocaleString(LOCALE, {
+      minimumFractionDigits: dynamicMinimumFractionDigits,
+    });
+
     // Case: Dot was added at the end of number
     if (!isDeletion && newValue.charAt(newValue.length - 1) === '.') {
       return {
         value: newNumber,
         caretPosition: changedCaretPosition,
-        fallbackInputValue: newValue,
+        fallbackInputValue: localizedNewNumber + '.',
         minimumFractionDigits: 0,
       };
     }
@@ -289,7 +293,6 @@ class NumericInputBase extends Component<Props, State> {
 
     // Case: Valid change has been made
 
-    const localizedNewNumber = newNumber.toLocaleString(LOCALE, numberLocaleOptions);
     const hasNumberChanged = value !== newNumber;
     const commasDiff = getNumberOfCommas(localizedNewNumber) - getNumberOfCommas(newValue);
     const haveCommasChanged = commasDiff > 0;

--- a/source/components/NumericInput.js
+++ b/source/components/NumericInput.js
@@ -180,7 +180,7 @@ class NumericInputBase extends Component<Props, State> {
       return {
         value: null,
         caretPosition: 1,
-        fallbackInputValue: valueToProcess, // render standalone minus sign
+        fallbackInputValue: '-',
         minimumFractionDigits: 0,
       };
     }
@@ -231,8 +231,18 @@ class NumericInputBase extends Component<Props, State> {
     );
     const newNumber = getValueAsNumber(newValue, maximumFractionDigits);
 
-    // Case: Dot was added at the beginning of number
+    // Case: Just a dot was entered
+    if (valueToProcess === '.') {
+      const hasMinFractions = dynamicMinimumFractionDigits > 0;
+      return {
+        value: hasMinFractions ? 0 : null,
+        caretPosition: 2,
+        fallbackInputValue: hasMinFractions ? '' : '0.',
+        minimumFractionDigits: dynamicMinimumFractionDigits,
+      };
+    }
 
+    // Case: Dot was added at the beginning of number
     if (newValue.charAt(0) === '.') {
       return {
         value: null,

--- a/source/components/NumericInput.js
+++ b/source/components/NumericInput.js
@@ -247,7 +247,6 @@ class NumericInputBase extends Component<Props, State> {
       return {
         value: newNumber,
         caretPosition: changedCaretPosition,
-        fallbackInputValue: newValue, // render new value as-is
         minimumFractionDigits: dynamicMinimumFractionDigits,
       };
     }

--- a/source/components/NumericInput.js
+++ b/source/components/NumericInput.js
@@ -291,12 +291,14 @@ class NumericInputBase extends Component<Props, State> {
     }
 
     // Case: Valid change has been made
-
     const hasNumberChanged = value !== newNumber;
     const commasDiff = getNumberOfCommas(localizedNewNumber) - getNumberOfCommas(newValue);
     const haveCommasChanged = commasDiff > 0;
     const onlyCommasChanged = !hasNumberChanged && haveCommasChanged;
-    const caretCorrection = onlyCommasChanged ? deleteCaretCorrection : commasDiff;
+    const leadingZeroCorrection = value === 0 ? -1 : 0;
+    const caretCorrection = (
+      onlyCommasChanged ? deleteCaretCorrection : commasDiff
+    ) + leadingZeroCorrection;
     return {
       caretPosition: Math.max(newCaretPosition + caretCorrection, 0),
       fallbackInputValue: null,

--- a/source/themes/simple/SimpleBubble.scss
+++ b/source/themes/simple/SimpleBubble.scss
@@ -27,7 +27,6 @@ $bubble-arrow-size: var(--rp-bubble-arrow-size, 10px) !default;
 $bubble-arrow-width: var(--rp-bubble-arrow-width, calc(2*#{$bubble-arrow-size})) !default;
 $bubble-arrow-height: var(--rp-bubble-arrow-height, $bubble-arrow-size) !default;
 
-
 .root {
   position: absolute;
   left: 0;
@@ -37,14 +36,14 @@ $bubble-arrow-height: var(--rp-bubble-arrow-height, $bubble-arrow-size) !default
   // ==== ARROW ====
   // The arrow is referred to as [data-bubble-arrow] so that the component doesn't have a high
   // specificity internally, allowing it to be overwritten externally
-  @if calc(#{$bubble-arrow} == true) {
+  @if ($bubble-arrow) {
     &.transparent [data-bubble-arrow] {
       @include arrow(
         up,
         $bubble-bg-color-transparent,
         $bubble-border-color-transparent,
         $bubble-arrow-width,
-        $bubble-arrow-height,
+        $bubble-arrow-height
       );
     }
 
@@ -54,7 +53,7 @@ $bubble-arrow-height: var(--rp-bubble-arrow-height, $bubble-arrow-size) !default
         $bubble-bg-color-transparent,
         $bubble-border-color-transparent,
         $bubble-arrow-width,
-        $bubble-arrow-height,
+        $bubble-arrow-height
       );
     }
 
@@ -64,7 +63,7 @@ $bubble-arrow-height: var(--rp-bubble-arrow-height, $bubble-arrow-size) !default
         $bubble-bg-color,
         $bubble-border-color,
         $bubble-arrow-width,
-        $bubble-arrow-height,
+        $bubble-arrow-height
       );
     }
 
@@ -74,7 +73,7 @@ $bubble-arrow-height: var(--rp-bubble-arrow-height, $bubble-arrow-size) !default
         $bubble-bg-color,
         $bubble-border-color,
         $bubble-arrow-width,
-        $bubble-arrow-height,
+        $bubble-arrow-height
       );
     }
 

--- a/source/themes/simple/SimpleOptions.scss
+++ b/source/themes/simple/SimpleOptions.scss
@@ -41,14 +41,14 @@ $options-arrow-height: var(--rp-options-arrow-height, $options-arrow-size) !defa
     padding: 0;
   }
 
-  @if calc(#{$options-arrow} == true) {
+  @if ($options-arrow) {
     [data-bubble-arrow] {
       @include arrow(
         up,
         $option-bg-color,
         $options-border-color,
         $options-arrow-width,
-        $options-arrow-height,
+        $options-arrow-height
       );
     }
 
@@ -56,20 +56,20 @@ $options-arrow-height: var(--rp-options-arrow-height, $options-arrow-size) !defa
       &:not(.openUpward) [data-bubble-arrow] {
         @include arrow(
           up,
-          $option-bg-color-highlighted !important,
+          $option-bg-color-highlighted,
           $options-border-color,
           $options-arrow-width,
-          $options-arrow-height,
+          $options-arrow-height
         );
       }
       &.openUpward [data-bubble-arrow] {
         height: inherit;
         @include arrow(
           down,
-          $option-bg-color-highlighted !important,
+          $option-bg-color-highlighted,
           $options-border-color,
           $options-arrow-width,
-          $options-arrow-height,
+          $options-arrow-height
         );
       }
     }

--- a/source/themes/simple/mixins/arrow.scss
+++ b/source/themes/simple/mixins/arrow.scss
@@ -10,7 +10,7 @@
   &:after {
     content: "";
     position: absolute;
-    @include arrow_internal($direction, $bg-color, calc(#{$width} - 1px), calc(#{$height} - 1px));
+    @include arrow_internal($direction, $bg-color, calc(#{$width} - 2px), calc(#{$height} - 2px));
   }
 }
 

--- a/stories/NumericInput.stories.js
+++ b/stories/NumericInput.stories.js
@@ -84,7 +84,15 @@ storiesOf('NumericInput', module)
       />
     ))
   )
-
+  .add('allowSigns = false',
+    withState({ value: null }, store => (
+      <NumericInput
+        value={store.state.value}
+        onChange={value => store.set({ value })}
+        allowSigns={false}
+      />
+    ))
+  )
   .add('onFocus / onBlur',
     withState({ value: null, focused: false, blurred: false }, store => (
       <NumericInput


### PR DESCRIPTION
This PR improves the handling of transient number inputs like:

Transformed state (the zero is added visually)
- `.` = `0.`

Parsed transient state (these are not shown but the output behaves like this)
- `.1` = `0.1`
- `1.` = `1`

This greatly improves UX while entering numbers in Daedalus (or other applications that would show errors like "this field is required" as soon as the number would be `null`)

This PR also fixes:

- Broken arrow color and borders
- Many small issues found and reported by QA

**Known and Acceptable Issues:**
If you enter a `,` in the fraction part of the number the caret will jump over one digit.

[QA Slack Channel](https://input-output-rnd.slack.com/archives/GGKFXSKC6/p1566222711246800)