### PR TITLE
Release/0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,16 @@ The history of all changes to react-polymorph.
 vNext
 =====
 
+0.9.1
+=====
+
 ### Features
 
 - New `Link` component [PR 126](https://github.com/input-output-hk/react-polymorph/pull/126)
+
+### Fixes
+
+- Fixes error in `GlobalListeners` and `Dropdown` when Daedalus window is resized [PR 125](https://github.com/input-output-hk/react-polymorph/pull/125)
 
 0.9.0
 =====

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-polymorph",
   "description": "React components with highly customizable logic, markup and styles.",
-  "version": "0.9.0-rc.26",
+  "version": "0.9.0",
   "scripts": {
     "build": "cross-env yarn clean && yarn sass && yarn js",
     "build:watch": "concurrently 'yarn js:watch' 'yarn sass:watch'",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-polymorph",
   "description": "React components with highly customizable logic, markup and styles.",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "scripts": {
     "build": "cross-env yarn clean && yarn sass && yarn js",
     "build:watch": "concurrently 'yarn js:watch' 'yarn sass:watch'",


### PR DESCRIPTION
This release includes the new `Link` component and fixes error in `GlobalListeners` and `Dropdown` when Daedalus window is resized.