### PR TITLE
Feature/ddw 1018 configurable numeric input formats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@ vNext
 ### Breaking Changes
 
 - `NumericInput` component was completely rewritten to be more flexible and straight forward.
-  [PR 114](https://github.com/input-output-hk/react-polymorph/pull/114)
+  [PR 114](https://github.com/input-output-hk/react-polymorph/pull/114) and allow configurable
+  number formats [PR 123](https://github.com/input-output-hk/react-polymorph/pull/123)
   
 - Adds a new prop `arrowRelativeToTip` to tooltips which allows to center the arrow relative to the size of the tooltip 
   and not the parent element. [PR 113](https://github.com/input-output-hk/react-polymorph/pull/113)

--- a/__tests__/NumericInput.behavior.test.js
+++ b/__tests__/NumericInput.behavior.test.js
@@ -16,22 +16,45 @@ describe('NumericInput onChange simulations', () => {
     };
   };
 
-  test('valid input triggers onChange listener', () => {
-    const { input, onChangeMock } = mountNumericInputWithProps();
-    input.simulate('change', { nativeEvent: { target: { value: '19.00' } } });
-    expect(onChangeMock.mock.calls[0][0]).toBe(19.00);
+  describe('onChange behavior', () => {
+    test('valid input triggers onChange listener', () => {
+      const { input, onChangeMock } = mountNumericInputWithProps();
+      input.simulate('change', { nativeEvent: { target: { value: '19.00' } } });
+      expect(onChangeMock.mock.calls[0][0]).toBe(19.00);
+    });
+    test('invalid input does not trigger onChange listener', () => {
+      const { input, onChangeMock } = mountNumericInputWithProps();
+      input.simulate('change', { nativeEvent: { target: { value: 'A.00' } } });
+      expect(onChangeMock.mock.calls.length).toBe(0);
+    });
   });
 
-  test('handles comma as group separator by default', () => {
-    const { input, onChangeMock } = mountNumericInputWithProps();
-    input.simulate('change', { nativeEvent: { target: { value: '9,999,999.00' } } });
-    expect(onChangeMock.mock.calls[0][0]).toBe(9999999.00);
-  });
-
-  test('invalid input does not trigger onChange listener', () => {
-    const { input, onChangeMock } = mountNumericInputWithProps();
-    input.simulate('change', { nativeEvent: { target: { value: 'A.00' } } });
-    expect(onChangeMock.mock.calls.length).toBe(0);
+  describe('configurable number formats', () => {
+    test('handles commas as thousand separators by default', () => {
+      const { input, onChangeMock } = mountNumericInputWithProps();
+      input.simulate('change', { nativeEvent: { target: { value: '9,999,999.00' } } });
+      expect(onChangeMock.mock.calls[0][0]).toBe(9999999.00);
+    });
+    test('can be configured to handle dots as thousand separators', () => {
+      const { input, onChangeMock } = mountNumericInputWithProps({
+        numberFormat: {
+          groupSeparators: '.',
+          fractionSeparator: ',',
+        }
+      });
+      input.simulate('change', { nativeEvent: { target: { value: '9.999.999,00' } } });
+      expect(onChangeMock.mock.calls[0][0]).toBe(9999999.00);
+    });
+    test('can be configured to handle spaces as thousand separators', () => {
+      const { input, onChangeMock } = mountNumericInputWithProps({
+        numberFormat: {
+          groupSeparators: ' ',
+          fractionSeparator: '.',
+        }
+      });
+      input.simulate('change', { nativeEvent: { target: { value: '9 999 999.00' } } });
+      expect(onChangeMock.mock.calls[0][0]).toBe(9999999.00);
+    });
   });
 
   test('enforces given minimumFractionDigits', () => {

--- a/__tests__/NumericInput.behavior.test.js
+++ b/__tests__/NumericInput.behavior.test.js
@@ -38,8 +38,8 @@ describe('NumericInput onChange simulations', () => {
     test('can be configured to handle dots as thousand separators', () => {
       const { input, onChangeMock } = mountNumericInputWithProps({
         numberFormat: {
-          groupSeparators: '.',
-          fractionSeparator: ',',
+          groupSeparator: '.',
+          decimalSeparator: ',',
         }
       });
       input.simulate('change', { nativeEvent: { target: { value: '9.999.999,00' } } });
@@ -48,8 +48,8 @@ describe('NumericInput onChange simulations', () => {
     test('can be configured to handle spaces as thousand separators', () => {
       const { input, onChangeMock } = mountNumericInputWithProps({
         numberFormat: {
-          groupSeparators: ' ',
-          fractionSeparator: '.',
+          groupSeparator: ' ',
+          decimalSeparator: '.',
         }
       });
       input.simulate('change', { nativeEvent: { target: { value: '9 999 999.00' } } });

--- a/__tests__/NumericInput.behavior.test.js
+++ b/__tests__/NumericInput.behavior.test.js
@@ -5,45 +5,48 @@ import { mountInSimpleTheme } from './helpers/theming';
 
 describe('NumericInput onChange simulations', () => {
 
-  test('valid input triggers onChange listener', () => {
+  const mountNumericInputWithProps = (props) => {
     const onChangeMock = jest.fn();
-    const wrapper = mountInSimpleTheme(<NumericInput onChange={onChangeMock} />);
+    const wrapper = mountInSimpleTheme(<NumericInput {...props} onChange={onChangeMock} />);
     const input = wrapper.find('input');
+    return {
+      input,
+      onChangeMock,
+      wrapper,
+    };
+  };
+
+  test('valid input triggers onChange listener', () => {
+    const { input, onChangeMock } = mountNumericInputWithProps();
     input.simulate('change', { nativeEvent: { target: { value: '19.00' } } });
     expect(onChangeMock.mock.calls[0][0]).toBe(19.00);
   });
 
-  test('handles en-US localized input values', () => {
-    const onChangeMock = jest.fn();
-    const wrapper = mountInSimpleTheme(<NumericInput onChange={onChangeMock} />);
-    const input = wrapper.find('input');
+  test('handles comma as group separator by default', () => {
+    const { input, onChangeMock } = mountNumericInputWithProps();
     input.simulate('change', { nativeEvent: { target: { value: '9,999,999.00' } } });
     expect(onChangeMock.mock.calls[0][0]).toBe(9999999.00);
   });
 
   test('invalid input does not trigger onChange listener', () => {
-    const onChangeMock = jest.fn();
-    const wrapper = mountInSimpleTheme(
-      <NumericInput onChange={onChangeMock} />
-    );
-    const input = wrapper.find('input');
+    const { input, onChangeMock } = mountNumericInputWithProps();
     input.simulate('change', { nativeEvent: { target: { value: 'A.00' } } });
     expect(onChangeMock.mock.calls.length).toBe(0);
   });
 
   test('enforces given minimumFractionDigits', () => {
-    const wrapper = mountInSimpleTheme(
-      <NumericInput numberLocaleOptions={{ minimumFractionDigits: 6 }} value={0} />
-    );
-    const input = wrapper.find('input');
+    const { input } = mountNumericInputWithProps({
+      numberLocaleOptions: { minimumFractionDigits: 6 },
+      value: 0,
+    });
     expect(input.getDOMNode().value).toBe('0.000000');
   });
 
   test('enforces given maximumFractionDigits', () => {
-    const wrapper = mountInSimpleTheme(
-      <NumericInput numberLocaleOptions={{ maximumFractionDigits: 2 }} value={0.123} />
-    );
-    const input = wrapper.find('input');
+    const { input } = mountNumericInputWithProps({
+      numberLocaleOptions: { maximumFractionDigits: 2 },
+      value: 0.123,
+    });
     expect(input.getDOMNode().value).toBe('0.12');
   });
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-polymorph",
   "description": "React components with highly customizable logic, markup and styles.",
-  "version": "0.9.0-rc.22",
+  "version": "0.9.0-rc.23",
   "scripts": {
     "build": "cross-env yarn clean && yarn sass && yarn js",
     "build:watch": "concurrently 'yarn js:watch' 'yarn sass:watch'",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-polymorph",
   "description": "React components with highly customizable logic, markup and styles.",
-  "version": "0.9.0-rc.21",
+  "version": "0.9.0-rc.22",
   "scripts": {
     "build": "cross-env yarn clean && yarn sass && yarn js",
     "build:watch": "concurrently 'yarn js:watch' 'yarn sass:watch'",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-polymorph",
   "description": "React components with highly customizable logic, markup and styles.",
-  "version": "0.9.0-rc.23",
+  "version": "0.9.0-rc.24",
   "scripts": {
     "build": "cross-env yarn clean && yarn sass && yarn js",
     "build:watch": "concurrently 'yarn js:watch' 'yarn sass:watch'",

--- a/source/components/NumericInput.js
+++ b/source/components/NumericInput.js
@@ -17,13 +17,13 @@ import { removeCharAtPosition } from '../utils/strings';
 import type { InputEvent } from '../utils/types';
 
 type NumberFormatOptions = {
-  groupSeparators: string,
-  fractionSeparator: string,
+  groupSeparator: string,
+  decimalSeparator: string,
 };
 
 const DEFAULT_NUMBER_FORMAT = {
-  groupSeparators: ',',
-  fractionSeparator: '.',
+  groupSeparator: ',',
+  decimalSeparator: '.',
 };
 
 export type NumericInputProps = {
@@ -466,14 +466,14 @@ function getNumberOfDots(value: string): number {
   return (value.match(/\./g) || []).length;
 }
 
-function getIntegerDigits(value: string, fractionSeparator: string = '.'): string {
-  const fractionSeparatorIndex = value.indexOf(fractionSeparator);
+function getIntegerDigits(value: string, decimalSeparator: string = '.'): string {
+  const fractionSeparatorIndex = value.indexOf(decimalSeparator);
   if (fractionSeparatorIndex === -1) return value;
   return value.substring(0, fractionSeparatorIndex);
 }
 
-function getFractionDigits(value: string, fractionSeparator: string = '.'): string {
-  const fractionSeparatorIndex = value.indexOf(fractionSeparator);
+function getFractionDigits(value: string, decimalSeparator: string = '.'): string {
+  const fractionSeparatorIndex = value.indexOf(decimalSeparator);
   if (fractionSeparatorIndex === -1) return '';
   return value.substring(fractionSeparatorIndex + 1);
 }
@@ -490,9 +490,9 @@ function transformNumberFormat(
 ) {
   return (
     value
-      .replace(new RegExp('\\' + inputFormat.groupSeparators, 'g'), '#')
-      .replace(new RegExp('\\' + inputFormat.fractionSeparator, 'g'), '@')
-      .replace(new RegExp('#', 'g'), outputFormat.groupSeparators)
-      .replace(new RegExp('@', 'g'), outputFormat.fractionSeparator)
+      .replace(new RegExp('\\' + inputFormat.groupSeparator, 'g'), '#')
+      .replace(new RegExp('\\' + inputFormat.decimalSeparator, 'g'), '@')
+      .replace(new RegExp('#', 'g'), outputFormat.groupSeparator)
+      .replace(new RegExp('@', 'g'), outputFormat.decimalSeparator)
   );
 }

--- a/source/components/NumericInput.js
+++ b/source/components/NumericInput.js
@@ -16,7 +16,7 @@ import type { ThemeContextProp } from './HOC/withTheme';
 import { removeCharAtPosition } from '../utils/strings';
 import type { InputEvent } from '../utils/types';
 
-type Props = {
+export type NumericInputProps = {
   allowSigns?: boolean,
   autoFocus?: boolean,
   className?: string,
@@ -47,7 +47,7 @@ type State = {
 // TODO: make this configurable (generalize handling commas and dots in other languages!)
 const LOCALE = 'en-US';
 
-class NumericInputBase extends Component<Props, State> {
+class NumericInputBase extends Component<NumericInputProps, State> {
 
   inputElement: { current: null | ElementRef<'input'> };
   _hasInputBeenChanged: boolean = false;
@@ -64,7 +64,7 @@ class NumericInputBase extends Component<Props, State> {
     value: null,
   };
 
-  constructor(props: Props) {
+  constructor(props: NumericInputProps) {
     super(props);
     const { context, numberLocaleOptions, themeId, theme, themeOverrides } = props;
     this.inputElement = createRef();
@@ -96,11 +96,11 @@ class NumericInputBase extends Component<Props, State> {
     }
   }
 
-  componentWillReceiveProps(nextProps: Props) {
+  componentWillReceiveProps(nextProps: NumericInputProps) {
     didThemePropsChange(this.props, nextProps, this.setState.bind(this));
   }
 
-  componentDidUpdate(prevProps: Props, prevState: State) {
+  componentDidUpdate(prevProps: NumericInputProps, prevState: State) {
     const { value } = this.props;
     const { inputCaretPosition } = this.state;
     const hasValueBeenChanged = value !== prevProps.value;

--- a/source/skins/simple/DropdownSkin.js
+++ b/source/skins/simple/DropdownSkin.js
@@ -55,6 +55,7 @@ export const DropdownSkin = (props: Props) => {
         isOpen={props.isOpen}
         isOpeningUpward={props.isOpeningUpward}
         noOptionsArrow={props.noArrow}
+        noSelectedOptionCheckmark
         onChange={props.onItemSelected}
         options={props.items}
         optionsMaxHeight={props.optionsMaxHeight}

--- a/source/skins/simple/OptionsSkin.js
+++ b/source/skins/simple/OptionsSkin.js
@@ -23,6 +23,7 @@ type Props = {
   noOptionsArrow?: boolean,
   noResults: boolean,
   noResultsMessage: string | Element<any>,
+  noSelectedOptionCheckmark?: boolean,
   optionRenderer: Function,
   options: Array<any>,
   optionsRef: ElementRef<*>,
@@ -48,6 +49,7 @@ export const OptionsSkin = (props: Props) => {
     noOptionsArrow,
     noResults,
     noResultsMessage,
+    noSelectedOptionCheckmark,
     optionsMaxHeight,
     optionRenderer,
     options,
@@ -88,7 +90,8 @@ export const OptionsSkin = (props: Props) => {
               theme[themeId].option,
               isHighlightedOption(index) ? theme[themeId].highlightedOption : null,
               isSelectedOption(index) ? theme[themeId].selectedOption : null,
-              option.isDisabled ? theme[themeId].disabledOption : null
+              option.isDisabled ? theme[themeId].disabledOption : null,
+              noSelectedOptionCheckmark ? theme[themeId].hasNoSelectedOptionCheckmark : null,
             ])}
             onClick={boundHandleClickOnOption}
             onMouseEnter={boundSetHighlightedOptionIndex}

--- a/source/themes/API/options.js
+++ b/source/themes/API/options.js
@@ -2,6 +2,7 @@
 export const OPTIONS_THEME_API = {
   disabledOption: '',
   firstOptionHighlighted: '',
+  hasNoSelectedOptionCheckmark: '',
   highlightedOption: '',
   isOpen: '',
   openUpward: '',

--- a/source/themes/simple/SimpleOptions.scss
+++ b/source/themes/simple/SimpleOptions.scss
@@ -97,7 +97,7 @@ $options-arrow-height: var(--rp-options-arrow-height, $options-arrow-size) !defa
   line-height: $option-line-height;
   padding: $option-padding;
 
-  &.selectedOption {
+  &.selectedOption:not(.hasNoSelectedOptionCheckmark) {
     display: flex;
     .label {
       flex-grow: 1;

--- a/stories/NumericInput.stories.js
+++ b/stories/NumericInput.stories.js
@@ -62,8 +62,8 @@ storiesOf('NumericInput', module)
       <NumericInput
         onChange={value => store.set({ value })}
         numberFormat={{
-          fractionSeparator: ',',
-          groupSeparators: '.',
+          decimalSeparator: ',',
+          groupSeparator: '.',
         }}
         value={store.state.value}
       />
@@ -74,8 +74,8 @@ storiesOf('NumericInput', module)
       <NumericInput
         onChange={value => store.set({ value })}
         numberFormat={{
-          fractionSeparator: '.',
-          groupSeparators: ' ',
+          decimalSeparator: '.',
+          groupSeparator: ' ',
         }}
         value={store.state.value}
       />

--- a/stories/NumericInput.stories.js
+++ b/stories/NumericInput.stories.js
@@ -57,6 +57,30 @@ storiesOf('NumericInput', module)
       />
     ))
   )
+  .add('format: group (dot) fraction (comma)',
+    withState({ value: 0 }, store => (
+      <NumericInput
+        onChange={value => store.set({ value })}
+        numberFormat={{
+          fractionSeparator: ',',
+          groupSeparators: '.',
+        }}
+        value={store.state.value}
+      />
+    ))
+  )
+  .add('format: group (space) fraction (dot)',
+    withState({ value: 0 }, store => (
+      <NumericInput
+        onChange={value => store.set({ value })}
+        numberFormat={{
+          fractionSeparator: '.',
+          groupSeparators: ' ',
+        }}
+        value={store.state.value}
+      />
+    ))
+  )
   .add('autoFocus',
     withState({ value: null }, store => (
       <NumericInput


### PR DESCRIPTION
This PR makes the numeric input number format (optionally) configurable with the following props:
```js
 numberFormat={{
   fractionSeparator: '.',
   groupSeparators: ' ',
 }}
```

## How to test:
Two new stories for `NumericInput` have been added to show case scenarios with customized number formats.