### PR TITLE
[DDW-1227] Fix options component dimensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ vNext
 
 - Adds new `PasswordInput` component [PR 134](https://github.com/input-output-hk/react-polymorph/pull/134)
 
+### Chores
+
+- Enable Option component, `optionHeight` property, override from parent components [PR 135](https://github.com/input-output-hk/react-polymorph/pull/135)
+
+### Fixes
+
+- Fixed global listener `mouseIsOverRoot`  event handler [PR 135](https://github.com/input-output-hk/react-polymorph/pull/135)
+
 0.9.2
 =====
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,9 @@ vNext
 
 - Adds new `PasswordInput` component [PR 134](https://github.com/input-output-hk/react-polymorph/pull/134)
 
-### Chores
-
-- Enable Option component, `optionHeight` property, override from parent components [PR 135](https://github.com/input-output-hk/react-polymorph/pull/135)
-
 ### Fixes
 
+- Fixed Option component, `optionHeight` property, override from parent components [PR 135](https://github.com/input-output-hk/react-polymorph/pull/135)
 - Fixed global listener `mouseIsOverRoot`  event handler [PR 135](https://github.com/input-output-hk/react-polymorph/pull/135)
 
 0.9.2

--- a/source/components/Autocomplete.js
+++ b/source/components/Autocomplete.js
@@ -256,8 +256,8 @@ class AutocompleteBase extends Component<Props, State> {
         rootRef={this.rootElement}
         toggleOpen={this.toggleOpen}
       >
-        {({ optionsMaxHeight }) => (
-          <AutocompleteSkin
+        {({ optionsMaxHeight, optionHeight }) => (
+          <AutocompleteSkins
             error={error || this.state.error}
             filteredOptions={this.state.filteredOptions}
             getSelectionProps={this.getSelectionProps}
@@ -277,6 +277,7 @@ class AutocompleteBase extends Component<Props, State> {
             theme={this.state.composedTheme}
             toggleMouseLocation={this.toggleMouseLocation}
             toggleOpen={this.toggleOpen}
+            optionHeight={optionHeight}
             {...rest}
           />
         )}

--- a/source/components/Autocomplete.js
+++ b/source/components/Autocomplete.js
@@ -257,7 +257,7 @@ class AutocompleteBase extends Component<Props, State> {
         toggleOpen={this.toggleOpen}
       >
         {({ optionsMaxHeight, optionHeight }) => (
-          <AutocompleteSkins
+          <AutocompleteSkin
             error={error || this.state.error}
             filteredOptions={this.state.filteredOptions}
             getSelectionProps={this.getSelectionProps}

--- a/source/components/Dropdown.js
+++ b/source/components/Dropdown.js
@@ -154,7 +154,7 @@ class DropdownBase extends Component<Props, State> {
         rootRef={this.rootElement}
         toggleOpen={this.toggleOpen}
       >
-        {({ optionsMaxHeight }) => (
+        {({ optionsMaxHeight, optionHeight }) => (
           <DropdownSkin
             isOpen={this.isOpen()}
             isOpeningUpward={isOpeningUpward}
@@ -162,6 +162,7 @@ class DropdownBase extends Component<Props, State> {
             onLabelClick={this._onLabelClick}
             optionsRef={this.optionsElement}
             optionsMaxHeight={optionsMaxHeight}
+            optionHeight={optionHeight}
             rootRef={this.rootElement}
             setMouseOverItems={this._setMouseOverItems}
             setMouseOverRoot={this._setMouseOverRoot}

--- a/source/components/Dropdown.js
+++ b/source/components/Dropdown.js
@@ -143,11 +143,12 @@ class DropdownBase extends Component<Props, State> {
     } = this.props;
 
     const DropdownSkin = skin || context.skins[IDENTIFIERS.DROPDOWN];
-    const { isMouseOverItems } = this.state;
+    const { isMouseOverItems, isMouseOverRoot } = this.state;
 
     return (
       <GlobalListeners
         mouseIsOverOptions={isMouseOverItems}
+        mouseIsOverRoot={isMouseOverRoot}
         optionsIsOpen={this.isOpen()}
         optionsIsOpeningUpward={isOpeningUpward}
         optionsRef={this.optionsElement}

--- a/source/components/HOC/GlobalListeners.js
+++ b/source/components/HOC/GlobalListeners.js
@@ -15,6 +15,7 @@ import {
 type Props = {
   children: Function,
   mouseIsOverOptions: boolean,
+  mouseIsOverRoot: boolean,
   optionsIsOpen: boolean,
   optionsIsOpeningUpward: boolean,
   optionsRef?: ElementRef<*>,
@@ -136,6 +137,7 @@ export class GlobalListeners extends Component<Props, State> {
       optionsRef,
       toggleOpen,
       mouseIsOverOptions,
+      mouseIsOverRoot,
     } = this.props;
 
     // checks if Options are open & being scrolled upon via mouse position prior to toggling closed
@@ -144,7 +146,7 @@ export class GlobalListeners extends Component<Props, State> {
     if (!rootRef || !rootRef.current || !doDocumentStylesExist || !isOptionsInDOM) {
       return;
     }
-    optionsIsOpen && !mouseIsOverOptions && toggleOpen();
+    optionsIsOpen && !mouseIsOverOptions && !mouseIsOverRoot && toggleOpen();
     const { height, top } = rootRef.current.getBoundingClientRect();
     // opening upwards case
     if (optionsIsOpeningUpward && top < window.innerHeight) {

--- a/source/components/HOC/GlobalListeners.js
+++ b/source/components/HOC/GlobalListeners.js
@@ -15,7 +15,7 @@ import {
 type Props = {
   children: Function,
   mouseIsOverOptions: boolean,
-  mouseIsOverRoot: boolean,
+  mouseIsOverRoot?: boolean,
   optionsIsOpen: boolean,
   optionsIsOpeningUpward: boolean,
   optionsRef?: ElementRef<*>,

--- a/source/components/Options.js
+++ b/source/components/Options.js
@@ -33,7 +33,7 @@ type Props = {
   onBlur?: Function,
   onChange?: Function,
   onClose?: Function,
-  optionHeight: number,
+  optionHeight: ?number,
   options: Array<any>,
   optionRenderer?: Function,
   optionsRef?: ElementRef<any>,

--- a/source/components/Select.js
+++ b/source/components/Select.js
@@ -34,6 +34,7 @@ type Props = {
   themeId: string,
   themeOverrides: Object,
   value: string,
+  optionHeight?: number,
 };
 
 type State = {
@@ -147,6 +148,7 @@ class SelectBase extends Component<Props, State> {
       autoFocus,
       context,
       allowBlank,
+      optionHeight,
       ...rest
     } = this.props;
 
@@ -174,6 +176,7 @@ class SelectBase extends Component<Props, State> {
             handleChange={this.handleChange}
             toggleOpen={this.toggleOpen}
             toggleMouseLocation={this.toggleMouseLocation}
+            optionHeight={optionHeight}
             {...rest}
           />
         )}

--- a/source/skins/simple/AutocompleteSkin.js
+++ b/source/skins/simple/AutocompleteSkin.js
@@ -44,6 +44,7 @@ type Props = {
   themeId: string,
   toggleMouseLocation: Function,
   toggleOpen: Function,
+  optionHeight: ?number,
 };
 
 export const AutocompleteSkin = (props: Props) => {
@@ -148,6 +149,7 @@ export const AutocompleteSkin = (props: Props) => {
         targetRef={props.suggestionsRef}
         toggleMouseLocation={props.toggleMouseLocation}
         toggleOpen={props.toggleOpen}
+        optionHeight={props.optionHeight}
       />
     </div>
   );

--- a/source/skins/simple/DropdownSkin.js
+++ b/source/skins/simple/DropdownSkin.js
@@ -29,6 +29,7 @@ type Props = {
   setMouseOverRoot: Function,
   theme: Object,
   themeId: string,
+  optionHeight: ?number,
 };
 
 export const DropdownSkin = (props: Props) => {
@@ -61,6 +62,7 @@ export const DropdownSkin = (props: Props) => {
         onChange={props.onItemSelected}
         options={props.items}
         optionsMaxHeight={props.optionsMaxHeight}
+        optionHeight={props.optionHeight}
         optionsRef={props.optionsRef}
         optionRenderer={props.optionRenderer}
         selectedOption={props.activeItem}

--- a/source/skins/simple/SelectSkin.js
+++ b/source/skins/simple/SelectSkin.js
@@ -42,6 +42,7 @@ type Props = {
   toggleOpen: Function,
   toggleMouseLocation: Function,
   value: string,
+  optionHeight: ?number,
 };
 
 export const SelectSkin = (props: Props) => {
@@ -89,6 +90,7 @@ export const SelectSkin = (props: Props) => {
         targetRef={props.inputRef}
         toggleMouseLocation={props.toggleMouseLocation}
         toggleOpen={props.toggleOpen}
+        optionHeight={props.optionHeight}
       />
     </div>
   );

--- a/stories/Dropdown.stories.js
+++ b/stories/Dropdown.stories.js
@@ -55,6 +55,7 @@ storiesOf('Dropdown', module)
         }}
         items={COUNTRY_ITEMS}
         noArrow
+        optionHeight={52}
       />
     ))
   )
@@ -67,6 +68,7 @@ storiesOf('Dropdown', module)
           store.set({ value });
         }}
         items={COUNTRY_ITEMS}
+        optionHeight={52}
       />
     ))
   )
@@ -81,6 +83,7 @@ storiesOf('Dropdown', module)
           store.set({ value });
         }}
         items={COUNTRY_ITEMS}
+        optionHeight={52}
       />
     ))
   )
@@ -94,6 +97,7 @@ storiesOf('Dropdown', module)
           store.set({ value });
         }}
         items={COUNTRY_ITEMS}
+        optionHeight={52}
       />
     ))
   )
@@ -110,6 +114,7 @@ storiesOf('Dropdown', module)
         optionRenderer={o => (
           <div className={styles.customOption}>{o.label}</div>
         )}
+        optionHeight={52}
       />
     ))
   );

--- a/stories/Select.stories.js
+++ b/stories/Select.stories.js
@@ -128,6 +128,7 @@ storiesOf('Select', module)
             <span>{option.label}</span>
           </div>
           )}
+        optionHeight={56}
       />
     ))
   )
@@ -246,6 +247,7 @@ storiesOf('Select', module)
             <div className={styles.value}>{option.value}</div>
           </div>
         )}
+        optionHeight={63}
       />
     ))
   );


### PR DESCRIPTION
This PR introduces flexible option height and availability to pass them from parent components.

## Testing Checklist
- [ ] Check storybook stories under: `Autocomplete` section
- [ ] Check storybook stories under: `Select` section
- [ ] Check storybook stories under: `Options` section
- [ ] Check storybook stories under: `Dropdown` section