### PR TITLE
[DDW-733] Implement password input component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The history of all changes to react-polymorph.
 vNext
 =====
 
+### Features
+
+- Adds new `PasswordInput` component [PR 134](https://github.com/input-output-hk/react-polymorph/pull/134)
+
 0.9.2
 =====
 

--- a/__tests__/Tooltip.test.js
+++ b/__tests__/Tooltip.test.js
@@ -1,0 +1,131 @@
+import React from 'react';
+
+import { renderInSimpleTheme } from './helpers/theming';
+import { Tooltip } from '../source/components/Tooltip';
+import styles from '../stories/Tooltip.stories.scss';
+
+test('tooltip plain', () => {
+  expect(renderInSimpleTheme(
+    <Tooltip
+      isVisible
+      tip="plain tooltip, nothing special about me">
+      hover over me
+    </Tooltip>
+  )).toMatchSnapshot();
+});
+
+test('tooltip with html', () => {
+  expect(renderInSimpleTheme(
+    <Tooltip
+      isVisible
+      tip={
+        <div>
+          I can use <span className={styles.htmlTip}>HTML</span>
+        </div>
+      }>
+      hover over me
+    </Tooltip>
+  )).toMatchSnapshot();
+});
+
+test('tooltip isAligningRight', () => {
+  expect(renderInSimpleTheme(
+    <Tooltip isAligningRight tip="I am aligning right">
+      hover over me
+    </Tooltip>
+  )).toMatchSnapshot();
+});
+
+test('tooltip isBounded', () => {
+  expect(renderInSimpleTheme(
+    <Tooltip
+      isBounded
+      tip="Help, I am stuck in this small box"
+    >
+      hover over me
+    </Tooltip>
+  )).toMatchSnapshot();
+});
+
+test('tooltip with custom class', () => {
+  expect(renderInSimpleTheme(
+    <Tooltip
+      className={styles.customTooltip}
+      tip="How did I get all the way over here?"
+    >
+      hover over me
+    </Tooltip>
+  )).toMatchSnapshot();
+});
+
+test('tooltip isOpeningUpward={false}', () => {
+  expect(renderInSimpleTheme(
+    <Tooltip
+      isOpeningUpward={false}
+      tip="I come from a land down under"
+    >
+      hover over me
+    </Tooltip>
+  )).toMatchSnapshot();
+});
+
+test('tooltip arrowRelativeToTip', () => {
+  expect(renderInSimpleTheme(
+    <Tooltip
+      arrowRelativeToTip
+      tip="small tip"
+    >
+      {'this is a really long string for demonstration purposes'}
+    </Tooltip>
+  )).toMatchSnapshot();
+});
+
+test('tooltip arrowRelativeToTip (below)', () => {
+  expect(renderInSimpleTheme(
+    <Tooltip
+      arrowRelativeToTip
+      isOpeningUpward={false}
+      tip="small tip from below"
+    >
+      {'this is a really long string for demonstration purposes'}
+    </Tooltip>
+  )).toMatchSnapshot();
+});
+
+test('tooltip isCentered', () => {
+  expect(renderInSimpleTheme(
+    <Tooltip
+      arrowRelativeToTip
+      isCentered
+      tip="centered above"
+    >
+      {'this is a really long string for demonstration purposes'}
+    </Tooltip>
+  )).toMatchSnapshot();
+});
+
+test('tooltip isCentered (below)', () => {
+  expect(renderInSimpleTheme(
+    <Tooltip
+      arrowRelativeToTip
+      isCentered
+      isOpeningUpward={false}
+      tip="centered below"
+    >
+      {'this is a really long string for demonstration purposes'}
+    </Tooltip>
+  )).toMatchSnapshot();
+});
+
+test('tooltip isCentered (below)', () => {
+  expect(renderInSimpleTheme(
+    <Tooltip
+      arrowRelativeToTip
+      isCentered
+      isOpeningUpward={false}
+      tip="centered below"
+    >
+      {'this is a really long string for demonstration purposes'}
+    </Tooltip>
+  )).toMatchSnapshot();
+});

--- a/__tests__/__snapshots__/Tooltip.test.js.snap
+++ b/__tests__/__snapshots__/Tooltip.test.js.snap
@@ -1,0 +1,250 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`tooltip arrowRelativeToTip (below) 1`] = `
+<span
+  class="root"
+>
+  <div
+    class="bubble alignLeft nowrap root transparent"
+  >
+    <div
+      class="bubble hasAutoWidth"
+      data-bubble-container="true"
+    >
+      small tip from below
+      <span
+        class="arrow"
+        data-bubble-arrow="true"
+      />
+    </div>
+  </div>
+  this is a really long string for demonstration purposes
+</span>
+`;
+
+exports[`tooltip arrowRelativeToTip 1`] = `
+<span
+  class="root"
+>
+  <div
+    class="bubble alignLeft nowrap root openUpward transparent"
+  >
+    <div
+      class="bubble hasAutoWidth"
+      data-bubble-container="true"
+    >
+      small tip
+      <span
+        class="arrow"
+        data-bubble-arrow="true"
+      />
+    </div>
+  </div>
+  this is a really long string for demonstration purposes
+</span>
+`;
+
+exports[`tooltip isAligningRight 1`] = `
+<span
+  class="root"
+>
+  <div
+    class="bubble alignRight nowrap root openUpward transparent"
+  >
+    <div
+      class="bubble"
+      data-bubble-container="true"
+    >
+      I am aligning right
+    </div>
+    <span
+      class="arrow"
+      data-bubble-arrow="true"
+    />
+  </div>
+  hover over me
+</span>
+`;
+
+exports[`tooltip isBounded 1`] = `
+<span
+  class="root"
+>
+  <div
+    class="bubble alignLeft root openUpward transparent"
+  >
+    <div
+      class="bubble"
+      data-bubble-container="true"
+    >
+      Help, I am stuck in this small box
+    </div>
+    <span
+      class="arrow"
+      data-bubble-arrow="true"
+    />
+  </div>
+  hover over me
+</span>
+`;
+
+exports[`tooltip isCentered (below) 1`] = `
+<span
+  class="root isCentered"
+>
+  <div
+    class="bubble alignLeft nowrap root isCentered transparent"
+  >
+    <div
+      class="bubble hasAutoWidth"
+      data-bubble-container="true"
+    >
+      centered below
+      <span
+        class="arrow"
+        data-bubble-arrow="true"
+      />
+    </div>
+  </div>
+  this is a really long string for demonstration purposes
+</span>
+`;
+
+exports[`tooltip isCentered (below) 2`] = `
+<span
+  class="root isCentered"
+>
+  <div
+    class="bubble alignLeft nowrap root isCentered transparent"
+  >
+    <div
+      class="bubble hasAutoWidth"
+      data-bubble-container="true"
+    >
+      centered below
+      <span
+        class="arrow"
+        data-bubble-arrow="true"
+      />
+    </div>
+  </div>
+  this is a really long string for demonstration purposes
+</span>
+`;
+
+exports[`tooltip isCentered 1`] = `
+<span
+  class="root isCentered"
+>
+  <div
+    class="bubble alignLeft nowrap root openUpward isCentered transparent"
+  >
+    <div
+      class="bubble hasAutoWidth"
+      data-bubble-container="true"
+    >
+      centered above
+      <span
+        class="arrow"
+        data-bubble-arrow="true"
+      />
+    </div>
+  </div>
+  this is a really long string for demonstration purposes
+</span>
+`;
+
+exports[`tooltip isOpeningUpward={false} 1`] = `
+<span
+  class="root"
+>
+  <div
+    class="bubble alignLeft nowrap root transparent"
+  >
+    <div
+      class="bubble"
+      data-bubble-container="true"
+    >
+      I come from a land down under
+    </div>
+    <span
+      class="arrow"
+      data-bubble-arrow="true"
+    />
+  </div>
+  hover over me
+</span>
+`;
+
+exports[`tooltip plain 1`] = `
+<span
+  class="root isVisible"
+>
+  <div
+    class="bubble alignLeft nowrap root openUpward transparent"
+  >
+    <div
+      class="bubble"
+      data-bubble-container="true"
+    >
+      plain tooltip, nothing special about me
+    </div>
+    <span
+      class="arrow"
+      data-bubble-arrow="true"
+    />
+  </div>
+  hover over me
+</span>
+`;
+
+exports[`tooltip with custom class 1`] = `
+<span
+  class="customTooltip root"
+>
+  <div
+    class="bubble alignLeft nowrap root openUpward transparent"
+  >
+    <div
+      class="bubble"
+      data-bubble-container="true"
+    >
+      How did I get all the way over here?
+    </div>
+    <span
+      class="arrow"
+      data-bubble-arrow="true"
+    />
+  </div>
+  hover over me
+</span>
+`;
+
+exports[`tooltip with html 1`] = `
+<span
+  class="root isVisible"
+>
+  <div
+    class="bubble alignLeft nowrap root openUpward transparent"
+  >
+    <div
+      class="bubble"
+      data-bubble-container="true"
+    >
+      <div>
+        I can use 
+        <span
+          class="htmlTip"
+        >
+          HTML
+        </span>
+      </div>
+    </div>
+    <span
+      class="arrow"
+      data-bubble-arrow="true"
+    />
+  </div>
+  hover over me
+</span>
+`;

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
     "storybook": "start-storybook -p 6543 -c storybook --ci",
     "storybook:build": "build-storybook -c storybook -o dist/storybook",
     "test": "cross-env NODE_ENV=test jest",
-    "test:clean": "cross-env NODE_ENV=test jest -u",
-    "test:watch": "cross-env NODE_ENV=test jest --watchAll"
+    "test:update": "yarn test -u",
+    "test:watch": "yarn test --watchAll"
   },
   "dependencies": {
     "create-react-context": "0.2.2",

--- a/source/components/Bubble.js
+++ b/source/components/Bubble.js
@@ -12,9 +12,16 @@ import { addDocumentListeners, removeDocumentListeners } from '../utils/events';
 import { IDENTIFIERS } from '.';
 import type { ThemeContextProp } from './HOC/withTheme';
 
-type Props = {
+export type BubblePosition = {
+  width: number,
+  positionX: number,
+  positionY: number,
+};
+
+export type BubbleProps = {
   className?: string,
   context: ThemeContextProp,
+  isCentered: boolean,
   isHidden: boolean,
   isFloating: boolean,
   isOpeningUpward: boolean,
@@ -30,7 +37,7 @@ type Props = {
 
 type State = {
   composedTheme: Object,
-  position: ?Object
+  position: ?BubblePosition
 };
 
 class BubbleBase extends Component<Props, State> {
@@ -41,6 +48,7 @@ class BubbleBase extends Component<Props, State> {
   static displayName = 'Bubble';
   static defaultProps = {
     context: createEmptyContext(),
+    isCentered: false,
     isHidden: false,
     isFloating: false,
     isOpeningUpward: false,

--- a/source/components/Bubble.js
+++ b/source/components/Bubble.js
@@ -40,7 +40,7 @@ type State = {
   position: ?BubblePosition
 };
 
-class BubbleBase extends Component<Props, State> {
+class BubbleBase extends Component<BubbleProps, State> {
   // declare ref types
   rootElement: ?Element<any>;
 
@@ -60,7 +60,7 @@ class BubbleBase extends Component<Props, State> {
     themeOverrides: {}
   };
 
-  constructor(props: Props) {
+  constructor(props: BubbleProps) {
     super(props);
 
     // define ref
@@ -86,7 +86,7 @@ class BubbleBase extends Component<Props, State> {
     }, 0);
   }
 
-  componentWillReceiveProps(nextProps: Props) {
+  componentWillReceiveProps(nextProps: BubbleProps) {
     didThemePropsChange(this.props, nextProps, this.setState.bind(this));
   }
 

--- a/source/components/PasswordInput.js
+++ b/source/components/PasswordInput.js
@@ -1,0 +1,98 @@
+// @flow
+import React, { Component } from 'react';
+// $FlowFixMe
+import type { ComponentType, SyntheticInputEvent, Element } from 'react';
+
+// internal utility functions
+import { createEmptyContext, withTheme } from './HOC/withTheme';
+import { composeTheme, addThemeId } from '../utils/themes';
+
+// import constants
+import { IDENTIFIERS } from '.';
+import type { ThemeContextProp } from './HOC/withTheme';
+
+export type PasswordInputProps = {
+  autoFocus?: boolean,
+  className?: string,
+  context: ThemeContextProp,
+  disabled?: boolean,
+  error?: string,
+  label?: string | Element<any>,
+  isTooltipOpen: boolean,
+  onBlur?: Function,
+  onChange?: Function,
+  onFocus?: Function,
+  placeholder?: string,
+  readOnly?: boolean,
+  skin?: ComponentType<any>,
+  theme: ?Object,
+  themeId: string,
+  themeOverrides: Object,
+  value: ?string,
+  tooltip?: string,
+  score?: number,
+  state?: $Values<typeof PasswordInputBase.STATE>,
+};
+
+type State = {
+  composedTheme: Object,
+};
+
+class PasswordInputBase extends Component<PasswordInputProps, State> {
+
+  static displayName = 'PasswordInput';
+  static STATE = {
+    DEFAULT: 'default',
+    ERROR: 'error',
+    WARNING: 'warning',
+    SUCCESS: 'success',
+  };
+
+  static defaultProps = {
+    context: createEmptyContext(),
+    isTooltipOpen: false,
+    readOnly: false,
+    theme: null,
+    themeId: IDENTIFIERS.PASSWORD_INPUT,
+    themeOverrides: {},
+    value: null,
+    score: 0,
+    state: PasswordInputBase.STATE.DEFAULT,
+  };
+
+  constructor(props: PasswordInputProps) {
+    super(props);
+    const { context, themeId, theme, themeOverrides } = props;
+    this.state = {
+      composedTheme: composeTheme(
+        addThemeId(theme || context.theme, themeId),
+        addThemeId(themeOverrides, themeId),
+        context.ROOT_THEME_API
+      ),
+    };
+  }
+
+  render() {
+    // destructuring props ensures only the "...rest" get passed down
+    const {
+      context,
+      skin,
+      theme,
+      themeOverrides,
+      ...rest
+    } = this.props;
+
+    const PasswordInputSkin = skin || context.skins[IDENTIFIERS.PASSWORD_INPUT];
+
+    return (
+      <PasswordInputSkin
+        theme={this.state.composedTheme}
+        {...rest}
+      />
+    );
+  }
+}
+
+export const PasswordInput = withTheme(PasswordInputBase);
+
+PasswordInput.STATE = PasswordInputBase.STATE;

--- a/source/components/PasswordInput.js
+++ b/source/components/PasswordInput.js
@@ -1,7 +1,7 @@
 // @flow
 import React, { Component } from 'react';
 // $FlowFixMe
-import type { ComponentType, SyntheticInputEvent, Element } from 'react';
+import type { ComponentType, Element } from 'react';
 
 // internal utility functions
 import { createEmptyContext, withTheme } from './HOC/withTheme';

--- a/source/components/Tooltip.js
+++ b/source/components/Tooltip.js
@@ -1,6 +1,6 @@
 // @flow
 import React, { Component } from 'react';
-import type { ComponentType, Element } from 'react';
+import type { ComponentType, Element, Node } from 'react';
 
 // internal utility functions
 import { createEmptyContext, withTheme } from './HOC/withTheme';
@@ -10,13 +10,16 @@ import { composeTheme, addThemeId, didThemePropsChange } from '../utils/themes';
 import { IDENTIFIERS } from '.';
 import type { ThemeContextProp } from './HOC/withTheme';
 
-type Props = {
+export type TooltipProps = {
+  children: ?Node,
   className?: string,
   context: ThemeContextProp,
   isAligningRight?: boolean,
-  isBounded?: boolean,
+  isBounded: boolean,
+  isCentered: boolean,
   isOpeningUpward: boolean,
   isTransparent: boolean,
+  isVisible: boolean,
   arrowRelativeToTip: boolean,
   skin?: ComponentType<any>,
   theme: ?Object, // will take precedence over theme in context if passed
@@ -29,11 +32,14 @@ type State = {
   composedTheme: Object
 };
 
-class TooltipBase extends Component<Props, State> {
+class TooltipBase extends Component<TooltipProps, State> {
   // define static properties
   static displayName = 'Tooltip';
   static defaultProps = {
     context: createEmptyContext(),
+    isBounded: false,
+    isCentered: false,
+    isVisible: false,
     isOpeningUpward: true,
     isTransparent: true,
     arrowRelativeToTip: false,
@@ -42,7 +48,7 @@ class TooltipBase extends Component<Props, State> {
     themeOverrides: {}
   };
 
-  constructor(props: Props) {
+  constructor(props: TooltipProps) {
     super(props);
 
     const { context, themeId, theme, themeOverrides } = props;
@@ -56,7 +62,7 @@ class TooltipBase extends Component<Props, State> {
     };
   }
 
-  componentWillReceiveProps(nextProps: Props) {
+  componentWillReceiveProps(nextProps: TooltipProps) {
     didThemePropsChange(this.props, nextProps, this.setState.bind(this));
   }
 

--- a/source/components/index.js
+++ b/source/components/index.js
@@ -16,6 +16,7 @@ export const IDENTIFIERS = {
   LOADING_SPINNER: 'loadingspinner',
   MODAL: 'modal',
   OPTIONS: 'options',
+  PASSWORD_INPUT: 'passwordInput',
   PROGRESS_BAR: 'progressbar',
   RADIO: 'radio',
   SCROLLBAR: 'scrollbar',

--- a/source/skins/simple/BubbleSkin.js
+++ b/source/skins/simple/BubbleSkin.js
@@ -7,17 +7,11 @@ import classnames from 'classnames';
 
 // internal utility functions
 import { pickDOMProps } from '../../utils/props';
+import type { BubblePosition, BubbleProps } from '../../components/Bubble';
 
-type Props = {
+type Props = BubbleProps & {
   children?: ?Node,
-  className: string,
-  isFloating: boolean,
-  isHidden: boolean,
-  isOpeningUpward: boolean,
-  isTransparent: boolean,
-  arrowRelativeToTip: boolean,
-  noArrow: boolean,
-  position: Object,
+  position: BubblePosition,
   rootRef: ElementRef<*>,
   theme: Object,
   themeId: string
@@ -25,7 +19,7 @@ type Props = {
 
 export const BubbleSkin = (props: Props) => {
   const { arrowRelativeToTip, noArrow, theme, themeId } = props;
-
+  const autoWidthClass = arrowRelativeToTip ? theme[themeId].hasAutoWidth : null;
   return (
     <div
       ref={props.rootRef}
@@ -34,6 +28,7 @@ export const BubbleSkin = (props: Props) => {
         props.className,
         theme[themeId].root,
         props.isOpeningUpward ? theme[themeId].openUpward : null,
+        props.isCentered ? theme[themeId].isCentered : null,
         props.isTransparent ? theme[themeId].transparent : null,
         props.isFloating ? theme[themeId].isFloating : null,
         props.isHidden ? theme[themeId].isHidden : null,
@@ -47,14 +42,23 @@ export const BubbleSkin = (props: Props) => {
         }
       }
     >
-      <div className={theme[themeId].bubble} data-bubble-container>
+      <div
+        className={classnames([theme[themeId].bubble, autoWidthClass])}
+        data-bubble-container="true"
+      >
         {props.children}
         {arrowRelativeToTip && (
-          <span className={theme[themeId].arrow} data-bubble-arrow={noArrow ? undefined : true} />
+          <span
+            className={theme[themeId].arrow}
+            data-bubble-arrow={noArrow ? undefined : true}
+          />
         )}
       </div>
       {!arrowRelativeToTip && (
-        <span className={theme[themeId].arrow} data-bubble-arrow={noArrow ? undefined : true} />
+        <span
+          className={theme[themeId].arrow}
+          data-bubble-arrow={noArrow ? undefined : true}
+        />
       )}
     </div>
   );

--- a/source/skins/simple/PasswordInputSkin.js
+++ b/source/skins/simple/PasswordInputSkin.js
@@ -1,0 +1,44 @@
+// @flow
+import classnames from 'classnames';
+import React from 'react';
+import type { ElementRef } from 'react';
+
+import { Input } from '../../components/Input';
+import { Tooltip } from '../../components/Tooltip';
+import type { PasswordInputProps } from '../../components/PasswordInput';
+import { PasswordInput } from '../../components/PasswordInput';
+
+type Props = PasswordInputProps & {
+  inputRef: ElementRef<'input'>,
+  theme: Object,
+};
+
+export const PasswordInputSkin = (props: Props) => {
+  const { isTooltipOpen, theme, themeId, tooltip, score, state, ...inputProps } = props;
+  const input = (
+    <Input
+      {...inputProps}
+      type="password"
+    />
+  );
+  const stateClass = state ? theme[themeId][state] : theme[themeId][PasswordInput.STATE.DEFAULT];
+  return (
+    <div className={classnames([theme[themeId].root, stateClass])}>
+      {tooltip ? (
+        <Tooltip
+          arrowRelativeToTip
+          isCentered
+          isOpeningUpward={false}
+          isVisible={isTooltipOpen}
+          tip={tooltip}
+          theme={props.theme}
+        >
+          {input}
+        </Tooltip>
+      ) : input}
+      <div className={theme[themeId].indicator}>
+        <div className={theme[themeId].score} style={{ width: `${(score || 0) * 100}%` }} />
+      </div>
+    </div>
+  );
+};

--- a/source/skins/simple/TooltipSkin.js
+++ b/source/skins/simple/TooltipSkin.js
@@ -1,12 +1,12 @@
 // @flow
 import React from 'react';
-import type { Node, Element } from 'react';
 
 // external libraries
 import classnames from 'classnames';
 
 // components
 import { Bubble } from '../../components/Bubble';
+import type { TooltipProps } from '../../components/Tooltip';
 
 // skins
 import { BubbleSkin } from './BubbleSkin';
@@ -14,17 +14,9 @@ import { BubbleSkin } from './BubbleSkin';
 // internal utility functions
 import { pickDOMProps } from '../../utils/props';
 
-type Props = {
-  children?: ?Node,
-  className?: string,
-  isAligningRight?: boolean,
-  isBounded?: boolean,
-  isOpeningUpward: boolean,
-  isTransparent: boolean,
-  arrowRelativeToTip: boolean,
+type Props = TooltipProps & {
   theme: Object,
   themeId: string,
-  tip: string | Element<any>
 };
 
 export const TooltipSkin = (props: Props) => {
@@ -32,7 +24,12 @@ export const TooltipSkin = (props: Props) => {
   return (
     <span
       {...pickDOMProps(props)}
-      className={classnames([props.className, theme[themeId].root])}
+      className={classnames([
+        props.className,
+        theme[themeId].root,
+        props.isVisible ? theme[themeId].isVisible : null,
+        props.isCentered ? theme[themeId].isCentered : null,
+      ])}
     >
       <Bubble
         className={classnames([
@@ -43,6 +40,7 @@ export const TooltipSkin = (props: Props) => {
           props.isBounded ? null : theme[themeId].nowrap
         ])}
         theme={theme}
+        isCentered={props.isCentered}
         isOpeningUpward={props.isOpeningUpward}
         skin={BubbleSkin}
         isTransparent={props.isTransparent}

--- a/source/skins/simple/index.js
+++ b/source/skins/simple/index.js
@@ -13,6 +13,7 @@ import { LinkSkin } from './LinkSkin';
 import { LoadingSpinnerSkin } from './LoadingSpinnerSkin';
 import { ModalSkin } from './ModalSkin';
 import { OptionsSkin } from './OptionsSkin';
+import { PasswordInputSkin } from './PasswordInputSkin';
 import { ProgressBarSkin } from './ProgressBarSkin';
 import { RadioSkin } from './RadioSkin';
 import { ScrollBarSkin } from './ScrollBarSkin';
@@ -37,6 +38,7 @@ export const SimpleSkins = {
   [IDENTIFIERS.LOADING_SPINNER]: LoadingSpinnerSkin,
   [IDENTIFIERS.MODAL]: ModalSkin,
   [IDENTIFIERS.OPTIONS]: OptionsSkin,
+  [IDENTIFIERS.PASSWORD_INPUT]: PasswordInputSkin,
   [IDENTIFIERS.PROGRESS_BAR]: ProgressBarSkin,
   [IDENTIFIERS.RADIO]: RadioSkin,
   [IDENTIFIERS.SCROLLBAR]: ScrollBarSkin,

--- a/source/themes/API/index.js
+++ b/source/themes/API/index.js
@@ -16,6 +16,7 @@ import { LINK_THEME_API } from './link';
 import { LOADING_SPINNER_API } from './loadingspinner';
 import { MODAL_THEME_API } from './modal';
 import { OPTIONS_THEME_API } from './options';
+import { PASSWORD_INPUT_THEME_API } from './password-input';
 import { PROGRESS_BAR_THEME_API } from './progressbar';
 import { RADIO_THEME_API } from './radio';
 import { SCROLLBAR_THEME_API } from './scrollbar';
@@ -43,6 +44,7 @@ export const ROOT_THEME_API = {
   [IDENTIFIERS.LOADING_SPINNER]: LOADING_SPINNER_API,
   [IDENTIFIERS.MODAL]: MODAL_THEME_API,
   [IDENTIFIERS.OPTIONS]: OPTIONS_THEME_API,
+  [IDENTIFIERS.PASSWORD_INPUT]: PASSWORD_INPUT_THEME_API,
   [IDENTIFIERS.PROGRESS_BAR]: PROGRESS_BAR_THEME_API,
   [IDENTIFIERS.RADIO]: RADIO_THEME_API,
   [IDENTIFIERS.SCROLLBAR]: SCROLLBAR_THEME_API,

--- a/source/themes/API/password-input.js
+++ b/source/themes/API/password-input.js
@@ -1,0 +1,9 @@
+// @flow
+export const PASSWORD_INPUT_THEME_API = {
+  root: '',
+  tooltip: '',
+  hint: '',
+  error: '',
+  warning: '',
+  success: '',
+};

--- a/source/themes/API/tooltip.js
+++ b/source/themes/API/tooltip.js
@@ -4,5 +4,7 @@ export const TOOLTIP_THEME_API = {
   bubble: '',
   alignRight: '',
   alignLeft: '',
+  isCentered: '',
+  isVisible: '',
   nowrap: ''
 };

--- a/source/themes/simple/SimpleBubble.scss
+++ b/source/themes/simple/SimpleBubble.scss
@@ -191,3 +191,20 @@ $bubble-arrow-height: var(--rp-bubble-arrow-height, $bubble-arrow-size) !default
     top: calc(100% + #{$bubble-no-arrow-distance});
   }
 }
+
+// ======== STATE: autoWidth =======
+
+.hasAutoWidth {
+  min-width: auto;
+}
+
+// ======== STATE: isCentered =======
+
+.isCentered {
+  text-align: center;
+  .bubble {
+    display: inline-block;
+    position: unset;
+    min-width: unset;
+  }
+}

--- a/source/themes/simple/SimplePasswordInput.scss
+++ b/source/themes/simple/SimplePasswordInput.scss
@@ -1,0 +1,67 @@
+@import "theme";
+
+$password-input-error-bg: var(--rp-password-input-error-bg, #f4b5bc) !default;
+$password-input-error-score-color: var(--rp-password-input-error-score-color, #ea4c5b) !default;
+$password-input-warning-bg: var(--rp-password-input-warning-bg, #f7d8a1) !default;
+$password-input-warning-score-color: var(--rp-password-input-warning-score-color, #f2a218) !default;
+$password-input-success-bg: var(--rp-password-input-success-bg, #a8e4c3) !default;
+$password-input-success-score-color: var(--rp-password-input-success-score-color, #2dc06c) !default;
+
+@mixin bubbleColor($color) {
+  :global {
+    .SimpleTooltip_bubble.SimpleBubble_root [data-bubble-arrow] {
+      &:before, &:after {
+        border-bottom-color: $color;
+      }
+    }
+    .SimpleTooltip_bubble .SimpleBubble_bubble {
+      background-color: $color;
+    }
+  }
+}
+
+.root {
+  // Remove bottom input border for any state but the default
+  // to make room for the score indicator
+  &:not(.default) {
+    :global {
+      .SimpleInput_input {
+        border-bottom: none;
+      }
+    }
+  }
+}
+
+.indicator, .score {
+  height: 2px;
+}
+
+.error {
+  .indicator {
+    background-color: $password-input-error-bg;
+  }
+  .score {
+    background-color: $password-input-error-score-color;
+  }
+  @include bubbleColor($password-input-error-score-color);
+}
+
+.warning {
+  .indicator {
+    background-color: $password-input-warning-bg;
+  }
+  .score {
+    background-color: $password-input-warning-score-color;
+  }
+  @include bubbleColor($password-input-warning-score-color);
+}
+
+.success {
+  .indicator {
+    background-color: $password-input-success-bg;
+  }
+  .score {
+    background-color: $password-input-success-score-color;
+  }
+  @include bubbleColor($password-input-success-score-color);
+}

--- a/source/themes/simple/SimplePasswordInput.scss
+++ b/source/themes/simple/SimplePasswordInput.scss
@@ -1,10 +1,17 @@
 @import "theme";
 
-$password-input-error-bg: var(--rp-password-input-error-bg, #f4b5bc) !default;
+// OVERRIDABLE CONFIGURATION VARIABLES
+
+// error
+$password-input-error-bg-color: var(--rp-password-input-error-bg-color, #f4b5bc) !default;
 $password-input-error-score-color: var(--rp-password-input-error-score-color, #ea4c5b) !default;
-$password-input-warning-bg: var(--rp-password-input-warning-bg, #f7d8a1) !default;
+
+// warning
+$password-input-warning-bg-color: var(--rp-password-input-warning-bg-color, #f7d8a1) !default;
 $password-input-warning-score-color: var(--rp-password-input-warning-score-color, #f2a218) !default;
-$password-input-success-bg: var(--rp-password-input-success-bg, #a8e4c3) !default;
+
+// success
+$password-input-success-bg-color: var(--rp-password-input-success-bg-color, #a8e4c3) !default;
 $password-input-success-score-color: var(--rp-password-input-success-score-color, #2dc06c) !default;
 
 @mixin bubbleColor($color) {
@@ -38,7 +45,7 @@ $password-input-success-score-color: var(--rp-password-input-success-score-color
 
 .error {
   .indicator {
-    background-color: $password-input-error-bg;
+    background-color: $password-input-error-bg-color;
   }
   .score {
     background-color: $password-input-error-score-color;
@@ -48,7 +55,7 @@ $password-input-success-score-color: var(--rp-password-input-success-score-color
 
 .warning {
   .indicator {
-    background-color: $password-input-warning-bg;
+    background-color: $password-input-warning-bg-color;
   }
   .score {
     background-color: $password-input-warning-score-color;
@@ -58,7 +65,7 @@ $password-input-success-score-color: var(--rp-password-input-success-score-color
 
 .success {
   .indicator {
-    background-color: $password-input-success-bg;
+    background-color: $password-input-success-bg-color;
   }
   .score {
     background-color: $password-input-success-score-color;

--- a/source/themes/simple/SimpleTooltip.scss
+++ b/source/themes/simple/SimpleTooltip.scss
@@ -3,7 +3,6 @@
 
 // OVERRIDABLE CONFIGURATION VARIABLES
 
-$tooltip-bg-color: var(--rp-tooltip-bg-color, #fafbfc) !default;
 $tooltip-font-family: var(--rp-tooltip-font-family, $theme-font-light, sans-serif) !default;
 $tooltip-text-color: var(--rp-tooltip-text-color, white) !default;
 
@@ -21,7 +20,6 @@ $tooltip-text-color: var(--rp-tooltip-text-color, white) !default;
 .bubble {
   font-family: $tooltip-font-family;
   color: $tooltip-text-color;
-  background-color: $tooltip-bg-color;
   display: none;
 }
 
@@ -35,4 +33,22 @@ $tooltip-text-color: var(--rp-tooltip-text-color, white) !default;
 
 .nowrap {
   white-space: nowrap;
+}
+
+.isCentered {
+  display: block;
+
+  &:hover .bubble {
+    display: inline-block;
+  }
+
+  .bubble {
+    text-align: center;
+  }
+}
+
+.isVisible {
+  .bubble {
+    display: inline-block;
+  }
 }

--- a/source/themes/simple/index.js
+++ b/source/themes/simple/index.js
@@ -19,6 +19,7 @@ import SimpleLink from './SimpleLink.scss';
 import SimpleLoadingSpinner from './SimpleLoadingSpinner.scss';
 import SimpleModal from './SimpleModal.scss';
 import SimpleOptions from './SimpleOptions.scss';
+import SimplePasswordInput from './SimplePasswordInput.scss';
 import SimpleProgressBar from './SimpleProgressBar.scss';
 import SimpleRadio from './SimpleRadio.scss';
 import SimpleScrollBar from './SimpleScrollBar.scss';
@@ -50,6 +51,7 @@ export const SimpleTheme = {
   [IDENTIFIERS.LOADING_SPINNER]: SimpleLoadingSpinner,
   [IDENTIFIERS.MODAL]: SimpleModal,
   [IDENTIFIERS.OPTIONS]: SimpleOptions,
+  [IDENTIFIERS.PASSWORD_INPUT]: SimplePasswordInput,
   [IDENTIFIERS.PROGRESS_BAR]: SimpleProgressBar,
   [IDENTIFIERS.RADIO]: SimpleRadio,
   [IDENTIFIERS.SCROLLBAR]: SimpleScrollBar,

--- a/stories/Bubble.stories.js
+++ b/stories/Bubble.stories.js
@@ -112,6 +112,15 @@ storiesOf('Bubble', module)
     </div>
   ))
 
+  .add('isCentered', () => (
+    <div className={styles.container} style={{ width: '200px' }}>
+      Bubble should be centered below me without stretching the full width
+      <Bubble isCentered>
+        centered below
+      </Bubble>
+    </div>
+  ))
+
   .add('theme overrides', () => (
     <div className={styles.container}>
       <Bubble

--- a/stories/PasswordInput.stories.js
+++ b/stories/PasswordInput.stories.js
@@ -1,0 +1,80 @@
+// @flow
+import React from 'react';
+
+// storybook
+import { storiesOf } from '@storybook/react';
+import { withState } from '@dump247/storybook-state';
+
+// components
+import { PasswordInput } from '../source/components/PasswordInput';
+
+// helpers
+import { decorateWithSimpleTheme } from './helpers/theming';
+
+// custom styles & theme overrides
+import styles from './PasswordInput.stories.scss';
+
+storiesOf('PasswordInput', module)
+
+  .addDecorator(decorateWithSimpleTheme)
+
+  // ====== Stories ======
+  .add('empty',
+    withState({ value: '' }, store => (
+      <div className={styles.container}>
+        <PasswordInput
+          isTooltipOpen
+          label="Label"
+          value={store.state.value}
+          placeholder="Hint"
+          onChange={value => store.set({ value })}
+          tooltip="Regular tooltip"
+        />
+      </div>
+    ))
+  )
+  .add('error',
+    withState({ value: 'test' }, store => (
+      <div className={styles.container}>
+        <PasswordInput
+          isTooltipOpen
+          label="Label"
+          value={store.state.value}
+          onChange={value => store.set({ value })}
+          tooltip="Password doesn't match"
+          score={0.1}
+          state={PasswordInput.STATE.ERROR}
+        />
+      </div>
+    ))
+  )
+  .add('warning',
+    withState({ value: 'test' }, store => (
+      <div className={styles.container}>
+        <PasswordInput
+          isTooltipOpen
+          label="Label"
+          value={store.state.value}
+          onChange={value => store.set({ value })}
+          tooltip="Warning message"
+          score={0.5}
+          state={PasswordInput.STATE.WARNING}
+        />
+      </div>
+    ))
+  )
+  .add('success',
+    withState({ value: 'test' }, store => (
+      <div className={styles.container}>
+        <PasswordInput
+          isTooltipOpen
+          label="Label"
+          value={store.state.value}
+          onChange={value => store.set({ value })}
+          tooltip="Excellent"
+          score={0.8}
+          state={PasswordInput.STATE.SUCCESS}
+        />
+      </div>
+    ))
+  );

--- a/stories/PasswordInput.stories.scss
+++ b/stories/PasswordInput.stories.scss
@@ -1,0 +1,3 @@
+.container {
+  padding: 20px;
+}

--- a/stories/Tooltip.stories.js
+++ b/stories/Tooltip.stories.js
@@ -99,6 +99,43 @@ storiesOf('Tooltip', module)
     </div>
   ))
 
+  .add('arrowRelativeToTip (below)', () => (
+    <div className={styles.fitToSize}>
+      <Tooltip
+        arrowRelativeToTip
+        isOpeningUpward={false}
+        tip="small tip from below"
+      >
+        {'this is a really long string for demonstration purposes'}
+      </Tooltip>
+    </div>
+  ))
+
+  .add('centered', () => (
+    <div className={styles.fitToSize}>
+      <Tooltip
+        arrowRelativeToTip
+        isCentered
+        tip="centered above"
+      >
+        {'this is a really long string for demonstration purposes'}
+      </Tooltip>
+    </div>
+  ))
+
+  .add('centered (below)', () => (
+    <div className={styles.fitToSize}>
+      <Tooltip
+        arrowRelativeToTip
+        isCentered
+        isOpeningUpward={false}
+        tip="centered below"
+      >
+        {'this is a really long string for demonstration purposes'}
+      </Tooltip>
+    </div>
+  ))
+
   .add('theme overrides', () => (
     <div className={styles.container}>
       <Tooltip

--- a/stories/Tooltip.stories.scss
+++ b/stories/Tooltip.stories.scss
@@ -14,9 +14,6 @@
 }
 
 .fitToSize {
-  padding: 150px;
-  :global(.SimpleBubble_bubble) {
-    // size tooltip to text contained inside
-    min-width: auto;
-  }
+  margin: 150px;
+  background-color: #eee;
 }

--- a/stories/index.js
+++ b/stories/index.js
@@ -14,6 +14,7 @@ import './LoadingSpinner.stories';
 import './Modal.stories';
 import './NumericInput.stories';
 import './Options.stories';
+import './PasswordInput.stories';
 import './ProgressBar.stories';
 import './Radio.stories';
 import './ScrollBar.stories';


### PR DESCRIPTION
This PR implements the [designed password input](https://zpl.io/bAlyNGq) for Daedalus:

Note: This component does not implement any password score algorithm as this is very application specific. The `PasswordInput` can only be configured to display in different states:

![screenshot 2020-02-10 um 16 33 22](https://user-images.githubusercontent.com/172414/74163766-236af580-4c23-11ea-8ad3-5f57def590c6.png)
![screenshot 2020-02-10 um 16 33 30](https://user-images.githubusercontent.com/172414/74163773-2534b900-4c23-11ea-84b2-d4da65c337bd.png)
![screenshot 2020-02-10 um 16 33 35](https://user-images.githubusercontent.com/172414/74163775-25cd4f80-4c23-11ea-8740-eacd33c2360d.png)
![screenshot 2020-02-10 um 16 33 40](https://user-images.githubusercontent.com/172414/74163777-2665e600-4c23-11ea-8dfc-3e14dc239af6.png)

For this it was necessary to improve the Bubble and Tooltip components to allow centered alignment without full-width. I also added stories and test cases for all of these new cases (as well as for the Tooltip component which had no tests yet).

![screenshot 2020-02-10 um 16 35 56](https://user-images.githubusercontent.com/172414/74164027-7e045180-4c23-11ea-9216-ad0cd8075968.png)
![screenshot 2020-02-10 um 16 36 17](https://user-images.githubusercontent.com/172414/74164029-7e9ce800-4c23-11ea-944d-fc84d410866d.png)

A few minor refactorings and improvements round up the work 😉 