### PR TITLE
[DDW-246]: Eliminate usage of deprecated lifecycle methods

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "trailingComma": "none",
+  "singleQuote": true
+}

--- a/source/components/Autocomplete.js
+++ b/source/components/Autocomplete.js
@@ -1,21 +1,21 @@
 // @flow
-import React, { Component } from 'react';
-import type { ComponentType, Element } from 'react';
+import React, { Component } from "react";
+import type { ComponentType, Element } from "react";
 
 // external libraries
-import createRef from 'create-react-ref/lib/createRef';
-import _ from 'lodash';
+import createRef from "create-react-ref/lib/createRef";
+import _ from "lodash";
 
 // interal components
-import { GlobalListeners } from './HOC/GlobalListeners';
+import { GlobalListeners } from "./HOC/GlobalListeners";
 
 // internal utility functions
-import { createEmptyContext, withTheme } from './HOC/withTheme';
-import { composeTheme, addThemeId, didThemePropsChange } from '../utils/themes';
-import { composeFunctions } from '../utils/props';
+import { createEmptyContext, withTheme } from "./HOC/withTheme";
+import { composeTheme, addThemeId, didThemePropsChange } from "../utils/themes";
+import { composeFunctions } from "../utils/props";
 
-import { IDENTIFIERS } from '.';
-import type { ThemeContextProp } from './HOC/withTheme';
+import { IDENTIFIERS } from ".";
+import type { ThemeContextProp } from "./HOC/withTheme";
 
 type Props = {
   className?: string,
@@ -37,7 +37,7 @@ type Props = {
   sortAlphabetically: boolean,
   theme: ?Object, // will take precedence over theme in context if passed
   themeId: string,
-  themeOverrides: Object
+  themeOverrides: Object,
 };
 
 type State = {
@@ -53,12 +53,12 @@ type State = {
 class AutocompleteBase extends Component<Props, State> {
   // declare ref types
   rootElement: ?Element<any>;
-  inputElement: ?Element<'input'>;
+  inputElement: ?Element<"input">;
   suggestionsElement: ?Element<any>;
   optionsElement: ?Element<any>;
 
   // define static properties
-  static displayName = 'Autocomplete';
+  static displayName = "Autocomplete";
   static defaultProps = {
     context: createEmptyContext(),
     error: null,
@@ -70,7 +70,7 @@ class AutocompleteBase extends Component<Props, State> {
     sortAlphabetically: true, // options are sorted alphabetically by default
     theme: null,
     themeId: IDENTIFIERS.AUTOCOMPLETE,
-    themeOverrides: {}
+    themeOverrides: {},
   };
 
   constructor(props: Props) {
@@ -89,12 +89,12 @@ class AutocompleteBase extends Component<Props, State> {
       themeOverrides,
       sortAlphabetically,
       options,
-      preselectedOptions
+      preselectedOptions,
     } = props;
 
     this.state = {
-      inputValue: '',
-      error: '',
+      inputValue: "",
+      error: "",
       selectedOptions: preselectedOptions || [],
       filteredOptions:
         sortAlphabetically && options ? options.sort() : options || [],
@@ -104,12 +104,14 @@ class AutocompleteBase extends Component<Props, State> {
         addThemeId(theme || context.theme, themeId),
         addThemeId(themeOverrides, themeId),
         context.ROOT_THEME_API
-      )
+      ),
     };
   }
 
-  componentWillReceiveProps(nextProps: Props) {
-    didThemePropsChange(this.props, nextProps, this.setState.bind(this));
+  componentDidUpdate(prevProps: Props) {
+    if (prevProps !== this.props) {
+      didThemePropsChange(prevProps, this.props, this.setState.bind(this));
+    }
   }
 
   clear = () => this._removeOptions();
@@ -121,16 +123,19 @@ class AutocompleteBase extends Component<Props, State> {
   close = () => this.setState({ isOpen: false });
 
   toggleOpen = () => {
-    if (this.state.isOpen && this.optionsElement && this.optionsElement.current) {
+    if (
+      this.state.isOpen &&
+      this.optionsElement &&
+      this.optionsElement.current
+    ) {
       // set Options scroll position to top on close
       this.optionsElement.current.scrollTop = 0;
     }
     this.setState({ isOpen: !this.state.isOpen });
-  }
+  };
 
-  toggleMouseLocation = () => (
-    this.setState({ mouseIsOverOptions: !this.state.mouseIsOverOptions })
-  );
+  toggleMouseLocation = () =>
+    this.setState({ mouseIsOverOptions: !this.state.mouseIsOverOptions });
 
   handleAutocompleteClick = () => {
     const { inputElement } = this;
@@ -142,17 +147,19 @@ class AutocompleteBase extends Component<Props, State> {
   };
 
   onKeyDown = (event: SyntheticKeyboardEvent<>) => {
-
-    if ( // Check for backspace in order to delete the last selected option
+    if (
+      // Check for backspace in order to delete the last selected option
       event.keyCode === 8 &&
       !event.target.value &&
       this.state.selectedOptions.length
     ) {
       // Remove last selected option
       this.removeOption(this.state.selectedOptions.length - 1, event);
-    } else if (event.keyCode === 27) { // ESCAPE key: Stops propagation & modal closing
+    } else if (event.keyCode === 27) {
+      // ESCAPE key: Stops propagation & modal closing
       event.stopPropagation();
-    } else if (event.keyCode === 13) { // ENTER key: Opens suggestions
+    } else if (event.keyCode === 13) {
+      // ENTER key: Opens suggestions
       this.open();
     }
   };
@@ -173,18 +180,20 @@ class AutocompleteBase extends Component<Props, State> {
   ) => {
     const { maxSelections, multipleSameSelections } = this.props;
     const { selectedOptions, filteredOptions, isOpen } = this.state;
-    const canMoreOptionsBeSelected = (
-      maxSelections != null ? selectedOptions.length < maxSelections : true
-    );
-    const areFilteredOptionsAvailable = filteredOptions && filteredOptions.length > 0;
+    const canMoreOptionsBeSelected =
+      maxSelections != null ? selectedOptions.length < maxSelections : true;
+    const areFilteredOptionsAvailable =
+      filteredOptions && filteredOptions.length > 0;
 
-    if (!maxSelections || (canMoreOptionsBeSelected && areFilteredOptionsAvailable)) {
+    if (
+      !maxSelections ||
+      (canMoreOptionsBeSelected && areFilteredOptionsAvailable)
+    ) {
       if (!selectedOption) return;
       const option = selectedOption.trim();
-      const optionCanBeSelected = (
+      const optionCanBeSelected =
         (selectedOptions.indexOf(option) < 0 && !multipleSameSelections) ||
-        multipleSameSelections
-      );
+        multipleSameSelections;
 
       if (option && optionCanBeSelected && isOpen) {
         const newSelectedOptions = _.concat(selectedOptions, option);
@@ -193,7 +202,7 @@ class AutocompleteBase extends Component<Props, State> {
       }
     }
 
-    this._setInputValue('');
+    this._setInputValue("");
   };
 
   removeOption = (index: number, event: SyntheticEvent<>) => {
@@ -214,7 +223,7 @@ class AutocompleteBase extends Component<Props, State> {
   // associated with rendering this.state.selectedOptions, the user can call
   // this in the body of the renderSelections function
   getSelectionProps = ({
-    removeSelection
+    removeSelection,
   }: { removeSelection: Function } = {}) => {
     const { themeId } = this.props;
     const { inputValue, isOpen, selectedOptions, composedTheme } = this.state;
@@ -226,7 +235,7 @@ class AutocompleteBase extends Component<Props, State> {
       removeSelection: (index: number, event: SyntheticEvent<>) =>
         // the user's custom removeSelection event handler is composed with
         // the internal functionality of Autocomplete (this.removeOption)
-        composeFunctions(removeSelection, this.removeOption)(index, event)
+        composeFunctions(removeSelection, this.removeOption)(index, event),
     };
   };
 
@@ -290,13 +299,13 @@ class AutocompleteBase extends Component<Props, State> {
   _removeOptions = () => {
     const { onChange } = this.props;
     onChange ? onChange([]) : null;
-    this.setState({ selectedOptions: [], inputValue: '' });
+    this.setState({ selectedOptions: [], inputValue: "" });
   };
 
   _filterOptions = (value: string) => {
     let filteredOptions = [];
 
-    if (value !== '') {
+    if (value !== "") {
       _.some(this.props.options, (option) => {
         if (_.startsWith(option, value)) {
           filteredOptions.push(option);
@@ -310,10 +319,10 @@ class AutocompleteBase extends Component<Props, State> {
   };
 
   _filterInvalidChars = (value: string) => {
-    let filteredValue = '';
+    let filteredValue = "";
 
     if (this.props.invalidCharsRegex.test(value)) {
-      filteredValue = value.replace(this.props.invalidCharsRegex, '');
+      filteredValue = value.replace(this.props.invalidCharsRegex, "");
     } else {
       filteredValue = value;
     }
@@ -327,9 +336,9 @@ class AutocompleteBase extends Component<Props, State> {
     this.setState({
       isOpen: true,
       inputValue: filteredValue,
-      filteredOptions
+      filteredOptions,
     });
-  }
+  };
 }
 
 export const Autocomplete = withTheme(AutocompleteBase);

--- a/source/components/Autocomplete.js
+++ b/source/components/Autocomplete.js
@@ -1,21 +1,21 @@
 // @flow
-import React, { Component } from "react";
-import type { ComponentType, Element } from "react";
+import React, { Component } from 'react';
+import type { ComponentType, Element } from 'react';
 
 // external libraries
-import createRef from "create-react-ref/lib/createRef";
-import _ from "lodash";
+import createRef from 'create-react-ref/lib/createRef';
+import _ from 'lodash';
 
 // interal components
-import { GlobalListeners } from "./HOC/GlobalListeners";
+import { GlobalListeners } from './HOC/GlobalListeners';
 
 // internal utility functions
-import { createEmptyContext, withTheme } from "./HOC/withTheme";
-import { composeTheme, addThemeId, didThemePropsChange } from "../utils/themes";
-import { composeFunctions } from "../utils/props";
+import { createEmptyContext, withTheme } from './HOC/withTheme';
+import { composeTheme, addThemeId, didThemePropsChange } from '../utils/themes';
+import { composeFunctions } from '../utils/props';
 
-import { IDENTIFIERS } from ".";
-import type { ThemeContextProp } from "./HOC/withTheme";
+import { IDENTIFIERS } from '.';
+import type { ThemeContextProp } from './HOC/withTheme';
 
 type Props = {
   className?: string,
@@ -37,7 +37,7 @@ type Props = {
   sortAlphabetically: boolean,
   theme: ?Object, // will take precedence over theme in context if passed
   themeId: string,
-  themeOverrides: Object,
+  themeOverrides: Object
 };
 
 type State = {
@@ -47,18 +47,18 @@ type State = {
   isOpen: boolean,
   inputValue: string,
   mouseIsOverOptions: boolean,
-  selectedOptions: Array<any>,
+  selectedOptions: Array<any>
 };
 
 class AutocompleteBase extends Component<Props, State> {
   // declare ref types
   rootElement: ?Element<any>;
-  inputElement: ?Element<"input">;
+  inputElement: ?Element<'input'>;
   suggestionsElement: ?Element<any>;
   optionsElement: ?Element<any>;
 
   // define static properties
-  static displayName = "Autocomplete";
+  static displayName = 'Autocomplete';
   static defaultProps = {
     context: createEmptyContext(),
     error: null,
@@ -70,7 +70,7 @@ class AutocompleteBase extends Component<Props, State> {
     sortAlphabetically: true, // options are sorted alphabetically by default
     theme: null,
     themeId: IDENTIFIERS.AUTOCOMPLETE,
-    themeOverrides: {},
+    themeOverrides: {}
   };
 
   constructor(props: Props) {
@@ -89,12 +89,12 @@ class AutocompleteBase extends Component<Props, State> {
       themeOverrides,
       sortAlphabetically,
       options,
-      preselectedOptions,
+      preselectedOptions
     } = props;
 
     this.state = {
-      inputValue: "",
-      error: "",
+      inputValue: '',
+      error: '',
       selectedOptions: preselectedOptions || [],
       filteredOptions:
         sortAlphabetically && options ? options.sort() : options || [],
@@ -104,7 +104,7 @@ class AutocompleteBase extends Component<Props, State> {
         addThemeId(theme || context.theme, themeId),
         addThemeId(themeOverrides, themeId),
         context.ROOT_THEME_API
-      ),
+      )
     };
   }
 
@@ -202,7 +202,7 @@ class AutocompleteBase extends Component<Props, State> {
       }
     }
 
-    this._setInputValue("");
+    this._setInputValue('');
   };
 
   removeOption = (index: number, event: SyntheticEvent<>) => {
@@ -223,7 +223,7 @@ class AutocompleteBase extends Component<Props, State> {
   // associated with rendering this.state.selectedOptions, the user can call
   // this in the body of the renderSelections function
   getSelectionProps = ({
-    removeSelection,
+    removeSelection
   }: { removeSelection: Function } = {}) => {
     const { themeId } = this.props;
     const { inputValue, isOpen, selectedOptions, composedTheme } = this.state;
@@ -235,7 +235,7 @@ class AutocompleteBase extends Component<Props, State> {
       removeSelection: (index: number, event: SyntheticEvent<>) =>
         // the user's custom removeSelection event handler is composed with
         // the internal functionality of Autocomplete (this.removeOption)
-        composeFunctions(removeSelection, this.removeOption)(index, event),
+        composeFunctions(removeSelection, this.removeOption)(index, event)
     };
   };
 
@@ -299,13 +299,13 @@ class AutocompleteBase extends Component<Props, State> {
   _removeOptions = () => {
     const { onChange } = this.props;
     onChange ? onChange([]) : null;
-    this.setState({ selectedOptions: [], inputValue: "" });
+    this.setState({ selectedOptions: [], inputValue: '' });
   };
 
   _filterOptions = (value: string) => {
     let filteredOptions = [];
 
-    if (value !== "") {
+    if (value !== '') {
       _.some(this.props.options, (option) => {
         if (_.startsWith(option, value)) {
           filteredOptions.push(option);
@@ -319,10 +319,10 @@ class AutocompleteBase extends Component<Props, State> {
   };
 
   _filterInvalidChars = (value: string) => {
-    let filteredValue = "";
+    let filteredValue = '';
 
     if (this.props.invalidCharsRegex.test(value)) {
-      filteredValue = value.replace(this.props.invalidCharsRegex, "");
+      filteredValue = value.replace(this.props.invalidCharsRegex, '');
     } else {
       filteredValue = value;
     }
@@ -336,7 +336,7 @@ class AutocompleteBase extends Component<Props, State> {
     this.setState({
       isOpen: true,
       inputValue: filteredValue,
-      filteredOptions,
+      filteredOptions
     });
   };
 }

--- a/source/components/Bubble.js
+++ b/source/components/Bubble.js
@@ -1,21 +1,21 @@
 // @flow
-import React, { Component } from "react";
-import type { ComponentType, Element, ElementRef } from "react";
-import createRef from "create-react-ref/lib/createRef";
+import React, { Component } from 'react';
+import type { ComponentType, Element, ElementRef } from 'react';
+import createRef from 'create-react-ref/lib/createRef';
 
 // internal utility functions
-import { createEmptyContext, withTheme } from "./HOC/withTheme";
-import { composeTheme, addThemeId, didThemePropsChange } from "../utils/themes";
-import { addDocumentListeners, removeDocumentListeners } from "../utils/events";
+import { createEmptyContext, withTheme } from './HOC/withTheme';
+import { composeTheme, addThemeId, didThemePropsChange } from '../utils/themes';
+import { addDocumentListeners, removeDocumentListeners } from '../utils/events';
 
 // import constants
-import { IDENTIFIERS } from ".";
-import type { ThemeContextProp } from "./HOC/withTheme";
+import { IDENTIFIERS } from '.';
+import type { ThemeContextProp } from './HOC/withTheme';
 
 export type BubblePosition = {
   width: number,
   positionX: number,
-  positionY: number,
+  positionY: number
 };
 
 export type BubbleProps = {
@@ -32,12 +32,12 @@ export type BubbleProps = {
   theme: ?Object, // takes precedence over them in context if passed
   themeId: string,
   themeOverrides: Object, // custom css/scss from user adhering to component's theme API
-  targetRef?: ElementRef<*>, // ref to the target DOM element used for positioning the bubble
+  targetRef?: ElementRef<*> // ref to the target DOM element used for positioning the bubble
 };
 
 type State = {
   composedTheme: Object,
-  position: ?BubblePosition,
+  position: ?BubblePosition
 };
 
 class BubbleBase extends Component<BubbleProps, State> {
@@ -45,7 +45,7 @@ class BubbleBase extends Component<BubbleProps, State> {
   rootElement: ?Element<any>;
 
   // define static properties
-  static displayName = "Bubble";
+  static displayName = 'Bubble';
   static defaultProps = {
     context: createEmptyContext(),
     isCentered: false,
@@ -57,7 +57,7 @@ class BubbleBase extends Component<BubbleProps, State> {
     noArrow: false,
     theme: null,
     themeId: IDENTIFIERS.BUBBLE,
-    themeOverrides: {},
+    themeOverrides: {}
   };
 
   constructor(props: BubbleProps) {
@@ -74,7 +74,7 @@ class BubbleBase extends Component<BubbleProps, State> {
         addThemeId(themeOverrides, themeId),
         context.ROOT_THEME_API
       ),
-      position: null,
+      position: null
     };
   }
 
@@ -92,9 +92,9 @@ class BubbleBase extends Component<BubbleProps, State> {
     const wasBubbleHidden = !prevProps.isHidden && isHidden;
 
     if (prevProps.isFloating && !isHidden && !this._hasEventListeners) {
-      this._handleScrollEventListener("add");
+      this._handleScrollEventListener('add');
       addDocumentListeners(this._getDocumentEvents());
-      window.addEventListener("resize", this._updatePosition);
+      window.addEventListener('resize', this._updatePosition);
       this._hasEventListeners = true;
     }
     if (wasBubbleHidden) this._removeAllEventListeners();
@@ -117,10 +117,10 @@ class BubbleBase extends Component<BubbleProps, State> {
     if (rootElement) {
       const scrollableNode = this._getFirstScrollableParent(rootElement);
       if (scrollableNode) {
-        if (action === "add") {
-          scrollableNode.addEventListener("scroll", this._updatePosition);
-        } else if (action === "remove") {
-          scrollableNode.removeEventListener("scroll", this._updatePosition);
+        if (action === 'add') {
+          scrollableNode.addEventListener('scroll', this._updatePosition);
+        } else if (action === 'remove') {
+          scrollableNode.removeEventListener('scroll', this._updatePosition);
         }
       }
     }
@@ -129,8 +129,8 @@ class BubbleBase extends Component<BubbleProps, State> {
   _removeAllEventListeners() {
     if (this._hasEventListeners) {
       removeDocumentListeners(this._getDocumentEvents());
-      this._handleScrollEventListener("remove");
-      window.removeEventListener("resize", this._updatePosition);
+      this._handleScrollEventListener('remove');
+      window.removeEventListener('resize', this._updatePosition);
       this._hasEventListeners = false;
     }
   }
@@ -138,7 +138,7 @@ class BubbleBase extends Component<BubbleProps, State> {
   _getFirstScrollableParent = (element: ElementRef<*>) => {
     if (element == null) return null;
     const { rootElement } = this;
-    const node = {}.hasOwnProperty.call(element, "current")
+    const node = {}.hasOwnProperty.call(element, 'current')
       ? element.current
       : element;
 
@@ -159,7 +159,7 @@ class BubbleBase extends Component<BubbleProps, State> {
     const { rootElement } = this;
 
     let target =
-      targetRef && typeof targetRef !== "string" ? targetRef.current : null;
+      targetRef && typeof targetRef !== 'string' ? targetRef.current : null;
 
     // Without a target, try to fallback to the parent node
     if (!target) {
@@ -182,7 +182,7 @@ class BubbleBase extends Component<BubbleProps, State> {
     const position = {
       width: targetRect.width,
       positionX: targetRect.left,
-      positionY,
+      positionY
     };
     this.setState({ position });
   };
@@ -190,7 +190,7 @@ class BubbleBase extends Component<BubbleProps, State> {
   _getDocumentEvents() {
     return {
       resize: this._updatePosition,
-      scroll: this._updatePosition,
+      scroll: this._updatePosition
     };
   }
 

--- a/source/components/Bubble.js
+++ b/source/components/Bubble.js
@@ -1,16 +1,16 @@
 // @flow
-import React, { Component } from 'react';
-import type { ComponentType, Element, ElementRef } from 'react';
-import createRef from 'create-react-ref/lib/createRef';
+import React, { Component } from "react";
+import type { ComponentType, Element, ElementRef } from "react";
+import createRef from "create-react-ref/lib/createRef";
 
 // internal utility functions
-import { createEmptyContext, withTheme } from './HOC/withTheme';
-import { composeTheme, addThemeId, didThemePropsChange } from '../utils/themes';
-import { addDocumentListeners, removeDocumentListeners } from '../utils/events';
+import { createEmptyContext, withTheme } from "./HOC/withTheme";
+import { composeTheme, addThemeId, didThemePropsChange } from "../utils/themes";
+import { addDocumentListeners, removeDocumentListeners } from "../utils/events";
 
 // import constants
-import { IDENTIFIERS } from '.';
-import type { ThemeContextProp } from './HOC/withTheme';
+import { IDENTIFIERS } from ".";
+import type { ThemeContextProp } from "./HOC/withTheme";
 
 export type BubblePosition = {
   width: number,
@@ -37,7 +37,7 @@ export type BubbleProps = {
 
 type State = {
   composedTheme: Object,
-  position: ?BubblePosition
+  position: ?BubblePosition,
 };
 
 class BubbleBase extends Component<BubbleProps, State> {
@@ -45,7 +45,7 @@ class BubbleBase extends Component<BubbleProps, State> {
   rootElement: ?Element<any>;
 
   // define static properties
-  static displayName = 'Bubble';
+  static displayName = "Bubble";
   static defaultProps = {
     context: createEmptyContext(),
     isCentered: false,
@@ -57,7 +57,7 @@ class BubbleBase extends Component<BubbleProps, State> {
     noArrow: false,
     theme: null,
     themeId: IDENTIFIERS.BUBBLE,
-    themeOverrides: {}
+    themeOverrides: {},
   };
 
   constructor(props: BubbleProps) {
@@ -74,7 +74,7 @@ class BubbleBase extends Component<BubbleProps, State> {
         addThemeId(themeOverrides, themeId),
         context.ROOT_THEME_API
       ),
-      position: null
+      position: null,
     };
   }
 
@@ -86,28 +86,23 @@ class BubbleBase extends Component<BubbleProps, State> {
     }, 0);
   }
 
-  componentWillReceiveProps(nextProps: BubbleProps) {
-    didThemePropsChange(this.props, nextProps, this.setState.bind(this));
-  }
-
-  componentWillUpdate(nextProps) {
-    const { isFloating } = this.props;
-    // Add listeners when the bubble
-    if (isFloating && !nextProps.isHidden && !this._hasEventListeners) {
-      this._handleScrollEventListener('add');
-      addDocumentListeners(this._getDocumentEvents());
-      window.addEventListener('resize', this._updatePosition);
-      this._hasEventListeners = true;
-    }
-  }
-
-  componentDidUpdate(prevProps) {
+  componentDidUpdate(prevProps: BubbleProps) {
     const { isHidden } = this.props;
     const didVisibilityChange = isHidden !== prevProps.isHidden;
     const wasBubbleHidden = !prevProps.isHidden && isHidden;
 
+    if (prevProps.isFloating && !isHidden && !this._hasEventListeners) {
+      this._handleScrollEventListener("add");
+      addDocumentListeners(this._getDocumentEvents());
+      window.addEventListener("resize", this._updatePosition);
+      this._hasEventListeners = true;
+    }
     if (wasBubbleHidden) this._removeAllEventListeners();
     if (didVisibilityChange) this._updatePosition();
+
+    if (prevProps !== this.props) {
+      didThemePropsChange(prevProps, this.props, this.setState.bind(this));
+    }
   }
 
   componentWillUnmount() {
@@ -122,10 +117,10 @@ class BubbleBase extends Component<BubbleProps, State> {
     if (rootElement) {
       const scrollableNode = this._getFirstScrollableParent(rootElement);
       if (scrollableNode) {
-        if (action === 'add') {
-          scrollableNode.addEventListener('scroll', this._updatePosition);
-        } else if (action === 'remove') {
-          scrollableNode.removeEventListener('scroll', this._updatePosition);
+        if (action === "add") {
+          scrollableNode.addEventListener("scroll", this._updatePosition);
+        } else if (action === "remove") {
+          scrollableNode.removeEventListener("scroll", this._updatePosition);
         }
       }
     }
@@ -134,8 +129,8 @@ class BubbleBase extends Component<BubbleProps, State> {
   _removeAllEventListeners() {
     if (this._hasEventListeners) {
       removeDocumentListeners(this._getDocumentEvents());
-      this._handleScrollEventListener('remove');
-      window.removeEventListener('resize', this._updatePosition);
+      this._handleScrollEventListener("remove");
+      window.removeEventListener("resize", this._updatePosition);
       this._hasEventListeners = false;
     }
   }
@@ -143,10 +138,15 @@ class BubbleBase extends Component<BubbleProps, State> {
   _getFirstScrollableParent = (element: ElementRef<*>) => {
     if (element == null) return null;
     const { rootElement } = this;
-    const node = {}.hasOwnProperty.call(element, 'current') ? element.current : element;
+    const node = {}.hasOwnProperty.call(element, "current")
+      ? element.current
+      : element;
 
     if (rootElement) {
-      if (node === rootElement.current || node.scrollHeight <= node.clientHeight) {
+      if (
+        node === rootElement.current ||
+        node.scrollHeight <= node.clientHeight
+      ) {
         return this._getFirstScrollableParent(node.parentElement);
       }
     }
@@ -158,7 +158,8 @@ class BubbleBase extends Component<BubbleProps, State> {
     const { isOpeningUpward, targetRef } = this.props;
     const { rootElement } = this;
 
-    let target = targetRef && typeof targetRef !== 'string' ? targetRef.current : null;
+    let target =
+      targetRef && typeof targetRef !== "string" ? targetRef.current : null;
 
     // Without a target, try to fallback to the parent node
     if (!target) {
@@ -181,7 +182,7 @@ class BubbleBase extends Component<BubbleProps, State> {
     const position = {
       width: targetRect.width,
       positionX: targetRect.left,
-      positionY
+      positionY,
     };
     this.setState({ position });
   };
@@ -189,19 +190,13 @@ class BubbleBase extends Component<BubbleProps, State> {
   _getDocumentEvents() {
     return {
       resize: this._updatePosition,
-      scroll: this._updatePosition
+      scroll: this._updatePosition,
     };
   }
 
   render() {
     // destructuring props ensures only the "...rest" get passed down
-    const {
-      skin,
-      theme,
-      themeOverrides,
-      context,
-      ...rest
-    } = this.props;
+    const { skin, theme, themeOverrides, context, ...rest } = this.props;
 
     const BubbleSkin = skin || context.skins[IDENTIFIERS.BUBBLE];
 

--- a/source/components/Button.js
+++ b/source/components/Button.js
@@ -1,14 +1,14 @@
 // @flow
-import React, { Component } from "react";
-import type { ComponentType, Element } from "react";
+import React, { Component } from 'react';
+import type { ComponentType, Element } from 'react';
 
 // internal utility functions
-import { createEmptyContext, withTheme } from "./HOC/withTheme";
-import { composeTheme, addThemeId, didThemePropsChange } from "../utils/themes";
+import { createEmptyContext, withTheme } from './HOC/withTheme';
+import { composeTheme, addThemeId, didThemePropsChange } from '../utils/themes';
 
 // import constants
-import { IDENTIFIERS } from ".";
-import type { ThemeContextProp } from "./HOC/withTheme";
+import { IDENTIFIERS } from '.';
+import type { ThemeContextProp } from './HOC/withTheme';
 
 type Props = {
   className?: string,
@@ -20,22 +20,22 @@ type Props = {
   skin?: ComponentType<any>,
   theme: ?Object, // will take precedence over theme in context if passed
   themeId: string,
-  themeOverrides: Object, // custom css/scss from user that adheres to component's theme API
+  themeOverrides: Object // custom css/scss from user that adheres to component's theme API
 };
 
 type State = {
-  composedTheme: Object,
+  composedTheme: Object
 };
 
 class ButtonBase extends Component<Props, State> {
   // define static properties
-  static displayName = "Button";
+  static displayName = 'Button';
   static defaultProps = {
     context: createEmptyContext(),
     loading: false,
     theme: null,
     themeId: IDENTIFIERS.BUTTON,
-    themeOverrides: {},
+    themeOverrides: {}
   };
 
   constructor(props: Props) {
@@ -48,7 +48,7 @@ class ButtonBase extends Component<Props, State> {
         addThemeId(theme || context.theme, themeId),
         addThemeId(themeOverrides, themeId),
         context.ROOT_THEME_API
-      ),
+      )
     };
   }
 

--- a/source/components/Button.js
+++ b/source/components/Button.js
@@ -1,14 +1,14 @@
 // @flow
-import React, { Component } from 'react';
-import type { ComponentType, Element } from 'react';
+import React, { Component } from "react";
+import type { ComponentType, Element } from "react";
 
 // internal utility functions
-import { createEmptyContext, withTheme } from './HOC/withTheme';
-import { composeTheme, addThemeId, didThemePropsChange } from '../utils/themes';
+import { createEmptyContext, withTheme } from "./HOC/withTheme";
+import { composeTheme, addThemeId, didThemePropsChange } from "../utils/themes";
 
 // import constants
-import { IDENTIFIERS } from '.';
-import type { ThemeContextProp } from './HOC/withTheme';
+import { IDENTIFIERS } from ".";
+import type { ThemeContextProp } from "./HOC/withTheme";
 
 type Props = {
   className?: string,
@@ -20,22 +20,22 @@ type Props = {
   skin?: ComponentType<any>,
   theme: ?Object, // will take precedence over theme in context if passed
   themeId: string,
-  themeOverrides: Object // custom css/scss from user that adheres to component's theme API
+  themeOverrides: Object, // custom css/scss from user that adheres to component's theme API
 };
 
 type State = {
-  composedTheme: Object
+  composedTheme: Object,
 };
 
 class ButtonBase extends Component<Props, State> {
   // define static properties
-  static displayName = 'Button';
+  static displayName = "Button";
   static defaultProps = {
     context: createEmptyContext(),
     loading: false,
     theme: null,
     themeId: IDENTIFIERS.BUTTON,
-    themeOverrides: {}
+    themeOverrides: {},
   };
 
   constructor(props: Props) {
@@ -48,23 +48,19 @@ class ButtonBase extends Component<Props, State> {
         addThemeId(theme || context.theme, themeId),
         addThemeId(themeOverrides, themeId),
         context.ROOT_THEME_API
-      )
+      ),
     };
   }
 
-  componentWillReceiveProps(nextProps: Props) {
-    didThemePropsChange(this.props, nextProps, this.setState.bind(this));
+  componentDidUpdate(prevProps: Props) {
+    if (prevProps !== this.props) {
+      didThemePropsChange(prevProps, this.props, this.setState.bind(this));
+    }
   }
 
   render() {
     // destructuring props ensures only the "...rest" get passed down
-    const {
-      skin,
-      theme,
-      themeOverrides,
-      context,
-      ...rest
-    } = this.props;
+    const { skin, theme, themeOverrides, context, ...rest } = this.props;
 
     const ButtonSkin = skin || context.skins[IDENTIFIERS.BUTTON];
 

--- a/source/components/Checkbox.js
+++ b/source/components/Checkbox.js
@@ -1,14 +1,14 @@
 // @flow
-import React, { Component } from 'react';
-import type { ComponentType, Element } from 'react';
+import React, { Component } from "react";
+import type { ComponentType, Element } from "react";
 
 // internal utility functions
-import { createEmptyContext, withTheme } from './HOC/withTheme';
-import { composeTheme, addThemeId, didThemePropsChange } from '../utils/themes';
+import { createEmptyContext, withTheme } from "./HOC/withTheme";
+import { composeTheme, addThemeId, didThemePropsChange } from "../utils/themes";
 
 // import constants
-import { IDENTIFIERS } from '.';
-import type { ThemeContextProp } from './HOC/withTheme';
+import { IDENTIFIERS } from ".";
+import type { ThemeContextProp } from "./HOC/withTheme";
 
 type Props = {
   checked: boolean,
@@ -24,22 +24,22 @@ type Props = {
   skin?: ComponentType<any>,
   theme: ?Object, // will take precedence over theme in context if passed
   themeId: string,
-  themeOverrides: Object
+  themeOverrides: Object,
 };
 
 type State = {
-  composedTheme: Object
+  composedTheme: Object,
 };
 
 class CheckboxBase extends Component<Props, State> {
   // define static properties
-  static displayName = 'Checkbox';
+  static displayName = "Checkbox";
   static defaultProps = {
     checked: false,
     context: createEmptyContext(),
     theme: null,
     themeId: IDENTIFIERS.CHECKBOX,
-    themeOverrides: {}
+    themeOverrides: {},
   };
 
   constructor(props: Props) {
@@ -52,23 +52,19 @@ class CheckboxBase extends Component<Props, State> {
         addThemeId(theme || context.theme, themeId),
         addThemeId(themeOverrides, themeId),
         context.ROOT_THEME_API
-      )
+      ),
     };
   }
 
-  componentWillReceiveProps(nextProps: Props) {
-    didThemePropsChange(this.props, nextProps, this.setState.bind(this));
+  componentDidUpdate(prevProps: Props) {
+    if (prevProps !== this.props) {
+      didThemePropsChange(prevProps, this.props, this.setState.bind(this));
+    }
   }
 
   render() {
     // destructuring props ensures only the "...rest" get passed down
-    const {
-      skin,
-      theme,
-      themeOverrides,
-      context,
-      ...rest
-    } = this.props;
+    const { skin, theme, themeOverrides, context, ...rest } = this.props;
 
     const CheckboxSkin = skin || context.skins[this.props.themeId];
 

--- a/source/components/Checkbox.js
+++ b/source/components/Checkbox.js
@@ -1,14 +1,14 @@
 // @flow
-import React, { Component } from "react";
-import type { ComponentType, Element } from "react";
+import React, { Component } from 'react';
+import type { ComponentType, Element } from 'react';
 
 // internal utility functions
-import { createEmptyContext, withTheme } from "./HOC/withTheme";
-import { composeTheme, addThemeId, didThemePropsChange } from "../utils/themes";
+import { createEmptyContext, withTheme } from './HOC/withTheme';
+import { composeTheme, addThemeId, didThemePropsChange } from '../utils/themes';
 
 // import constants
-import { IDENTIFIERS } from ".";
-import type { ThemeContextProp } from "./HOC/withTheme";
+import { IDENTIFIERS } from '.';
+import type { ThemeContextProp } from './HOC/withTheme';
 
 type Props = {
   checked: boolean,
@@ -24,22 +24,22 @@ type Props = {
   skin?: ComponentType<any>,
   theme: ?Object, // will take precedence over theme in context if passed
   themeId: string,
-  themeOverrides: Object,
+  themeOverrides: Object
 };
 
 type State = {
-  composedTheme: Object,
+  composedTheme: Object
 };
 
 class CheckboxBase extends Component<Props, State> {
   // define static properties
-  static displayName = "Checkbox";
+  static displayName = 'Checkbox';
   static defaultProps = {
     checked: false,
     context: createEmptyContext(),
     theme: null,
     themeId: IDENTIFIERS.CHECKBOX,
-    themeOverrides: {},
+    themeOverrides: {}
   };
 
   constructor(props: Props) {
@@ -52,7 +52,7 @@ class CheckboxBase extends Component<Props, State> {
         addThemeId(theme || context.theme, themeId),
         addThemeId(themeOverrides, themeId),
         context.ROOT_THEME_API
-      ),
+      )
     };
   }
 

--- a/source/components/Dropdown.js
+++ b/source/components/Dropdown.js
@@ -1,16 +1,16 @@
 // @flow
-import React, { Component } from 'react';
-import type { ComponentType, Element } from 'react';
-import createRef from 'create-react-ref/lib/createRef';
+import React, { Component } from "react";
+import type { ComponentType, Element } from "react";
+import createRef from "create-react-ref/lib/createRef";
 
 // internal utility functions
-import { createEmptyContext, withTheme } from './HOC/withTheme';
-import { composeTheme, addThemeId, didThemePropsChange } from '../utils/themes';
+import { createEmptyContext, withTheme } from "./HOC/withTheme";
+import { composeTheme, addThemeId, didThemePropsChange } from "../utils/themes";
 
 // import constants
-import { IDENTIFIERS } from '.';
-import type { ThemeContextProp } from './HOC/withTheme';
-import { GlobalListeners } from './HOC/GlobalListeners';
+import { IDENTIFIERS } from ".";
+import type { ThemeContextProp } from "./HOC/withTheme";
+import { GlobalListeners } from "./HOC/GlobalListeners";
 
 type Props = {
   activeItem: any,
@@ -43,7 +43,7 @@ class DropdownBase extends Component<Props, State> {
   optionsElement: ?Element<*>;
 
   // define static properties
-  static displayName = 'Dropdown';
+  static displayName = "Dropdown";
   static defaultProps = {
     context: createEmptyContext(),
     clickToOpen: false,
@@ -74,8 +74,10 @@ class DropdownBase extends Component<Props, State> {
     };
   }
 
-  componentWillReceiveProps(nextProps: Props) {
-    didThemePropsChange(this.props, nextProps, this.setState.bind(this));
+  componentDidUpdate(prevProps: Props) {
+    if (prevProps !== this.props) {
+      didThemePropsChange(prevProps, this.props, this.setState.bind(this));
+    }
   }
 
   componentWillUnmount() {
@@ -87,7 +89,9 @@ class DropdownBase extends Component<Props, State> {
   isOpen = () => {
     const { clickToOpen, isOpen } = this.props;
     const { isMouseOverItems, isMouseOverRoot } = this.state;
-    const isOpenBecauseOfHover = clickToOpen ? false : isMouseOverItems || isMouseOverRoot;
+    const isOpenBecauseOfHover = clickToOpen
+      ? false
+      : isMouseOverItems || isMouseOverRoot;
     return isOpen || this.state.isOpen || isOpenBecauseOfHover;
   };
 

--- a/source/components/Dropdown.js
+++ b/source/components/Dropdown.js
@@ -1,16 +1,16 @@
 // @flow
-import React, { Component } from "react";
-import type { ComponentType, Element } from "react";
-import createRef from "create-react-ref/lib/createRef";
+import React, { Component } from 'react';
+import type { ComponentType, Element } from 'react';
+import createRef from 'create-react-ref/lib/createRef';
 
 // internal utility functions
-import { createEmptyContext, withTheme } from "./HOC/withTheme";
-import { composeTheme, addThemeId, didThemePropsChange } from "../utils/themes";
+import { createEmptyContext, withTheme } from './HOC/withTheme';
+import { composeTheme, addThemeId, didThemePropsChange } from '../utils/themes';
 
 // import constants
-import { IDENTIFIERS } from ".";
-import type { ThemeContextProp } from "./HOC/withTheme";
-import { GlobalListeners } from "./HOC/GlobalListeners";
+import { IDENTIFIERS } from '.';
+import type { ThemeContextProp } from './HOC/withTheme';
+import { GlobalListeners } from './HOC/GlobalListeners';
 
 type Props = {
   activeItem: any,
@@ -27,14 +27,14 @@ type Props = {
   skin?: ComponentType<any>,
   theme: ?Object,
   themeId: string,
-  themeOverrides: Object,
+  themeOverrides: Object
 };
 
 type State = {
   composedTheme: Object,
   isMouseOverItems: boolean,
   isMouseOverRoot: boolean,
-  isOpen: boolean,
+  isOpen: boolean
 };
 
 class DropdownBase extends Component<Props, State> {
@@ -43,7 +43,7 @@ class DropdownBase extends Component<Props, State> {
   optionsElement: ?Element<*>;
 
   // define static properties
-  static displayName = "Dropdown";
+  static displayName = 'Dropdown';
   static defaultProps = {
     context: createEmptyContext(),
     clickToOpen: false,
@@ -51,7 +51,7 @@ class DropdownBase extends Component<Props, State> {
     noArrow: false,
     theme: null,
     themeOverrides: {},
-    themeId: IDENTIFIERS.DROPDOWN,
+    themeId: IDENTIFIERS.DROPDOWN
   };
 
   constructor(props: Props) {
@@ -70,7 +70,7 @@ class DropdownBase extends Component<Props, State> {
       ),
       isMouseOverItems: false,
       isMouseOverRoot: false,
-      isOpen: false,
+      isOpen: false
     };
   }
 

--- a/source/components/FormField.js
+++ b/source/components/FormField.js
@@ -1,14 +1,14 @@
 // @flow
-import React, { Component } from 'react';
-import type { ElementRef, ComponentType, Element } from 'react';
+import React, { Component } from "react";
+import type { ElementRef, ComponentType, Element } from "react";
 
 // internal utility functions
-import { createEmptyContext, withTheme } from './HOC/withTheme';
-import { composeTheme, addThemeId, didThemePropsChange } from '../utils/themes';
+import { createEmptyContext, withTheme } from "./HOC/withTheme";
+import { composeTheme, addThemeId, didThemePropsChange } from "../utils/themes";
 
 // import constants
-import { IDENTIFIERS } from '.';
-import type { ThemeContextProp } from './HOC/withTheme';
+import { IDENTIFIERS } from ".";
+import type { ThemeContextProp } from "./HOC/withTheme";
 
 type Props = {
   className?: ?string,
@@ -21,22 +21,22 @@ type Props = {
   skin?: ComponentType<any>,
   theme: ?Object, // will take precedence over theme in context if passed
   themeId: string,
-  themeOverrides: Object
+  themeOverrides: Object,
 };
 
 type State = {
   error: string,
-  composedTheme: Object
+  composedTheme: Object,
 };
 
 class FormFieldBase extends Component<Props, State> {
   // define static properties
-  static displayName = 'FormField';
+  static displayName = "FormField";
   static defaultProps = {
     context: createEmptyContext(),
     theme: null,
     themeId: IDENTIFIERS.FORM_FIELD,
-    themeOverrides: {}
+    themeOverrides: {},
   };
 
   constructor(props: Props) {
@@ -45,17 +45,19 @@ class FormFieldBase extends Component<Props, State> {
     const { context, themeId, theme, themeOverrides } = props;
 
     this.state = {
-      error: '',
+      error: "",
       composedTheme: composeTheme(
         addThemeId(theme || context.theme, themeId),
         addThemeId(themeOverrides, themeId),
         context.ROOT_THEME_API
-      )
+      ),
     };
   }
 
-  componentWillReceiveProps(nextProps: Props) {
-    didThemePropsChange(this.props, nextProps, this.setState.bind(this));
+  componentDidUpdate(prevProps: Props) {
+    if (prevProps !== this.props) {
+      didThemePropsChange(prevProps, this.props, this.setState.bind(this));
+    }
   }
 
   setError = (error: string) => this.setState({ error });
@@ -63,7 +65,8 @@ class FormFieldBase extends Component<Props, State> {
   focusChild = () => {
     const { inputRef } = this.props;
     if (inputRef && inputRef.current) {
-      if (typeof inputRef.current.focus === 'function') inputRef.current.focus();
+      if (typeof inputRef.current.focus === "function")
+        inputRef.current.focus();
     }
   };
 

--- a/source/components/FormField.js
+++ b/source/components/FormField.js
@@ -1,14 +1,14 @@
 // @flow
-import React, { Component } from "react";
-import type { ElementRef, ComponentType, Element } from "react";
+import React, { Component } from 'react';
+import type { ElementRef, ComponentType, Element } from 'react';
 
 // internal utility functions
-import { createEmptyContext, withTheme } from "./HOC/withTheme";
-import { composeTheme, addThemeId, didThemePropsChange } from "../utils/themes";
+import { createEmptyContext, withTheme } from './HOC/withTheme';
+import { composeTheme, addThemeId, didThemePropsChange } from '../utils/themes';
 
 // import constants
-import { IDENTIFIERS } from ".";
-import type { ThemeContextProp } from "./HOC/withTheme";
+import { IDENTIFIERS } from '.';
+import type { ThemeContextProp } from './HOC/withTheme';
 
 type Props = {
   className?: ?string,
@@ -21,22 +21,22 @@ type Props = {
   skin?: ComponentType<any>,
   theme: ?Object, // will take precedence over theme in context if passed
   themeId: string,
-  themeOverrides: Object,
+  themeOverrides: Object
 };
 
 type State = {
   error: string,
-  composedTheme: Object,
+  composedTheme: Object
 };
 
 class FormFieldBase extends Component<Props, State> {
   // define static properties
-  static displayName = "FormField";
+  static displayName = 'FormField';
   static defaultProps = {
     context: createEmptyContext(),
     theme: null,
     themeId: IDENTIFIERS.FORM_FIELD,
-    themeOverrides: {},
+    themeOverrides: {}
   };
 
   constructor(props: Props) {
@@ -45,12 +45,12 @@ class FormFieldBase extends Component<Props, State> {
     const { context, themeId, theme, themeOverrides } = props;
 
     this.state = {
-      error: "",
+      error: '',
       composedTheme: composeTheme(
         addThemeId(theme || context.theme, themeId),
         addThemeId(themeOverrides, themeId),
         context.ROOT_THEME_API
-      ),
+      )
     };
   }
 
@@ -65,7 +65,7 @@ class FormFieldBase extends Component<Props, State> {
   focusChild = () => {
     const { inputRef } = this.props;
     if (inputRef && inputRef.current) {
-      if (typeof inputRef.current.focus === "function")
+      if (typeof inputRef.current.focus === 'function')
         inputRef.current.focus();
     }
   };

--- a/source/components/HOC/GlobalListeners.js
+++ b/source/components/HOC/GlobalListeners.js
@@ -1,16 +1,16 @@
 // @flow
-import React, { Component, Fragment } from 'react';
+import React, { Component, Fragment } from "react";
 // $FlowFixMe
-import type { SyntheticMouseEvent, ElementRef } from 'react';
-import { debounce } from 'lodash';
+import type { SyntheticMouseEvent, ElementRef } from "react";
+import { debounce } from "lodash";
 
 import {
   addDocumentListeners,
   addWindowListeners,
   removeDocumentListeners,
   removeWindowListeners,
-  targetIsDescendant
-} from '../../utils/events';
+  targetIsDescendant,
+} from "../../utils/events";
 
 type Props = {
   children: Function,
@@ -21,49 +21,50 @@ type Props = {
   optionsRef?: ElementRef<*>,
   optionRenderer?: Function,
   rootRef?: ElementRef<*>,
-  toggleOpen: Function
+  toggleOpen: Function,
 };
 
 type State = {
-  optionsMaxHeight: number
+  optionsMaxHeight: number,
 };
 
 export class GlobalListeners extends Component<Props, State> {
   // define static properties
-  static displayName = 'GlobalListeners';
+  static displayName = "GlobalListeners";
   static defaultProps = {
-    optionsIsOpen: false
+    optionsIsOpen: false,
   };
 
   constructor(props: Props) {
     super(props);
 
     this.state = {
-      optionsMaxHeight: 300
+      optionsMaxHeight: 300,
     };
   }
 
   componentDidMount() {
-    if (this.props.optionsIsOpen) { return; }
+    if (this.props.optionsIsOpen) {
+      return;
+    }
     // adds scroll and resize event listeners for calculating Options max-height
     this._addCalculateMaxHeightListeners();
     // runs initial Options max-height calculation
     this._calculateOptionsMaxHeight();
   }
 
-  componentWillReceiveProps(nextProps: Props) {
+  componentDidUpdate(prevProps: Props) {
     const { optionsIsOpen } = this.props;
 
     // if Options is transferring from closed to open, add listeners
     // if Options is transferring from open to closed, remove listeners
-    if (!optionsIsOpen && nextProps.optionsIsOpen) {
+    if (!prevProps.optionsIsOpen && optionsIsOpen) {
       // first remove max-height calc handler on scroll and resize
       // then add toggle handler on scroll and resize
       this._removeGlobalListeners();
       addWindowListeners(this._getWindowListeners());
       addDocumentListeners(this._getDocumentListeners());
-
-    } else if (optionsIsOpen && !nextProps.optionsIsOpen) {
+    } else if (prevProps.optionsIsOpen && !optionsIsOpen) {
       // remove toggle handler on scroll and resize
       // then add calc max-height calc handler on scroll and resize
       this._removeGlobalListeners();
@@ -88,28 +89,34 @@ export class GlobalListeners extends Component<Props, State> {
     this._removeGlobalListeners();
 
     // before toggle, ensure options is open and optionsRef exists on DOM
-    if (!optionsIsOpen || !optionsRef || !optionsRef.current) { return; }
+    if (!optionsIsOpen || !optionsRef || !optionsRef.current) {
+      return;
+    }
     this.props.toggleOpen();
   };
 
   _getDocumentListeners = () => ({
     click: this._handleDocumentClick,
-    scroll: this._handleDocumentScroll
+    scroll: this._handleDocumentScroll,
   });
 
   _getWindowListeners = () => ({
-    resize: this._handleWindowResize
+    resize: this._handleWindowResize,
   });
 
   _handleDocumentClick = (event: SyntheticMouseEvent<>) => {
     const { optionsIsOpen, rootRef } = this.props;
 
     // ensure Options is open
-    if (!optionsIsOpen || !rootRef || !rootRef.current) { return; }
+    if (!optionsIsOpen || !rootRef || !rootRef.current) {
+      return;
+    }
 
     // return early if the user clicked an element within the parent component
     // for example, the parent component could be Autocomplete or Select
-    if (targetIsDescendant(event, rootRef.current)) { return; }
+    if (targetIsDescendant(event, rootRef.current)) {
+      return;
+    }
 
     // otherwise, remove all listeners and close Options
     this._removeListenersAndToggle();
@@ -120,8 +127,15 @@ export class GlobalListeners extends Component<Props, State> {
   _handleDocumentScroll = () => this._removeListenersAndToggle();
 
   _addCalculateMaxHeightListeners = () => {
-    const scrollListener = ['scroll', debounce(this._calculateOptionsMaxHeight, 300, { leading: true }), true];
-    const resizeListener = ['resize', debounce(this._calculateOptionsMaxHeight, 300)];
+    const scrollListener = [
+      "scroll",
+      debounce(this._calculateOptionsMaxHeight, 300, { leading: true }),
+      true,
+    ];
+    const resizeListener = [
+      "resize",
+      debounce(this._calculateOptionsMaxHeight, 300),
+    ];
     document.addEventListener(...scrollListener);
     window.addEventListener(...resizeListener);
   };
@@ -143,7 +157,12 @@ export class GlobalListeners extends Component<Props, State> {
     // checks if Options are open & being scrolled upon via mouse position prior to toggling closed
     const isOptionsInDOM = optionsRef && optionsRef.current;
     const doDocumentStylesExist = documentElement && documentElement.style;
-    if (!rootRef || !rootRef.current || !doDocumentStylesExist || !isOptionsInDOM) {
+    if (
+      !rootRef ||
+      !rootRef.current ||
+      !doDocumentStylesExist ||
+      !isOptionsInDOM
+    ) {
       return;
     }
     optionsIsOpen && !mouseIsOverOptions && !mouseIsOverRoot && toggleOpen();

--- a/source/components/HOC/GlobalListeners.js
+++ b/source/components/HOC/GlobalListeners.js
@@ -1,16 +1,16 @@
 // @flow
-import React, { Component, Fragment } from "react";
+import React, { Component, Fragment } from 'react';
 // $FlowFixMe
-import type { SyntheticMouseEvent, ElementRef } from "react";
-import { debounce } from "lodash";
+import type { SyntheticMouseEvent, ElementRef } from 'react';
+import { debounce } from 'lodash';
 
 import {
   addDocumentListeners,
   addWindowListeners,
   removeDocumentListeners,
   removeWindowListeners,
-  targetIsDescendant,
-} from "../../utils/events";
+  targetIsDescendant
+} from '../../utils/events';
 
 type Props = {
   children: Function,
@@ -21,25 +21,25 @@ type Props = {
   optionsRef?: ElementRef<*>,
   optionRenderer?: Function,
   rootRef?: ElementRef<*>,
-  toggleOpen: Function,
+  toggleOpen: Function
 };
 
 type State = {
-  optionsMaxHeight: number,
+  optionsMaxHeight: number
 };
 
 export class GlobalListeners extends Component<Props, State> {
   // define static properties
-  static displayName = "GlobalListeners";
+  static displayName = 'GlobalListeners';
   static defaultProps = {
-    optionsIsOpen: false,
+    optionsIsOpen: false
   };
 
   constructor(props: Props) {
     super(props);
 
     this.state = {
-      optionsMaxHeight: 300,
+      optionsMaxHeight: 300
     };
   }
 
@@ -97,11 +97,11 @@ export class GlobalListeners extends Component<Props, State> {
 
   _getDocumentListeners = () => ({
     click: this._handleDocumentClick,
-    scroll: this._handleDocumentScroll,
+    scroll: this._handleDocumentScroll
   });
 
   _getWindowListeners = () => ({
-    resize: this._handleWindowResize,
+    resize: this._handleWindowResize
   });
 
   _handleDocumentClick = (event: SyntheticMouseEvent<>) => {
@@ -128,13 +128,13 @@ export class GlobalListeners extends Component<Props, State> {
 
   _addCalculateMaxHeightListeners = () => {
     const scrollListener = [
-      "scroll",
+      'scroll',
       debounce(this._calculateOptionsMaxHeight, 300, { leading: true }),
-      true,
+      true
     ];
     const resizeListener = [
-      "resize",
-      debounce(this._calculateOptionsMaxHeight, 300),
+      'resize',
+      debounce(this._calculateOptionsMaxHeight, 300)
     ];
     document.addEventListener(...scrollListener);
     window.addEventListener(...resizeListener);
@@ -151,7 +151,7 @@ export class GlobalListeners extends Component<Props, State> {
       optionsRef,
       toggleOpen,
       mouseIsOverOptions,
-      mouseIsOverRoot,
+      mouseIsOverRoot
     } = this.props;
 
     // checks if Options are open & being scrolled upon via mouse position prior to toggling closed

--- a/source/components/Header.js
+++ b/source/components/Header.js
@@ -1,15 +1,15 @@
 // @flow
-import React, { Component } from "react";
-import type { ComponentType, Node } from "react";
-import { pickBy, isEmpty } from "lodash";
+import React, { Component } from 'react';
+import type { ComponentType, Node } from 'react';
+import { pickBy, isEmpty } from 'lodash';
 
 // utility functions
-import { createEmptyContext, withTheme } from "./HOC/withTheme";
-import { composeTheme, addThemeId, didThemePropsChange } from "../utils/themes";
+import { createEmptyContext, withTheme } from './HOC/withTheme';
+import { composeTheme, addThemeId, didThemePropsChange } from '../utils/themes';
 
 // constants
-import { IDENTIFIERS } from ".";
-import type { ThemeContextProp } from "./HOC/withTheme";
+import { IDENTIFIERS } from '.';
+import type { ThemeContextProp } from './HOC/withTheme';
 
 type Props = {
   bold?: boolean,
@@ -32,19 +32,19 @@ type Props = {
   themeId: string,
   themeOverrides: Object,
   thin?: boolean,
-  upperCase?: boolean,
+  upperCase?: boolean
 };
 
 type State = { composedTheme: Object };
 
 class HeaderBase extends Component<Props, State> {
   // define static properties
-  static displayName = "Header";
+  static displayName = 'Header';
   static defaultProps = {
     context: createEmptyContext(),
     theme: null,
     themeId: IDENTIFIERS.HEADER,
-    themeOverrides: {},
+    themeOverrides: {}
   };
 
   constructor(props: Props) {
@@ -57,7 +57,7 @@ class HeaderBase extends Component<Props, State> {
         addThemeId(theme || context.theme, themeId),
         addThemeId(themeOverrides, themeId),
         context.ROOT_THEME_API
-      ),
+      )
     };
   }
 
@@ -114,7 +114,7 @@ class HeaderBase extends Component<Props, State> {
   };
 
   _getActiveClasses = (styleProps: Object) => {
-    const activeClasses = ["header"];
+    const activeClasses = ['header'];
     const activeTheme = this._getActiveTheme(styleProps);
     const activeFont = this._getActiveFont(styleProps);
 

--- a/source/components/Header.js
+++ b/source/components/Header.js
@@ -1,15 +1,15 @@
 // @flow
-import React, { Component } from 'react';
-import type { ComponentType, Node } from 'react';
-import { pickBy, isEmpty } from 'lodash';
+import React, { Component } from "react";
+import type { ComponentType, Node } from "react";
+import { pickBy, isEmpty } from "lodash";
 
 // utility functions
-import { createEmptyContext, withTheme } from './HOC/withTheme';
-import { composeTheme, addThemeId, didThemePropsChange } from '../utils/themes';
+import { createEmptyContext, withTheme } from "./HOC/withTheme";
+import { composeTheme, addThemeId, didThemePropsChange } from "../utils/themes";
 
 // constants
-import { IDENTIFIERS } from '.';
-import type { ThemeContextProp } from './HOC/withTheme';
+import { IDENTIFIERS } from ".";
+import type { ThemeContextProp } from "./HOC/withTheme";
 
 type Props = {
   bold?: boolean,
@@ -32,19 +32,19 @@ type Props = {
   themeId: string,
   themeOverrides: Object,
   thin?: boolean,
-  upperCase?: boolean
+  upperCase?: boolean,
 };
 
 type State = { composedTheme: Object };
 
-class HeaderBase extends Component <Props, State> {
+class HeaderBase extends Component<Props, State> {
   // define static properties
-  static displayName = 'Header';
+  static displayName = "Header";
   static defaultProps = {
     context: createEmptyContext(),
     theme: null,
     themeId: IDENTIFIERS.HEADER,
-    themeOverrides: {}
+    themeOverrides: {},
   };
 
   constructor(props: Props) {
@@ -57,12 +57,14 @@ class HeaderBase extends Component <Props, State> {
         addThemeId(theme || context.theme, themeId),
         addThemeId(themeOverrides, themeId),
         context.ROOT_THEME_API
-      )
+      ),
     };
   }
 
-  componentWillReceiveProps(nextProps: Props) {
-    didThemePropsChange(this.props, nextProps, this.setState.bind(this));
+  componentDidUpdate(prevProps: Props) {
+    if (prevProps !== this.props) {
+      didThemePropsChange(prevProps, this.props, this.setState.bind(this));
+    }
   }
 
   _assembleInlineStyles = ({ center, lowerCase, left, right, upperCase }) => {
@@ -95,27 +97,35 @@ class HeaderBase extends Component <Props, State> {
 
   _getActiveFont = ({ light, medium, regular, thin, bold }) => {
     const fontProps = pickBy({ light, medium, regular, thin, bold });
-    if (isEmpty(fontProps)) { return; }
+    if (isEmpty(fontProps)) {
+      return;
+    }
     // returns the first active font if more than 1 is passed
     return Object.keys(fontProps)[0];
   };
 
   _getActiveTheme = ({ h1, h2, h3, h4 }) => {
     const themeProps = pickBy({ h1, h2, h3, h4 });
-    if (isEmpty(themeProps)) { return; }
+    if (isEmpty(themeProps)) {
+      return;
+    }
     // returns the first active theme if more than 1 is passed
     return Object.keys(themeProps)[0];
   };
 
   _getActiveClasses = (styleProps: Object) => {
-    const activeClasses = ['header'];
+    const activeClasses = ["header"];
     const activeTheme = this._getActiveTheme(styleProps);
     const activeFont = this._getActiveFont(styleProps);
 
-    if (activeTheme) { return [...activeClasses, activeTheme]; }
-    if (activeFont) { return [...activeClasses, activeFont]; }
+    if (activeTheme) {
+      return [...activeClasses, activeTheme];
+    }
+    if (activeFont) {
+      return [...activeClasses, activeFont];
+    }
 
-    return [...activeClasses, activeTheme, activeFont].filter(val => val);
+    return [...activeClasses, activeTheme, activeFont].filter((val) => val);
   };
 
   render() {

--- a/source/components/InfiniteScroll.js
+++ b/source/components/InfiniteScroll.js
@@ -1,17 +1,17 @@
 // @flow
-import React, { Component } from 'react';
-import type { ComponentType, Node } from 'react';
+import React, { Component } from "react";
+import type { ComponentType, Node } from "react";
 // $FlowFixMe
-import createRef from 'create-react-ref/lib/createRef';
+import createRef from "create-react-ref/lib/createRef";
 
 // utilities
-import { createEmptyContext, withTheme } from './HOC/withTheme';
-import { composeTheme, addThemeId, didThemePropsChange } from '../utils/themes';
+import { createEmptyContext, withTheme } from "./HOC/withTheme";
+import { composeTheme, addThemeId, didThemePropsChange } from "../utils/themes";
 
 // constants
-import { IDENTIFIERS } from '.';
-import type { ReactElementRef } from '../utils/types.js';
-import type { ThemeContextProp } from './HOC/withTheme';
+import { IDENTIFIERS } from ".";
+import type { ReactElementRef } from "../utils/types.js";
+import type { ThemeContextProp } from "./HOC/withTheme";
 
 type Props = {
   className?: string,
@@ -22,7 +22,7 @@ type Props = {
   theme: ?Object, // will take precedence over theme in context if passed
   themeId: string,
   themeOverrides: Object,
-  threshold: number
+  threshold: number,
 };
 
 type State = {
@@ -30,7 +30,7 @@ type State = {
   data: Object | Array<{}>,
   error: boolean | string | Node,
   hasMoreData: boolean,
-  isLoading: boolean
+  isLoading: boolean,
 };
 
 class InfiniteScrollBase extends Component<Props, State> {
@@ -38,14 +38,14 @@ class InfiniteScrollBase extends Component<Props, State> {
   scrollContainer: ReactElementRef<typeof HTMLElement>;
 
   // define static properties
-  static displayName = 'InfiniteScroll';
+  static displayName = "InfiniteScroll";
   static defaultProps = {
     context: createEmptyContext(),
     fetchData() {},
     theme: null,
     themeId: IDENTIFIERS.INFINITE_SCROLL,
     themeOverrides: {},
-    threshold: 250
+    threshold: 250,
   };
 
   constructor(props: Props) {
@@ -64,39 +64,44 @@ class InfiniteScrollBase extends Component<Props, State> {
       data: [],
       error: false,
       isLoading: false,
-      hasMoreData: true
+      hasMoreData: true,
     };
-  }
-
-  componentWillMount() {
-    this._handleFetchData();
   }
 
   componentDidMount() {
     const { scrollContainer } = this;
+
+    this._handleFetchData();
     if (!scrollContainer.current) return;
-    scrollContainer.current.addEventListener('scroll', this._handleScroll);
+    scrollContainer.current.addEventListener("scroll", this._handleScroll);
   }
 
-  componentWillReceiveProps(nextProps: Props) {
-    didThemePropsChange(this.props, nextProps, this.setState.bind(this));
+  componentDidUpdate(prevProps: Props) {
+    if (prevProps !== this.props) {
+      didThemePropsChange(prevProps, this.props, this.setState.bind(this));
+    }
   }
 
   // calls user's fetchData function from props
-  _handleFetchData = () => this.props.fetchData(this.setState.bind(this))
+  _handleFetchData = () => this.props.fetchData(this.setState.bind(this));
 
   // scroll event listener attached to scrollContainer element
   _handleScroll = () => {
     const { error, isLoading, hasMoreData } = this.state;
 
     // return early for error, loading, or lack of future data
-    if (error || isLoading || !hasMoreData) { return; }
+    if (error || isLoading || !hasMoreData) {
+      return;
+    }
     return this._checkForScrollBottom();
   };
 
   // prevents new data fetch until user has scrolled near bottom of existing data
   _checkForScrollBottom = () => {
-    const { scrollContainer, props: { threshold } } = this;
+    const {
+      scrollContainer,
+      props: { threshold },
+    } = this;
     if (!scrollContainer.current) return;
     const { offsetHeight, scrollTop, scrollHeight } = scrollContainer.current;
 
@@ -105,29 +110,21 @@ class InfiniteScrollBase extends Component<Props, State> {
     }
   };
 
-  _isFunction = (renderProp: ?Function) => (renderProp && typeof renderProp === 'function')
+  _isFunction = (renderProp: ?Function) =>
+    renderProp && typeof renderProp === "function";
 
   render() {
     const {
-      props: {
-        className,
-        context,
-        renderItems,
-        skin,
-        themeId
-      },
-      state: {
-        composedTheme,
-        data,
-        error,
-        hasMoreData,
-        isLoading
-      },
-      scrollContainer
+      props: { className, context, renderItems, skin, themeId },
+      state: { composedTheme, data, error, hasMoreData, isLoading },
+      scrollContainer,
     } = this;
 
-    if (!this._isFunction(renderItems)) { return null; }
-    const InfiniteScrollSkin = skin || context.skins[IDENTIFIERS.INFINITE_SCROLL];
+    if (!this._isFunction(renderItems)) {
+      return null;
+    }
+    const InfiniteScrollSkin =
+      skin || context.skins[IDENTIFIERS.INFINITE_SCROLL];
 
     return (
       <InfiniteScrollSkin

--- a/source/components/InfiniteScroll.js
+++ b/source/components/InfiniteScroll.js
@@ -1,17 +1,17 @@
 // @flow
-import React, { Component } from "react";
-import type { ComponentType, Node } from "react";
+import React, { Component } from 'react';
+import type { ComponentType, Node } from 'react';
 // $FlowFixMe
-import createRef from "create-react-ref/lib/createRef";
+import createRef from 'create-react-ref/lib/createRef';
 
 // utilities
-import { createEmptyContext, withTheme } from "./HOC/withTheme";
-import { composeTheme, addThemeId, didThemePropsChange } from "../utils/themes";
+import { createEmptyContext, withTheme } from './HOC/withTheme';
+import { composeTheme, addThemeId, didThemePropsChange } from '../utils/themes';
 
 // constants
-import { IDENTIFIERS } from ".";
-import type { ReactElementRef } from "../utils/types.js";
-import type { ThemeContextProp } from "./HOC/withTheme";
+import { IDENTIFIERS } from '.';
+import type { ReactElementRef } from '../utils/types.js';
+import type { ThemeContextProp } from './HOC/withTheme';
 
 type Props = {
   className?: string,
@@ -22,7 +22,7 @@ type Props = {
   theme: ?Object, // will take precedence over theme in context if passed
   themeId: string,
   themeOverrides: Object,
-  threshold: number,
+  threshold: number
 };
 
 type State = {
@@ -30,7 +30,7 @@ type State = {
   data: Object | Array<{}>,
   error: boolean | string | Node,
   hasMoreData: boolean,
-  isLoading: boolean,
+  isLoading: boolean
 };
 
 class InfiniteScrollBase extends Component<Props, State> {
@@ -38,14 +38,14 @@ class InfiniteScrollBase extends Component<Props, State> {
   scrollContainer: ReactElementRef<typeof HTMLElement>;
 
   // define static properties
-  static displayName = "InfiniteScroll";
+  static displayName = 'InfiniteScroll';
   static defaultProps = {
     context: createEmptyContext(),
     fetchData() {},
     theme: null,
     themeId: IDENTIFIERS.INFINITE_SCROLL,
     themeOverrides: {},
-    threshold: 250,
+    threshold: 250
   };
 
   constructor(props: Props) {
@@ -64,7 +64,7 @@ class InfiniteScrollBase extends Component<Props, State> {
       data: [],
       error: false,
       isLoading: false,
-      hasMoreData: true,
+      hasMoreData: true
     };
   }
 
@@ -73,7 +73,7 @@ class InfiniteScrollBase extends Component<Props, State> {
 
     this._handleFetchData();
     if (!scrollContainer.current) return;
-    scrollContainer.current.addEventListener("scroll", this._handleScroll);
+    scrollContainer.current.addEventListener('scroll', this._handleScroll);
   }
 
   componentDidUpdate(prevProps: Props) {
@@ -100,7 +100,7 @@ class InfiniteScrollBase extends Component<Props, State> {
   _checkForScrollBottom = () => {
     const {
       scrollContainer,
-      props: { threshold },
+      props: { threshold }
     } = this;
     if (!scrollContainer.current) return;
     const { offsetHeight, scrollTop, scrollHeight } = scrollContainer.current;
@@ -111,13 +111,13 @@ class InfiniteScrollBase extends Component<Props, State> {
   };
 
   _isFunction = (renderProp: ?Function) =>
-    renderProp && typeof renderProp === "function";
+    renderProp && typeof renderProp === 'function';
 
   render() {
     const {
       props: { className, context, renderItems, skin, themeId },
       state: { composedTheme, data, error, hasMoreData, isLoading },
-      scrollContainer,
+      scrollContainer
     } = this;
 
     if (!this._isFunction(renderItems)) {

--- a/source/components/Input.js
+++ b/source/components/Input.js
@@ -1,19 +1,19 @@
 // @flow
-import React, { Component } from 'react';
+import React, { Component } from "react";
 // $FlowFixMe
-import type { ComponentType, Element, SyntheticInputEvent } from 'react';
+import type { ComponentType, Element, SyntheticInputEvent } from "react";
 
 // external libraries
-import createRef from 'create-react-ref/lib/createRef';
-import { isString, flow } from 'lodash';
+import createRef from "create-react-ref/lib/createRef";
+import { isString, flow } from "lodash";
 
 // utilities
-import { createEmptyContext, withTheme } from './HOC/withTheme';
-import { composeTheme, addThemeId, didThemePropsChange } from '../utils/themes';
+import { createEmptyContext, withTheme } from "./HOC/withTheme";
+import { composeTheme, addThemeId, didThemePropsChange } from "../utils/themes";
 
 // constants
-import { IDENTIFIERS } from '.';
-import type { ThemeContextProp } from './HOC/withTheme';
+import { IDENTIFIERS } from ".";
+import type { ThemeContextProp } from "./HOC/withTheme";
 
 type Props = {
   autoFocus: boolean,
@@ -37,29 +37,29 @@ type Props = {
   theme: ?Object, // will take precedence over theme in context if passed
   themeId: string,
   themeOverrides: Object,
-  value: string
+  value: string,
 };
 
 type State = {
   error: string,
-  composedTheme: Object
+  composedTheme: Object,
 };
 
 class InputBase extends Component<Props, State> {
   // declare ref types
-  inputElement: Element<'input'>;
+  inputElement: Element<"input">;
 
   // define static properties
-  static displayName = 'Input';
+  static displayName = "Input";
   static defaultProps = {
     autoFocus: false,
     context: createEmptyContext(),
-    error: '',
+    error: "",
     readOnly: false,
     theme: null,
     themeId: IDENTIFIERS.INPUT,
     themeOverrides: {},
-    value: ''
+    value: "",
   };
 
   constructor(props: Props) {
@@ -76,7 +76,7 @@ class InputBase extends Component<Props, State> {
         addThemeId(themeOverrides, themeId),
         context.ROOT_THEME_API
       ),
-      error: ''
+      error: "",
     };
   }
 
@@ -84,11 +84,13 @@ class InputBase extends Component<Props, State> {
     if (this.props.autoFocus) this.focus();
   }
 
-  componentWillReceiveProps(nextProps: Props) {
-    didThemePropsChange(this.props, nextProps, this.setState.bind(this));
+  componentDidUpdate(prevProps: Props) {
+    if (prevProps !== this.props) {
+      didThemePropsChange(prevProps, this.props, this.setState.bind(this));
+    }
   }
 
-  onChange = (event: SyntheticInputEvent<Element<'input'>>) => {
+  onChange = (event: SyntheticInputEvent<Element<"input">>) => {
     const { onChange, disabled } = this.props;
     if (disabled) return;
 
@@ -116,13 +118,13 @@ class InputBase extends Component<Props, State> {
     return flow([
       this._enforceStringValue,
       this._enforceMaxLength,
-      this._enforceMinLength
+      this._enforceMinLength,
     ]).call(this, value);
   }
 
   _enforceStringValue(value) {
     if (!isString(value)) {
-      throw new Error('Values passed to Input::onChange must be strings');
+      throw new Error("Values passed to Input::onChange must be strings");
     }
     return value;
   }
@@ -138,9 +140,9 @@ class InputBase extends Component<Props, State> {
     const isTooShort = minLength != null && value.length < minLength;
 
     if (isTooShort) {
-      this._setError('Please enter a valid input');
-    } else if (this.state.error !== '') {
-      this._setError('');
+      this._setError("Please enter a valid input");
+    } else if (this.state.error !== "") {
+      this._setError("");
     }
 
     return value;

--- a/source/components/Input.js
+++ b/source/components/Input.js
@@ -1,19 +1,19 @@
 // @flow
-import React, { Component } from "react";
+import React, { Component } from 'react';
 // $FlowFixMe
-import type { ComponentType, Element, SyntheticInputEvent } from "react";
+import type { ComponentType, Element, SyntheticInputEvent } from 'react';
 
 // external libraries
-import createRef from "create-react-ref/lib/createRef";
-import { isString, flow } from "lodash";
+import createRef from 'create-react-ref/lib/createRef';
+import { isString, flow } from 'lodash';
 
 // utilities
-import { createEmptyContext, withTheme } from "./HOC/withTheme";
-import { composeTheme, addThemeId, didThemePropsChange } from "../utils/themes";
+import { createEmptyContext, withTheme } from './HOC/withTheme';
+import { composeTheme, addThemeId, didThemePropsChange } from '../utils/themes';
 
 // constants
-import { IDENTIFIERS } from ".";
-import type { ThemeContextProp } from "./HOC/withTheme";
+import { IDENTIFIERS } from '.';
+import type { ThemeContextProp } from './HOC/withTheme';
 
 type Props = {
   autoFocus: boolean,
@@ -37,29 +37,29 @@ type Props = {
   theme: ?Object, // will take precedence over theme in context if passed
   themeId: string,
   themeOverrides: Object,
-  value: string,
+  value: string
 };
 
 type State = {
   error: string,
-  composedTheme: Object,
+  composedTheme: Object
 };
 
 class InputBase extends Component<Props, State> {
   // declare ref types
-  inputElement: Element<"input">;
+  inputElement: Element<'input'>;
 
   // define static properties
-  static displayName = "Input";
+  static displayName = 'Input';
   static defaultProps = {
     autoFocus: false,
     context: createEmptyContext(),
-    error: "",
+    error: '',
     readOnly: false,
     theme: null,
     themeId: IDENTIFIERS.INPUT,
     themeOverrides: {},
-    value: "",
+    value: ''
   };
 
   constructor(props: Props) {
@@ -76,7 +76,7 @@ class InputBase extends Component<Props, State> {
         addThemeId(themeOverrides, themeId),
         context.ROOT_THEME_API
       ),
-      error: "",
+      error: ''
     };
   }
 
@@ -90,7 +90,7 @@ class InputBase extends Component<Props, State> {
     }
   }
 
-  onChange = (event: SyntheticInputEvent<Element<"input">>) => {
+  onChange = (event: SyntheticInputEvent<Element<'input'>>) => {
     const { onChange, disabled } = this.props;
     if (disabled) return;
 
@@ -118,13 +118,13 @@ class InputBase extends Component<Props, State> {
     return flow([
       this._enforceStringValue,
       this._enforceMaxLength,
-      this._enforceMinLength,
+      this._enforceMinLength
     ]).call(this, value);
   }
 
   _enforceStringValue(value) {
     if (!isString(value)) {
-      throw new Error("Values passed to Input::onChange must be strings");
+      throw new Error('Values passed to Input::onChange must be strings');
     }
     return value;
   }
@@ -140,9 +140,9 @@ class InputBase extends Component<Props, State> {
     const isTooShort = minLength != null && value.length < minLength;
 
     if (isTooShort) {
-      this._setError("Please enter a valid input");
-    } else if (this.state.error !== "") {
-      this._setError("");
+      this._setError('Please enter a valid input');
+    } else if (this.state.error !== '') {
+      this._setError('');
     }
 
     return value;

--- a/source/components/Link.js
+++ b/source/components/Link.js
@@ -1,14 +1,14 @@
 // @flow
-import React, { Component } from 'react';
-import type { ComponentType } from 'react';
+import React, { Component } from "react";
+import type { ComponentType } from "react";
 
 // internal utility functions
-import { createEmptyContext, withTheme } from './HOC/withTheme';
-import { composeTheme, addThemeId, didThemePropsChange } from '../utils/themes';
+import { createEmptyContext, withTheme } from "./HOC/withTheme";
+import { composeTheme, addThemeId, didThemePropsChange } from "../utils/themes";
 
 // import constants
-import { IDENTIFIERS } from '.';
-import type { ThemeContextProp } from './HOC/withTheme';
+import { IDENTIFIERS } from ".";
+import type { ThemeContextProp } from "./HOC/withTheme";
 
 type Props = {
   label: string,
@@ -26,12 +26,12 @@ type Props = {
 };
 
 type State = {
-  composedTheme: Object
+  composedTheme: Object,
 };
 
 class LinkBase extends Component<Props, State> {
   // define static properties
-  static displayName = 'Link';
+  static displayName = "Link";
   static defaultProps = {
     context: createEmptyContext(),
     theme: null,
@@ -53,23 +53,19 @@ class LinkBase extends Component<Props, State> {
         addThemeId(theme || context.theme, themeId),
         addThemeId(themeOverrides, themeId),
         context.ROOT_THEME_API
-      )
+      ),
     };
   }
 
-  componentWillReceiveProps(nextProps: Props) {
-    didThemePropsChange(this.props, nextProps, this.setState.bind(this));
+  componentDidUpdate(prevProps: Props) {
+    if (prevProps !== this.props) {
+      didThemePropsChange(prevProps, this.props, this.setState.bind(this));
+    }
   }
 
   render() {
     // destructuring props ensures only the "...rest" get passed down
-    const {
-      skin,
-      theme,
-      themeOverrides,
-      context,
-      ...rest
-    } = this.props;
+    const { skin, theme, themeOverrides, context, ...rest } = this.props;
 
     const LinkSkin = skin || context.skins[this.props.themeId];
 

--- a/source/components/Link.js
+++ b/source/components/Link.js
@@ -1,14 +1,14 @@
 // @flow
-import React, { Component } from "react";
-import type { ComponentType } from "react";
+import React, { Component } from 'react';
+import type { ComponentType } from 'react';
 
 // internal utility functions
-import { createEmptyContext, withTheme } from "./HOC/withTheme";
-import { composeTheme, addThemeId, didThemePropsChange } from "../utils/themes";
+import { createEmptyContext, withTheme } from './HOC/withTheme';
+import { composeTheme, addThemeId, didThemePropsChange } from '../utils/themes';
 
 // import constants
-import { IDENTIFIERS } from ".";
-import type { ThemeContextProp } from "./HOC/withTheme";
+import { IDENTIFIERS } from '.';
+import type { ThemeContextProp } from './HOC/withTheme';
 
 type Props = {
   label: string,
@@ -22,16 +22,16 @@ type Props = {
   skin?: ComponentType<any>,
   theme: ?Object, // will take precedence over theme in context if passed
   themeId: string,
-  themeOverrides: Object,
+  themeOverrides: Object
 };
 
 type State = {
-  composedTheme: Object,
+  composedTheme: Object
 };
 
 class LinkBase extends Component<Props, State> {
   // define static properties
-  static displayName = "Link";
+  static displayName = 'Link';
   static defaultProps = {
     context: createEmptyContext(),
     theme: null,
@@ -40,7 +40,7 @@ class LinkBase extends Component<Props, State> {
     hasIconBefore: false,
     hasIconAfter: true,
     isUnderlined: true,
-    underlineOnHover: false,
+    underlineOnHover: false
   };
 
   constructor(props: Props) {
@@ -53,7 +53,7 @@ class LinkBase extends Component<Props, State> {
         addThemeId(theme || context.theme, themeId),
         addThemeId(themeOverrides, themeId),
         context.ROOT_THEME_API
-      ),
+      )
     };
   }
 

--- a/source/components/LoadingSpinner.js
+++ b/source/components/LoadingSpinner.js
@@ -1,14 +1,14 @@
 // @flow
-import React, { Component } from 'react';
-import type { ComponentType } from 'react';
+import React, { Component } from "react";
+import type { ComponentType } from "react";
 
 // internal utility functions
-import { createEmptyContext, withTheme } from './HOC/withTheme';
-import { composeTheme, addThemeId, didThemePropsChange } from '../utils/themes';
+import { createEmptyContext, withTheme } from "./HOC/withTheme";
+import { composeTheme, addThemeId, didThemePropsChange } from "../utils/themes";
 
 // import constants
-import { IDENTIFIERS } from '.';
-import type { ThemeContextProp } from './HOC/withTheme';
+import { IDENTIFIERS } from ".";
+import type { ThemeContextProp } from "./HOC/withTheme";
 
 type Props = {
   big: boolean,
@@ -18,23 +18,23 @@ type Props = {
   theme: ?Object, // will take precedence over theme in context if passed
   themeId: string,
   themeOverrides: Object,
-  visible: boolean
+  visible: boolean,
 };
 
 type State = {
-  composedTheme: Object
+  composedTheme: Object,
 };
 
 class LoadingSpinnerBase extends Component<Props, State> {
   // define static properties
-  static displayName = 'LoadingSpinner';
+  static displayName = "LoadingSpinner";
   static defaultProps = {
     big: false,
     context: createEmptyContext(),
     theme: null,
     themeId: IDENTIFIERS.LOADING_SPINNER,
     themeOverrides: {},
-    visible: true
+    visible: true,
   };
 
   constructor(props: Props) {
@@ -47,25 +47,22 @@ class LoadingSpinnerBase extends Component<Props, State> {
         addThemeId(theme || context.theme, themeId),
         addThemeId(themeOverrides, themeId),
         context.ROOT_THEME_API
-      )
+      ),
     };
   }
 
-  componentWillReceiveProps(nextProps: Props) {
-    didThemePropsChange(this.props, nextProps, this.setState.bind(this));
+  componentDidUpdate(prevProps: Props) {
+    if (prevProps !== this.props) {
+      didThemePropsChange(prevProps, this.props, this.setState.bind(this));
+    }
   }
 
   render() {
     // destructuring props ensures only the "...rest" get passed down
-    const {
-      skin,
-      theme,
-      themeOverrides,
-      context,
-      ...rest
-    } = this.props;
+    const { skin, theme, themeOverrides, context, ...rest } = this.props;
 
-    const LoadingSpinnerSkin = skin || context.skins[IDENTIFIERS.LOADING_SPINNER];
+    const LoadingSpinnerSkin =
+      skin || context.skins[IDENTIFIERS.LOADING_SPINNER];
 
     return <LoadingSpinnerSkin theme={this.state.composedTheme} {...rest} />;
   }

--- a/source/components/LoadingSpinner.js
+++ b/source/components/LoadingSpinner.js
@@ -1,14 +1,14 @@
 // @flow
-import React, { Component } from "react";
-import type { ComponentType } from "react";
+import React, { Component } from 'react';
+import type { ComponentType } from 'react';
 
 // internal utility functions
-import { createEmptyContext, withTheme } from "./HOC/withTheme";
-import { composeTheme, addThemeId, didThemePropsChange } from "../utils/themes";
+import { createEmptyContext, withTheme } from './HOC/withTheme';
+import { composeTheme, addThemeId, didThemePropsChange } from '../utils/themes';
 
 // import constants
-import { IDENTIFIERS } from ".";
-import type { ThemeContextProp } from "./HOC/withTheme";
+import { IDENTIFIERS } from '.';
+import type { ThemeContextProp } from './HOC/withTheme';
 
 type Props = {
   big: boolean,
@@ -18,23 +18,23 @@ type Props = {
   theme: ?Object, // will take precedence over theme in context if passed
   themeId: string,
   themeOverrides: Object,
-  visible: boolean,
+  visible: boolean
 };
 
 type State = {
-  composedTheme: Object,
+  composedTheme: Object
 };
 
 class LoadingSpinnerBase extends Component<Props, State> {
   // define static properties
-  static displayName = "LoadingSpinner";
+  static displayName = 'LoadingSpinner';
   static defaultProps = {
     big: false,
     context: createEmptyContext(),
     theme: null,
     themeId: IDENTIFIERS.LOADING_SPINNER,
     themeOverrides: {},
-    visible: true,
+    visible: true
   };
 
   constructor(props: Props) {
@@ -47,7 +47,7 @@ class LoadingSpinnerBase extends Component<Props, State> {
         addThemeId(theme || context.theme, themeId),
         addThemeId(themeOverrides, themeId),
         context.ROOT_THEME_API
-      ),
+      )
     };
   }
 

--- a/source/components/Modal.js
+++ b/source/components/Modal.js
@@ -1,14 +1,14 @@
 // @flow
-import React, { Component } from "react";
-import type { ComponentType, Element } from "react";
+import React, { Component } from 'react';
+import type { ComponentType, Element } from 'react';
 
 // internal utility functions
-import { createEmptyContext, withTheme } from "./HOC/withTheme";
-import { composeTheme, addThemeId, didThemePropsChange } from "../utils/themes";
+import { createEmptyContext, withTheme } from './HOC/withTheme';
+import { composeTheme, addThemeId, didThemePropsChange } from '../utils/themes';
 
 // import constants
-import { IDENTIFIERS } from ".";
-import type { ThemeContextProp } from "./HOC/withTheme";
+import { IDENTIFIERS } from '.';
+import type { ThemeContextProp } from './HOC/withTheme';
 
 type Props = {
   contentLabel: string | Element<any>,
@@ -19,24 +19,24 @@ type Props = {
   triggerCloseOnOverlayClick: boolean,
   theme: ?Object, // will take precedence over theme in context if passed
   themeId: string,
-  themeOverrides: Object,
+  themeOverrides: Object
 };
 
 type State = {
-  composedTheme: Object,
+  composedTheme: Object
 };
 
 class ModalBase extends Component<Props, State> {
   // define static properties
-  static displayName = "Modal";
+  static displayName = 'Modal';
   static defaultProps = {
-    contentLabel: "Modal Dialog",
+    contentLabel: 'Modal Dialog',
     context: createEmptyContext(),
     isOpen: false,
     triggerCloseOnOverlayClick: true,
     theme: null,
     themeId: IDENTIFIERS.MODAL,
-    themeOverrides: {},
+    themeOverrides: {}
   };
 
   constructor(props: Props) {
@@ -49,7 +49,7 @@ class ModalBase extends Component<Props, State> {
         addThemeId(theme || context.theme, themeId),
         addThemeId(themeOverrides, themeId),
         context.ROOT_THEME_API
-      ),
+      )
     };
   }
 

--- a/source/components/Modal.js
+++ b/source/components/Modal.js
@@ -1,14 +1,14 @@
 // @flow
-import React, { Component } from 'react';
-import type { ComponentType, Element } from 'react';
+import React, { Component } from "react";
+import type { ComponentType, Element } from "react";
 
 // internal utility functions
-import { createEmptyContext, withTheme } from './HOC/withTheme';
-import { composeTheme, addThemeId, didThemePropsChange } from '../utils/themes';
+import { createEmptyContext, withTheme } from "./HOC/withTheme";
+import { composeTheme, addThemeId, didThemePropsChange } from "../utils/themes";
 
 // import constants
-import { IDENTIFIERS } from '.';
-import type { ThemeContextProp } from './HOC/withTheme';
+import { IDENTIFIERS } from ".";
+import type { ThemeContextProp } from "./HOC/withTheme";
 
 type Props = {
   contentLabel: string | Element<any>,
@@ -19,24 +19,24 @@ type Props = {
   triggerCloseOnOverlayClick: boolean,
   theme: ?Object, // will take precedence over theme in context if passed
   themeId: string,
-  themeOverrides: Object
+  themeOverrides: Object,
 };
 
 type State = {
-  composedTheme: Object
+  composedTheme: Object,
 };
 
 class ModalBase extends Component<Props, State> {
   // define static properties
-  static displayName = 'Modal';
+  static displayName = "Modal";
   static defaultProps = {
-    contentLabel: 'Modal Dialog',
+    contentLabel: "Modal Dialog",
     context: createEmptyContext(),
     isOpen: false,
     triggerCloseOnOverlayClick: true,
     theme: null,
     themeId: IDENTIFIERS.MODAL,
-    themeOverrides: {}
+    themeOverrides: {},
   };
 
   constructor(props: Props) {
@@ -49,23 +49,19 @@ class ModalBase extends Component<Props, State> {
         addThemeId(theme || context.theme, themeId),
         addThemeId(themeOverrides, themeId),
         context.ROOT_THEME_API
-      )
+      ),
     };
   }
 
-  componentWillReceiveProps(nextProps: Props) {
-    didThemePropsChange(this.props, nextProps, this.setState.bind(this));
+  componentDidUpdate(prevProps: Props) {
+    if (prevProps !== this.props) {
+      didThemePropsChange(prevProps, this.props, this.setState.bind(this));
+    }
   }
 
   render() {
     // destructuring props ensures only the "...rest" get passed down
-    const {
-      skin,
-      theme,
-      themeOverrides,
-      context,
-      ...rest
-    } = this.props;
+    const { skin, theme, themeOverrides, context, ...rest } = this.props;
 
     const ModalSkin = skin || context.skins[IDENTIFIERS.MODAL];
 

--- a/source/components/NumericInput.js
+++ b/source/components/NumericInput.js
@@ -1,20 +1,25 @@
 // @flow
-import React, { Component } from 'react';
+import React, { Component } from "react";
 // $FlowFixMe
-import type { ComponentType, SyntheticInputEvent, Element, ElementRef } from 'react';
+import type {
+  ComponentType,
+  SyntheticInputEvent,
+  Element,
+  ElementRef,
+} from "react";
 
 // external libraries
-import createRef from 'create-react-ref/lib/createRef';
+import createRef from "create-react-ref/lib/createRef";
 
 // internal utility functions
-import { createEmptyContext, withTheme } from './HOC/withTheme';
-import { composeTheme, addThemeId, didThemePropsChange } from '../utils/themes';
+import { createEmptyContext, withTheme } from "./HOC/withTheme";
+import { composeTheme, addThemeId, didThemePropsChange } from "../utils/themes";
 
 // import constants
-import { IDENTIFIERS } from '.';
-import type { ThemeContextProp } from './HOC/withTheme';
-import { removeCharAtPosition } from '../utils/strings';
-import type { InputEvent } from '../utils/types';
+import { IDENTIFIERS } from ".";
+import type { ThemeContextProp } from "./HOC/withTheme";
+import { removeCharAtPosition } from "../utils/strings";
+import type { InputEvent } from "../utils/types";
 
 type NumberFormatOptions = {
   groupSeparator: string,
@@ -22,8 +27,8 @@ type NumberFormatOptions = {
 };
 
 const DEFAULT_NUMBER_FORMAT = {
-  groupSeparator: ',',
-  decimalSeparator: '.',
+  groupSeparator: ",",
+  decimalSeparator: ".",
 };
 
 export type NumericInputProps = {
@@ -56,14 +61,13 @@ type State = {
 };
 
 // Always use known number format and transform it where necessary
-const LOCALE = 'en-US';
+const LOCALE = "en-US";
 
 class NumericInputBase extends Component<NumericInputProps, State> {
-
-  inputElement: { current: null | ElementRef<'input'> };
+  inputElement: { current: null | ElementRef<"input"> };
   _hasInputBeenChanged: boolean = false;
 
-  static displayName = 'NumericInput';
+  static displayName = "NumericInput";
 
   static defaultProps = {
     allowSigns: true,
@@ -78,11 +82,17 @@ class NumericInputBase extends Component<NumericInputProps, State> {
 
   constructor(props: NumericInputProps) {
     super(props);
-    const { context, numberLocaleOptions, themeId, theme, themeOverrides } = props;
+    const {
+      context,
+      numberLocaleOptions,
+      themeId,
+      theme,
+      themeOverrides,
+    } = props;
     this.inputElement = createRef();
-    const minimumFractionDigits = (
-      numberLocaleOptions ? numberLocaleOptions.minimumFractionDigits : 0
-    );
+    const minimumFractionDigits = numberLocaleOptions
+      ? numberLocaleOptions.minimumFractionDigits
+      : 0;
     this.state = {
       composedTheme: composeTheme(
         addThemeId(theme || context.theme, themeId),
@@ -102,31 +112,37 @@ class NumericInputBase extends Component<NumericInputProps, State> {
       this.focus();
       if (inputElement && inputElement.current) {
         this.setState({
-          inputCaretPosition: inputElement.current.selectionStart
+          inputCaretPosition: inputElement.current.selectionStart,
         });
       }
     }
-  }
-
-  componentWillReceiveProps(nextProps: NumericInputProps) {
-    didThemePropsChange(this.props, nextProps, this.setState.bind(this));
   }
 
   componentDidUpdate(prevProps: NumericInputProps, prevState: State) {
     const { value } = this.props;
     const { inputCaretPosition } = this.state;
     const hasValueBeenChanged = value !== prevProps.value;
-    const hasCaretBeenChanged = inputCaretPosition !== prevState.inputCaretPosition;
-    if (this._hasInputBeenChanged || hasValueBeenChanged || hasCaretBeenChanged) {
+    const hasCaretBeenChanged =
+      inputCaretPosition !== prevState.inputCaretPosition;
+    if (
+      this._hasInputBeenChanged ||
+      hasValueBeenChanged ||
+      hasCaretBeenChanged
+    ) {
       this.setInputCaretPosition(inputCaretPosition);
     }
     this._hasInputBeenChanged = false;
+    if (prevProps !== this.props) {
+      didThemePropsChange(prevProps, this.props, this.setState.bind(this));
+    }
   }
 
-  onChange = (event: SyntheticInputEvent<Element<'input'>>) => {
+  onChange = (event: SyntheticInputEvent<Element<"input">>) => {
     event.preventDefault();
     const { value, onChange, disabled } = this.props;
-    if (disabled) { return; }
+    if (disabled) {
+      return;
+    }
     const result = this.processValueChange(event.nativeEvent);
     if (result) {
       this._hasInputBeenChanged = true;
@@ -147,7 +163,9 @@ class NumericInputBase extends Component<NumericInputProps, State> {
    * 2. Clean the given value
    * 3. Final processing
    */
-  processValueChange(event: InputEvent): ?{
+  processValueChange(
+    event: InputEvent
+  ): ?{
     value: ?number,
     caretPosition: number,
     fallbackInputValue?: ?string,
@@ -156,18 +174,22 @@ class NumericInputBase extends Component<NumericInputProps, State> {
     const { numberFormat, value, allowSigns } = this.props;
     const changedCaretPosition = event.target.selectionStart;
     const valueToProcess = transformNumberFormat(
-      event.target.value, numberFormat, DEFAULT_NUMBER_FORMAT
+      event.target.value,
+      numberFormat,
+      DEFAULT_NUMBER_FORMAT
     );
     const { inputType } = event;
-    const fallbackInputValue = this.state.fallbackInputValue || '';
-    const isBackwardDelete = inputType === 'deleteContentBackward';
-    const isForwardDelete = inputType === 'deleteContentForward';
+    const fallbackInputValue = this.state.fallbackInputValue || "";
+    const isBackwardDelete = inputType === "deleteContentBackward";
+    const isForwardDelete = inputType === "deleteContentForward";
     const isDeletion = isForwardDelete || isBackwardDelete;
-    const isInsert = inputType === 'insertText';
+    const isInsert = inputType === "insertText";
     const deleteCaretCorrection = isBackwardDelete ? 0 : 1;
     const validInputSignsRegExp = new RegExp(`^([-])?([0-9,.]+)?$`); // eslint-disable-line
     const validInputNoSignsRegExp = new RegExp(`^([0-9,.]+)?$`); // eslint-disable-line
-    const validInputRegex = allowSigns ? validInputSignsRegExp : validInputNoSignsRegExp;
+    const validInputRegex = allowSigns
+      ? validInputSignsRegExp
+      : validInputNoSignsRegExp;
     const valueHasLeadingZero = /^0[1-9]/.test(valueToProcess);
 
     /**
@@ -184,7 +206,7 @@ class NumericInputBase extends Component<NumericInputProps, State> {
     }
 
     // Case: Everything was deleted -> reset state
-    if (valueToProcess === '') {
+    if (valueToProcess === "") {
       return {
         value: null,
         caretPosition: 0,
@@ -197,11 +219,11 @@ class NumericInputBase extends Component<NumericInputProps, State> {
     if (valueToProcess === this.state.fallbackInputValue) return null;
 
     // Case: Just minus sign was entered
-    if (valueToProcess === '-') {
+    if (valueToProcess === "-") {
       return {
         value: null,
         caretPosition: 1,
-        fallbackInputValue: '-',
+        fallbackInputValue: "-",
         minimumFractionDigits: 0,
       };
     }
@@ -217,9 +239,10 @@ class NumericInputBase extends Component<NumericInputProps, State> {
 
     // Current value
     const currentNumber = value;
-    const currentValue = (
-      value != null ? value.toLocaleString(LOCALE, numberLocaleOptions) : fallbackInputValue
-    );
+    const currentValue =
+      value != null
+        ? value.toLocaleString(LOCALE, numberLocaleOptions)
+        : fallbackInputValue;
     const currentNumberOfDots = getNumberOfDots(currentValue);
     const hadDotBefore = currentNumberOfDots > 0;
 
@@ -230,15 +253,15 @@ class NumericInputBase extends Component<NumericInputProps, State> {
 
     // Case: A second decimal point was added somewhere
     if (hadDotBefore && newNumberOfDots === 2) {
-      const oldFirstDotIndex = currentValue.indexOf('.');
-      const newFirstDotIndex = newValue.indexOf('.');
+      const oldFirstDotIndex = currentValue.indexOf(".");
+      const newFirstDotIndex = newValue.indexOf(".");
       const wasDotAddedBeforeOldOne = newFirstDotIndex < oldFirstDotIndex;
       // Remove the second decimal point and set caret position
       newValue = removeCharAtPosition(
         newValue,
-        wasDotAddedBeforeOldOne ? newValue.lastIndexOf('.') : oldFirstDotIndex
+        wasDotAddedBeforeOldOne ? newValue.lastIndexOf(".") : oldFirstDotIndex
       );
-      newCaretPosition = newValue.indexOf('.') + 1;
+      newCaretPosition = newValue.indexOf(".") + 1;
     }
 
     newValue = truncateToPrecision(newValue, maximumFractionDigits);
@@ -248,23 +271,24 @@ class NumericInputBase extends Component<NumericInputProps, State> {
      */
     const numberOfFractionDigits = getFractionDigits(newValue).length;
     const dynamicMinimumFractionDigits = Math.min(
-      Math.max(propsMinimumFractionDigits, numberOfFractionDigits), maximumFractionDigits
+      Math.max(propsMinimumFractionDigits, numberOfFractionDigits),
+      maximumFractionDigits
     );
     const newNumber = getValueAsNumber(newValue, maximumFractionDigits);
 
     // Case: Just a dot was entered
-    if (valueToProcess === '.') {
+    if (valueToProcess === ".") {
       const hasMinFractions = dynamicMinimumFractionDigits > 0;
       return {
         value: 0,
         caretPosition: 2,
-        fallbackInputValue: hasMinFractions ? null : '0.',
+        fallbackInputValue: hasMinFractions ? null : "0.",
         minimumFractionDigits: dynamicMinimumFractionDigits,
       };
     }
 
     // Case: Dot was added at the beginning of number
-    if (newValue.charAt(0) === '.') {
+    if (newValue.charAt(0) === ".") {
       const newCaretPos = isInsert ? 2 : 1;
       return {
         value: newNumber,
@@ -278,7 +302,9 @@ class NumericInputBase extends Component<NumericInputProps, State> {
       const deleteAdjustment = isBackwardDelete ? 0 : 1; // special cases when deleting dot
       const insertAdjustment = -1; // don't move caret if numbers are "inserted"
       return {
-        caretPosition: changedCaretPosition + (isDeletion ? deleteAdjustment : insertAdjustment),
+        caretPosition:
+          changedCaretPosition +
+          (isDeletion ? deleteAdjustment : insertAdjustment),
         fallbackInputValue,
         minimumFractionDigits: dynamicMinimumFractionDigits,
         value: currentNumber,
@@ -290,15 +316,12 @@ class NumericInputBase extends Component<NumericInputProps, State> {
     });
 
     // Case: Dot was added at the end of number
-    if (!isDeletion && newValue.charAt(newValue.length - 1) === '.') {
+    if (!isDeletion && newValue.charAt(newValue.length - 1) === ".") {
       return {
         value: newNumber,
         caretPosition: changedCaretPosition,
-        fallbackInputValue: (
-          propsMinimumFractionDigits > 0
-            ? null
-            : localizedNewNumber + '.'
-        ),
+        fallbackInputValue:
+          propsMinimumFractionDigits > 0 ? null : localizedNewNumber + ".",
         minimumFractionDigits: 0,
       };
     }
@@ -317,13 +340,14 @@ class NumericInputBase extends Component<NumericInputProps, State> {
 
     // Case: Valid change has been made
     const hasNumberChanged = value !== newNumber;
-    const commasDiff = getNumberOfCommas(localizedNewNumber) - getNumberOfCommas(newValue);
+    const commasDiff =
+      getNumberOfCommas(localizedNewNumber) - getNumberOfCommas(newValue);
     const haveCommasChanged = commasDiff > 0;
     const onlyCommasChanged = !hasNumberChanged && haveCommasChanged;
     const leadingZeroCorrection = valueHasLeadingZero ? -1 : 0;
-    const caretCorrection = (
-      onlyCommasChanged ? deleteCaretCorrection : commasDiff
-    ) + leadingZeroCorrection;
+    const caretCorrection =
+      (onlyCommasChanged ? deleteCaretCorrection : commasDiff) +
+      leadingZeroCorrection;
     return {
       caretPosition: Math.max(newCaretPosition + caretCorrection, 0),
       fallbackInputValue: null,
@@ -345,15 +369,19 @@ class NumericInputBase extends Component<NumericInputProps, State> {
 
   getDynamicMinimumFractionDigits(): number {
     const minimumFractionDigitsProp = this.getMinimumFractionDigits();
-    return Math.max(this.state.minimumFractionDigits, minimumFractionDigitsProp || 0);
+    return Math.max(
+      this.state.minimumFractionDigits,
+      minimumFractionDigitsProp || 0
+    );
   }
 
   getMaximumFractionDigits(): number {
     const { numberLocaleOptions } = this.props;
     const minimumFractionDigits = this.getDynamicMinimumFractionDigits();
-    const maximumFractionDigits = (
+    const maximumFractionDigits =
       numberLocaleOptions && numberLocaleOptions.maximumFractionDigits != null
-    ) ? numberLocaleOptions.maximumFractionDigits : 3;
+        ? numberLocaleOptions.maximumFractionDigits
+        : 3;
     return Math.max(minimumFractionDigits, maximumFractionDigits);
   }
 
@@ -364,7 +392,11 @@ class NumericInputBase extends Component<NumericInputProps, State> {
   }
 
   getLocalizedNumber(value: ?number) {
-    return convertNumberToLocalizedString(value, LOCALE, this.getDynamicLocaleOptions());
+    return convertNumberToLocalizedString(
+      value,
+      LOCALE,
+      this.getDynamicLocaleOptions()
+    );
   }
 
   setInputCaretPosition = (position: number) => {
@@ -403,10 +435,10 @@ class NumericInputBase extends Component<NumericInputProps, State> {
 
     const InputSkin = skin || context.skins[IDENTIFIERS.INPUT];
 
-    const localizedInput = value != null ? this.getLocalizedNumber(value) : '';
-    const inputValue = this.state.fallbackInputValue ?
-      this.state.fallbackInputValue :
-      localizedInput;
+    const localizedInput = value != null ? this.getLocalizedNumber(value) : "";
+    const inputValue = this.state.fallbackInputValue
+      ? this.state.fallbackInputValue
+      : localizedInput;
 
     return (
       <InputSkin
@@ -414,7 +446,11 @@ class NumericInputBase extends Component<NumericInputProps, State> {
         inputRef={this.inputElement}
         onChange={this.onChange}
         theme={this.state.composedTheme}
-        value={transformNumberFormat(inputValue, DEFAULT_NUMBER_FORMAT, this.props.numberFormat)}
+        value={transformNumberFormat(
+          inputValue,
+          DEFAULT_NUMBER_FORMAT,
+          this.props.numberFormat
+        )}
         onBlur={this.onBlur}
         {...rest}
       />
@@ -428,20 +464,28 @@ export const NumericInput = withTheme(NumericInputBase);
 
 const NUMERIC_INPUT_REGEX = /^([-])?([0-9,]+)?(\.([0-9]+)?)?$/;
 
-const isValidNumericInput = (value: string): boolean => NUMERIC_INPUT_REGEX.test(value);
+const isValidNumericInput = (value: string): boolean =>
+  NUMERIC_INPUT_REGEX.test(value);
 
-const isParsableNumberString = (value: string, requiredPrecision: number): boolean => (
+const isParsableNumberString = (
+  value: string,
+  requiredPrecision: number
+): boolean =>
   // The number of digits is limited in Javascript - so the required precision influence
   // the possible number of integer digits (only 15 digits can be safely represented in total)
-  parseFloat(value) >= (Number.MIN_SAFE_INTEGER / 10 ** (requiredPrecision + 1)) &&
-  parseFloat(value) <= (Number.MAX_SAFE_INTEGER / 10 ** (requiredPrecision + 1)) &&
+  parseFloat(value) >=
+    Number.MIN_SAFE_INTEGER / 10 ** (requiredPrecision + 1) &&
+  parseFloat(value) <=
+    Number.MAX_SAFE_INTEGER / 10 ** (requiredPrecision + 1) &&
   !isNaN(parseFloat(value)) &&
-  isFinite(value)
-);
+  isFinite(value);
 
-const removeCommas = (value: string): string => value.replace(/,/g, '');
+const removeCommas = (value: string): string => value.replace(/,/g, "");
 
-function parseStringToNumber(value: string, requiredPrecision: number): ?number {
+function parseStringToNumber(
+  value: string,
+  requiredPrecision: number
+): ?number {
   const cleanedValue = removeCommas(value);
   if (!isValidNumericInput(cleanedValue)) return null;
   if (!isParsableNumberString(cleanedValue, requiredPrecision)) return null;
@@ -449,13 +493,20 @@ function parseStringToNumber(value: string, requiredPrecision: number): ?number 
 }
 
 function convertNumberToLocalizedString(
-  num: ?number, locale: string, options?: Number$LocaleOptions
+  num: ?number,
+  locale: string,
+  options?: Number$LocaleOptions
 ): string {
-  return num != null ? num.toLocaleString(locale, options) : '';
+  return num != null ? num.toLocaleString(locale, options) : "";
 }
 
-function getValueAsNumber(value: string | number, requiredPrecision: number): ?number {
-  return typeof value === 'string' ? parseStringToNumber(value, requiredPrecision) : value;
+function getValueAsNumber(
+  value: string | number,
+  requiredPrecision: number
+): ?number {
+  return typeof value === "string"
+    ? parseStringToNumber(value, requiredPrecision)
+    : value;
 }
 
 function getNumberOfCommas(value: string): number {
@@ -466,33 +517,39 @@ function getNumberOfDots(value: string): number {
   return (value.match(/\./g) || []).length;
 }
 
-function getIntegerDigits(value: string, decimalSeparator: string = '.'): string {
+function getIntegerDigits(
+  value: string,
+  decimalSeparator: string = "."
+): string {
   const fractionSeparatorIndex = value.indexOf(decimalSeparator);
   if (fractionSeparatorIndex === -1) return value;
   return value.substring(0, fractionSeparatorIndex);
 }
 
-function getFractionDigits(value: string, decimalSeparator: string = '.'): string {
+function getFractionDigits(
+  value: string,
+  decimalSeparator: string = "."
+): string {
   const fractionSeparatorIndex = value.indexOf(decimalSeparator);
-  if (fractionSeparatorIndex === -1) return '';
+  if (fractionSeparatorIndex === -1) return "";
   return value.substring(fractionSeparatorIndex + 1);
 }
 
 function truncateToPrecision(value: string, precision: number): string {
-  const decimalPointIndex = value.indexOf('.');
+  const decimalPointIndex = value.indexOf(".");
   if (decimalPointIndex === -1) return value;
   const fractionDigits = removeCommas(getFractionDigits(value));
-  return getIntegerDigits(value) + '.' + fractionDigits.substring(0, precision);
+  return getIntegerDigits(value) + "." + fractionDigits.substring(0, precision);
 }
 
 function transformNumberFormat(
-  value: string, inputFormat: NumberFormatOptions, outputFormat: NumberFormatOptions
+  value: string,
+  inputFormat: NumberFormatOptions,
+  outputFormat: NumberFormatOptions
 ) {
-  return (
-    value
-      .replace(new RegExp('\\' + inputFormat.groupSeparator, 'g'), '#')
-      .replace(new RegExp('\\' + inputFormat.decimalSeparator, 'g'), '@')
-      .replace(new RegExp('#', 'g'), outputFormat.groupSeparator)
-      .replace(new RegExp('@', 'g'), outputFormat.decimalSeparator)
-  );
+  return value
+    .replace(new RegExp("\\" + inputFormat.groupSeparator, "g"), "#")
+    .replace(new RegExp("\\" + inputFormat.decimalSeparator, "g"), "@")
+    .replace(new RegExp("#", "g"), outputFormat.groupSeparator)
+    .replace(new RegExp("@", "g"), outputFormat.decimalSeparator);
 }

--- a/source/components/NumericInput.js
+++ b/source/components/NumericInput.js
@@ -1,34 +1,34 @@
 // @flow
-import React, { Component } from "react";
+import React, { Component } from 'react';
 // $FlowFixMe
 import type {
   ComponentType,
   SyntheticInputEvent,
   Element,
-  ElementRef,
-} from "react";
+  ElementRef
+} from 'react';
 
 // external libraries
-import createRef from "create-react-ref/lib/createRef";
+import createRef from 'create-react-ref/lib/createRef';
 
 // internal utility functions
-import { createEmptyContext, withTheme } from "./HOC/withTheme";
-import { composeTheme, addThemeId, didThemePropsChange } from "../utils/themes";
+import { createEmptyContext, withTheme } from './HOC/withTheme';
+import { composeTheme, addThemeId, didThemePropsChange } from '../utils/themes';
 
 // import constants
-import { IDENTIFIERS } from ".";
-import type { ThemeContextProp } from "./HOC/withTheme";
-import { removeCharAtPosition } from "../utils/strings";
-import type { InputEvent } from "../utils/types";
+import { IDENTIFIERS } from '.';
+import type { ThemeContextProp } from './HOC/withTheme';
+import { removeCharAtPosition } from '../utils/strings';
+import type { InputEvent } from '../utils/types';
 
 type NumberFormatOptions = {
   groupSeparator: string,
-  decimalSeparator: string,
+  decimalSeparator: string
 };
 
 const DEFAULT_NUMBER_FORMAT = {
-  groupSeparator: ",",
-  decimalSeparator: ".",
+  groupSeparator: ',',
+  decimalSeparator: '.'
 };
 
 export type NumericInputProps = {
@@ -50,24 +50,24 @@ export type NumericInputProps = {
   theme: ?Object,
   themeId: string,
   themeOverrides: Object,
-  value: ?number,
+  value: ?number
 };
 
 type State = {
   composedTheme: Object,
   minimumFractionDigits: number,
   inputCaretPosition: number,
-  fallbackInputValue: ?string,
+  fallbackInputValue: ?string
 };
 
 // Always use known number format and transform it where necessary
-const LOCALE = "en-US";
+const LOCALE = 'en-US';
 
 class NumericInputBase extends Component<NumericInputProps, State> {
-  inputElement: { current: null | ElementRef<"input"> };
+  inputElement: { current: null | ElementRef<'input'> };
   _hasInputBeenChanged: boolean = false;
 
-  static displayName = "NumericInput";
+  static displayName = 'NumericInput';
 
   static defaultProps = {
     allowSigns: true,
@@ -77,7 +77,7 @@ class NumericInputBase extends Component<NumericInputProps, State> {
     theme: null,
     themeId: IDENTIFIERS.INPUT,
     themeOverrides: {},
-    value: null,
+    value: null
   };
 
   constructor(props: NumericInputProps) {
@@ -87,7 +87,7 @@ class NumericInputBase extends Component<NumericInputProps, State> {
       numberLocaleOptions,
       themeId,
       theme,
-      themeOverrides,
+      themeOverrides
     } = props;
     this.inputElement = createRef();
     const minimumFractionDigits = numberLocaleOptions
@@ -101,7 +101,7 @@ class NumericInputBase extends Component<NumericInputProps, State> {
       ),
       minimumFractionDigits: minimumFractionDigits || 0,
       inputCaretPosition: 0,
-      fallbackInputValue: null,
+      fallbackInputValue: null
     };
   }
 
@@ -112,7 +112,7 @@ class NumericInputBase extends Component<NumericInputProps, State> {
       this.focus();
       if (inputElement && inputElement.current) {
         this.setState({
-          inputCaretPosition: inputElement.current.selectionStart,
+          inputCaretPosition: inputElement.current.selectionStart
         });
       }
     }
@@ -137,7 +137,7 @@ class NumericInputBase extends Component<NumericInputProps, State> {
     }
   }
 
-  onChange = (event: SyntheticInputEvent<Element<"input">>) => {
+  onChange = (event: SyntheticInputEvent<Element<'input'>>) => {
     event.preventDefault();
     const { value, onChange, disabled } = this.props;
     if (disabled) {
@@ -153,7 +153,7 @@ class NumericInputBase extends Component<NumericInputProps, State> {
       this.setState({
         inputCaretPosition: result.caretPosition,
         minimumFractionDigits: result.minimumFractionDigits,
-        fallbackInputValue: result.fallbackInputValue,
+        fallbackInputValue: result.fallbackInputValue
       });
     }
   };
@@ -169,7 +169,7 @@ class NumericInputBase extends Component<NumericInputProps, State> {
     value: ?number,
     caretPosition: number,
     fallbackInputValue?: ?string,
-    minimumFractionDigits: number,
+    minimumFractionDigits: number
   } {
     const { numberFormat, value, allowSigns } = this.props;
     const changedCaretPosition = event.target.selectionStart;
@@ -179,11 +179,11 @@ class NumericInputBase extends Component<NumericInputProps, State> {
       DEFAULT_NUMBER_FORMAT
     );
     const { inputType } = event;
-    const fallbackInputValue = this.state.fallbackInputValue || "";
-    const isBackwardDelete = inputType === "deleteContentBackward";
-    const isForwardDelete = inputType === "deleteContentForward";
+    const fallbackInputValue = this.state.fallbackInputValue || '';
+    const isBackwardDelete = inputType === 'deleteContentBackward';
+    const isForwardDelete = inputType === 'deleteContentForward';
     const isDeletion = isForwardDelete || isBackwardDelete;
-    const isInsert = inputType === "insertText";
+    const isInsert = inputType === 'insertText';
     const deleteCaretCorrection = isBackwardDelete ? 0 : 1;
     const validInputSignsRegExp = new RegExp(`^([-])?([0-9,.]+)?$`); // eslint-disable-line
     const validInputNoSignsRegExp = new RegExp(`^([0-9,.]+)?$`); // eslint-disable-line
@@ -201,17 +201,17 @@ class NumericInputBase extends Component<NumericInputProps, State> {
         caretPosition: changedCaretPosition - 1,
         fallbackInputValue,
         minimumFractionDigits: this.state.minimumFractionDigits,
-        value,
+        value
       };
     }
 
     // Case: Everything was deleted -> reset state
-    if (valueToProcess === "") {
+    if (valueToProcess === '') {
       return {
         value: null,
         caretPosition: 0,
         fallbackInputValue: null,
-        minimumFractionDigits: 0,
+        minimumFractionDigits: 0
       };
     }
 
@@ -219,12 +219,12 @@ class NumericInputBase extends Component<NumericInputProps, State> {
     if (valueToProcess === this.state.fallbackInputValue) return null;
 
     // Case: Just minus sign was entered
-    if (valueToProcess === "-") {
+    if (valueToProcess === '-') {
       return {
         value: null,
         caretPosition: 1,
-        fallbackInputValue: "-",
-        minimumFractionDigits: 0,
+        fallbackInputValue: '-',
+        minimumFractionDigits: 0
       };
     }
 
@@ -253,15 +253,15 @@ class NumericInputBase extends Component<NumericInputProps, State> {
 
     // Case: A second decimal point was added somewhere
     if (hadDotBefore && newNumberOfDots === 2) {
-      const oldFirstDotIndex = currentValue.indexOf(".");
-      const newFirstDotIndex = newValue.indexOf(".");
+      const oldFirstDotIndex = currentValue.indexOf('.');
+      const newFirstDotIndex = newValue.indexOf('.');
       const wasDotAddedBeforeOldOne = newFirstDotIndex < oldFirstDotIndex;
       // Remove the second decimal point and set caret position
       newValue = removeCharAtPosition(
         newValue,
-        wasDotAddedBeforeOldOne ? newValue.lastIndexOf(".") : oldFirstDotIndex
+        wasDotAddedBeforeOldOne ? newValue.lastIndexOf('.') : oldFirstDotIndex
       );
-      newCaretPosition = newValue.indexOf(".") + 1;
+      newCaretPosition = newValue.indexOf('.') + 1;
     }
 
     newValue = truncateToPrecision(newValue, maximumFractionDigits);
@@ -277,23 +277,23 @@ class NumericInputBase extends Component<NumericInputProps, State> {
     const newNumber = getValueAsNumber(newValue, maximumFractionDigits);
 
     // Case: Just a dot was entered
-    if (valueToProcess === ".") {
+    if (valueToProcess === '.') {
       const hasMinFractions = dynamicMinimumFractionDigits > 0;
       return {
         value: 0,
         caretPosition: 2,
-        fallbackInputValue: hasMinFractions ? null : "0.",
-        minimumFractionDigits: dynamicMinimumFractionDigits,
+        fallbackInputValue: hasMinFractions ? null : '0.',
+        minimumFractionDigits: dynamicMinimumFractionDigits
       };
     }
 
     // Case: Dot was added at the beginning of number
-    if (newValue.charAt(0) === ".") {
+    if (newValue.charAt(0) === '.') {
       const newCaretPos = isInsert ? 2 : 1;
       return {
         value: newNumber,
         caretPosition: newCaretPos,
-        minimumFractionDigits: dynamicMinimumFractionDigits,
+        minimumFractionDigits: dynamicMinimumFractionDigits
       };
     }
 
@@ -307,22 +307,22 @@ class NumericInputBase extends Component<NumericInputProps, State> {
           (isDeletion ? deleteAdjustment : insertAdjustment),
         fallbackInputValue,
         minimumFractionDigits: dynamicMinimumFractionDigits,
-        value: currentNumber,
+        value: currentNumber
       };
     }
 
     const localizedNewNumber = newNumber.toLocaleString(LOCALE, {
-      minimumFractionDigits: dynamicMinimumFractionDigits,
+      minimumFractionDigits: dynamicMinimumFractionDigits
     });
 
     // Case: Dot was added at the end of number
-    if (!isDeletion && newValue.charAt(newValue.length - 1) === ".") {
+    if (!isDeletion && newValue.charAt(newValue.length - 1) === '.') {
       return {
         value: newNumber,
         caretPosition: changedCaretPosition,
         fallbackInputValue:
-          propsMinimumFractionDigits > 0 ? null : localizedNewNumber + ".",
-        minimumFractionDigits: 0,
+          propsMinimumFractionDigits > 0 ? null : localizedNewNumber + '.',
+        minimumFractionDigits: 0
       };
     }
 
@@ -334,7 +334,7 @@ class NumericInputBase extends Component<NumericInputProps, State> {
         caretPosition: newCaretPosition + deleteCaretCorrection,
         fallbackInputValue: null,
         minimumFractionDigits: dynamicMinimumFractionDigits,
-        value: currentNumber,
+        value: currentNumber
       };
     }
 
@@ -352,7 +352,7 @@ class NumericInputBase extends Component<NumericInputProps, State> {
       caretPosition: Math.max(newCaretPosition + caretCorrection, 0),
       fallbackInputValue: null,
       minimumFractionDigits: dynamicMinimumFractionDigits,
-      value: newNumber,
+      value: newNumber
     };
   }
 
@@ -387,7 +387,7 @@ class NumericInputBase extends Component<NumericInputProps, State> {
 
   getDynamicLocaleOptions(): Number$LocaleOptions {
     return Object.assign({}, this.props.numberLocaleOptions, {
-      minimumFractionDigits: this.getDynamicMinimumFractionDigits(),
+      minimumFractionDigits: this.getDynamicMinimumFractionDigits()
     });
   }
 
@@ -415,7 +415,7 @@ class NumericInputBase extends Component<NumericInputProps, State> {
 
   onBlur = () => {
     this.setState({
-      fallbackInputValue: null,
+      fallbackInputValue: null
     });
   };
 
@@ -435,7 +435,7 @@ class NumericInputBase extends Component<NumericInputProps, State> {
 
     const InputSkin = skin || context.skins[IDENTIFIERS.INPUT];
 
-    const localizedInput = value != null ? this.getLocalizedNumber(value) : "";
+    const localizedInput = value != null ? this.getLocalizedNumber(value) : '';
     const inputValue = this.state.fallbackInputValue
       ? this.state.fallbackInputValue
       : localizedInput;
@@ -480,7 +480,7 @@ const isParsableNumberString = (
   !isNaN(parseFloat(value)) &&
   isFinite(value);
 
-const removeCommas = (value: string): string => value.replace(/,/g, "");
+const removeCommas = (value: string): string => value.replace(/,/g, '');
 
 function parseStringToNumber(
   value: string,
@@ -497,14 +497,14 @@ function convertNumberToLocalizedString(
   locale: string,
   options?: Number$LocaleOptions
 ): string {
-  return num != null ? num.toLocaleString(locale, options) : "";
+  return num != null ? num.toLocaleString(locale, options) : '';
 }
 
 function getValueAsNumber(
   value: string | number,
   requiredPrecision: number
 ): ?number {
-  return typeof value === "string"
+  return typeof value === 'string'
     ? parseStringToNumber(value, requiredPrecision)
     : value;
 }
@@ -519,7 +519,7 @@ function getNumberOfDots(value: string): number {
 
 function getIntegerDigits(
   value: string,
-  decimalSeparator: string = "."
+  decimalSeparator: string = '.'
 ): string {
   const fractionSeparatorIndex = value.indexOf(decimalSeparator);
   if (fractionSeparatorIndex === -1) return value;
@@ -528,18 +528,18 @@ function getIntegerDigits(
 
 function getFractionDigits(
   value: string,
-  decimalSeparator: string = "."
+  decimalSeparator: string = '.'
 ): string {
   const fractionSeparatorIndex = value.indexOf(decimalSeparator);
-  if (fractionSeparatorIndex === -1) return "";
+  if (fractionSeparatorIndex === -1) return '';
   return value.substring(fractionSeparatorIndex + 1);
 }
 
 function truncateToPrecision(value: string, precision: number): string {
-  const decimalPointIndex = value.indexOf(".");
+  const decimalPointIndex = value.indexOf('.');
   if (decimalPointIndex === -1) return value;
   const fractionDigits = removeCommas(getFractionDigits(value));
-  return getIntegerDigits(value) + "." + fractionDigits.substring(0, precision);
+  return getIntegerDigits(value) + '.' + fractionDigits.substring(0, precision);
 }
 
 function transformNumberFormat(
@@ -548,8 +548,8 @@ function transformNumberFormat(
   outputFormat: NumberFormatOptions
 ) {
   return value
-    .replace(new RegExp("\\" + inputFormat.groupSeparator, "g"), "#")
-    .replace(new RegExp("\\" + inputFormat.decimalSeparator, "g"), "@")
-    .replace(new RegExp("#", "g"), outputFormat.groupSeparator)
-    .replace(new RegExp("@", "g"), outputFormat.decimalSeparator);
+    .replace(new RegExp('\\' + inputFormat.groupSeparator, 'g'), '#')
+    .replace(new RegExp('\\' + inputFormat.decimalSeparator, 'g'), '@')
+    .replace(new RegExp('#', 'g'), outputFormat.groupSeparator)
+    .replace(new RegExp('@', 'g'), outputFormat.decimalSeparator);
 }

--- a/source/components/Options.js
+++ b/source/components/Options.js
@@ -1,5 +1,5 @@
 // @flow
-import React, { Component } from 'react';
+import React, { Component } from "react";
 import type {
   ComponentType,
   // $FlowFixMe
@@ -10,16 +10,16 @@ import type {
   SyntheticEvent,
   Element,
   ElementRef,
-} from 'react';
+} from "react";
 
 // internal utility functions
-import { createEmptyContext, withTheme } from './HOC/withTheme';
-import { composeTheme, addThemeId, didThemePropsChange } from '../utils/themes';
-import { composeFunctions } from '../utils/props';
+import { createEmptyContext, withTheme } from "./HOC/withTheme";
+import { composeTheme, addThemeId, didThemePropsChange } from "../utils/themes";
+import { composeFunctions } from "../utils/props";
 
 // import constants
-import { IDENTIFIERS } from '.';
-import type { ThemeContextProp } from './HOC/withTheme';
+import { IDENTIFIERS } from ".";
+import type { ThemeContextProp } from "./HOC/withTheme";
 
 type Props = {
   className?: String,
@@ -50,7 +50,7 @@ type Props = {
   themeId: string,
   themeOverrides: Object,
   toggleMouseLocation?: Function,
-  toggleOpen?: Function
+  toggleOpen?: Function,
 };
 
 type State = {
@@ -64,21 +64,21 @@ class OptionsBase extends Component<Props, State> {
   optionsElement: ?Element<any>; // TODO: Does this get used? Don't think so.
 
   // define static properties
-  static displayName = 'Options';
+  static displayName = "Options";
   static defaultProps = {
     context: createEmptyContext(),
     isOpen: false,
     isOpeningUpward: false,
     noOptionsArrow: false,
     noOptionsCheckmark: false,
-    noResultsMessage: 'No results',
+    noResultsMessage: "No results",
     optionHeight: 46,
     options: [],
     resetOnClose: false,
     theme: null,
     themeId: IDENTIFIERS.OPTIONS,
     themeOverrides: {},
-    toggleOpen() {}
+    toggleOpen() {},
   };
 
   constructor(props: Props) {
@@ -99,28 +99,32 @@ class OptionsBase extends Component<Props, State> {
 
   componentDidMount() {
     if (this.props.isOpen) {
-      document.addEventListener('keydown', this._handleKeyDown, false);
+      document.addEventListener("keydown", this._handleKeyDown, false);
     }
   }
 
-  componentWillReceiveProps(nextProps: Props) {
-    if (!this.props.isOpen && nextProps.isOpen) {
-      document.addEventListener('keydown', this._handleKeyDown, false);
-    } else if (this.props.isOpen && !nextProps.isOpen) {
-      document.removeEventListener('keydown', this._handleKeyDown, false);
+  componentDidUpdate(prevProps: Props) {
+    if (prevProps !== this.props) {
+      if (!prevProps.isOpen && this.props.isOpen) {
+        document.addEventListener("keydown", this._handleKeyDown, false);
+      } else if (prevProps.isOpen && !this.props.isOpen) {
+        document.removeEventListener("keydown", this._handleKeyDown, false);
+      }
+      didThemePropsChange(prevProps, this.props, this.setState.bind(this));
     }
-    didThemePropsChange(this.props, nextProps, this.setState.bind(this));
   }
 
   componentWillUnmount() {
-    document.removeEventListener('keydown', this._handleKeyDown, false);
+    document.removeEventListener("keydown", this._handleKeyDown, false);
   }
 
   close = () => {
     const { isOpen, onClose, resetOnClose, toggleOpen } = this.props;
     if (isOpen && toggleOpen) toggleOpen();
     this.setState({
-      highlightedOptionIndex: resetOnClose ? 0 : this.state.highlightedOptionIndex
+      highlightedOptionIndex: resetOnClose
+        ? 0
+        : this.state.highlightedOptionIndex,
     });
     if (onClose) onClose();
   };
@@ -151,12 +155,15 @@ class OptionsBase extends Component<Props, State> {
 
   isSelectedOption = (optionIndex: number) => {
     const { options, isOpeningUpward } = this.props;
-    const index = isOpeningUpward ? options.length - 1 - optionIndex : optionIndex;
+    const index = isOpeningUpward
+      ? options.length - 1 - optionIndex
+      : optionIndex;
     const option = options[index];
     return option && this.props.selectedOption === option;
   };
 
-  isHighlightedOption = (optionIndex: number) => this.state.highlightedOptionIndex === optionIndex;
+  isHighlightedOption = (optionIndex: number) =>
+    this.state.highlightedOptionIndex === optionIndex;
 
   isDisabledOption = (optionIndex: number) => {
     const { options } = this.props;
@@ -187,7 +194,7 @@ class OptionsBase extends Component<Props, State> {
       isHighlightedOption,
       isDisabledOption,
       handleClickOnOption,
-      setHighlightedOptionIndex
+      setHighlightedOptionIndex,
     } = this;
 
     return {
@@ -204,7 +211,7 @@ class OptionsBase extends Component<Props, State> {
       onMouseEnter: (index: number, event: SyntheticMouseEvent<>) =>
         // user's custom onMouseEnter is composed with this.setHighlightedOptionIndex
         composeFunctions(onMouseEnter, setHighlightedOptionIndex)(index, event),
-      ...rest
+      ...rest,
     };
   };
 
@@ -229,7 +236,7 @@ class OptionsBase extends Component<Props, State> {
     if (options.length) {
       const lowerIndexBound = 0;
       const upperIndexBound = options.length - 1;
-      let newIndex = direction === 'up' ? currentIndex - 1 : currentIndex + 1;
+      let newIndex = direction === "up" ? currentIndex - 1 : currentIndex + 1;
 
       // Make sure new index is within options bounds
       newIndex = Math.max(lowerIndexBound, Math.min(newIndex, upperIndexBound));
@@ -239,8 +246,8 @@ class OptionsBase extends Component<Props, State> {
         const canMoveUp = newIndex > lowerIndexBound;
         const canMoveDown = newIndex < upperIndexBound;
         if (
-          (direction === 'up' && canMoveUp) ||
-          (direction === 'down' && canMoveDown)
+          (direction === "up" && canMoveUp) ||
+          (direction === "down" && canMoveDown)
         ) {
           this._handleHighlightMove(newIndex, direction);
         }
@@ -271,11 +278,11 @@ class OptionsBase extends Component<Props, State> {
         break;
       case 38: // Up Arrow key: moves highlighted selection 'up' 1 index
         event.preventDefault(); // prevent caret move
-        this._handleHighlightMove(highlightOptionIndex, 'up');
+        this._handleHighlightMove(highlightOptionIndex, "up");
         break;
       case 40: // Down Arrow key: moves highlighted selection 'down' 1 index
         event.preventDefault(); // prevent caret move
-        this._handleHighlightMove(highlightOptionIndex, 'down');
+        this._handleHighlightMove(highlightOptionIndex, "down");
         break;
       default:
         this.props.resetOnClose && this.setHighlightedOptionIndex(0);
@@ -284,7 +291,10 @@ class OptionsBase extends Component<Props, State> {
 
   _setMouseIsOverOptions = (isMouseOverOptions: boolean) => {
     const { toggleMouseLocation, setMouseIsOverOptions } = this.props;
-    if (this.state.isMouseOverOptions !== isMouseOverOptions && toggleMouseLocation) {
+    if (
+      this.state.isMouseOverOptions !== isMouseOverOptions &&
+      toggleMouseLocation
+    ) {
       toggleMouseLocation();
     }
     if (setMouseIsOverOptions) {

--- a/source/components/Options.js
+++ b/source/components/Options.js
@@ -1,5 +1,5 @@
 // @flow
-import React, { Component } from "react";
+import React, { Component } from 'react';
 import type {
   ComponentType,
   // $FlowFixMe
@@ -9,17 +9,17 @@ import type {
   // $FlowFixMe
   SyntheticEvent,
   Element,
-  ElementRef,
-} from "react";
+  ElementRef
+} from 'react';
 
 // internal utility functions
-import { createEmptyContext, withTheme } from "./HOC/withTheme";
-import { composeTheme, addThemeId, didThemePropsChange } from "../utils/themes";
-import { composeFunctions } from "../utils/props";
+import { createEmptyContext, withTheme } from './HOC/withTheme';
+import { composeTheme, addThemeId, didThemePropsChange } from '../utils/themes';
+import { composeFunctions } from '../utils/props';
 
 // import constants
-import { IDENTIFIERS } from ".";
-import type { ThemeContextProp } from "./HOC/withTheme";
+import { IDENTIFIERS } from '.';
+import type { ThemeContextProp } from './HOC/withTheme';
 
 type Props = {
   className?: String,
@@ -50,13 +50,13 @@ type Props = {
   themeId: string,
   themeOverrides: Object,
   toggleMouseLocation?: Function,
-  toggleOpen?: Function,
+  toggleOpen?: Function
 };
 
 type State = {
   composedTheme: Object,
   highlightedOptionIndex: number,
-  isMouseOverOptions: boolean,
+  isMouseOverOptions: boolean
 };
 
 class OptionsBase extends Component<Props, State> {
@@ -64,21 +64,21 @@ class OptionsBase extends Component<Props, State> {
   optionsElement: ?Element<any>; // TODO: Does this get used? Don't think so.
 
   // define static properties
-  static displayName = "Options";
+  static displayName = 'Options';
   static defaultProps = {
     context: createEmptyContext(),
     isOpen: false,
     isOpeningUpward: false,
     noOptionsArrow: false,
     noOptionsCheckmark: false,
-    noResultsMessage: "No results",
+    noResultsMessage: 'No results',
     optionHeight: 46,
     options: [],
     resetOnClose: false,
     theme: null,
     themeId: IDENTIFIERS.OPTIONS,
     themeOverrides: {},
-    toggleOpen() {},
+    toggleOpen() {}
   };
 
   constructor(props: Props) {
@@ -93,29 +93,29 @@ class OptionsBase extends Component<Props, State> {
         context.ROOT_THEME_API
       ),
       highlightedOptionIndex: 0,
-      isMouseOverOptions: false,
+      isMouseOverOptions: false
     };
   }
 
   componentDidMount() {
     if (this.props.isOpen) {
-      document.addEventListener("keydown", this._handleKeyDown, false);
+      document.addEventListener('keydown', this._handleKeyDown, false);
     }
   }
 
   componentDidUpdate(prevProps: Props) {
     if (prevProps !== this.props) {
       if (!prevProps.isOpen && this.props.isOpen) {
-        document.addEventListener("keydown", this._handleKeyDown, false);
+        document.addEventListener('keydown', this._handleKeyDown, false);
       } else if (prevProps.isOpen && !this.props.isOpen) {
-        document.removeEventListener("keydown", this._handleKeyDown, false);
+        document.removeEventListener('keydown', this._handleKeyDown, false);
       }
       didThemePropsChange(prevProps, this.props, this.setState.bind(this));
     }
   }
 
   componentWillUnmount() {
-    document.removeEventListener("keydown", this._handleKeyDown, false);
+    document.removeEventListener('keydown', this._handleKeyDown, false);
   }
 
   close = () => {
@@ -124,7 +124,7 @@ class OptionsBase extends Component<Props, State> {
     this.setState({
       highlightedOptionIndex: resetOnClose
         ? 0
-        : this.state.highlightedOptionIndex,
+        : this.state.highlightedOptionIndex
     });
     if (onClose) onClose();
   };
@@ -194,7 +194,7 @@ class OptionsBase extends Component<Props, State> {
       isHighlightedOption,
       isDisabledOption,
       handleClickOnOption,
-      setHighlightedOptionIndex,
+      setHighlightedOptionIndex
     } = this;
 
     return {
@@ -211,7 +211,7 @@ class OptionsBase extends Component<Props, State> {
       onMouseEnter: (index: number, event: SyntheticMouseEvent<>) =>
         // user's custom onMouseEnter is composed with this.setHighlightedOptionIndex
         composeFunctions(onMouseEnter, setHighlightedOptionIndex)(index, event),
-      ...rest,
+      ...rest
     };
   };
 
@@ -236,7 +236,7 @@ class OptionsBase extends Component<Props, State> {
     if (options.length) {
       const lowerIndexBound = 0;
       const upperIndexBound = options.length - 1;
-      let newIndex = direction === "up" ? currentIndex - 1 : currentIndex + 1;
+      let newIndex = direction === 'up' ? currentIndex - 1 : currentIndex + 1;
 
       // Make sure new index is within options bounds
       newIndex = Math.max(lowerIndexBound, Math.min(newIndex, upperIndexBound));
@@ -246,8 +246,8 @@ class OptionsBase extends Component<Props, State> {
         const canMoveUp = newIndex > lowerIndexBound;
         const canMoveDown = newIndex < upperIndexBound;
         if (
-          (direction === "up" && canMoveUp) ||
-          (direction === "down" && canMoveDown)
+          (direction === 'up' && canMoveUp) ||
+          (direction === 'down' && canMoveDown)
         ) {
           this._handleHighlightMove(newIndex, direction);
         }
@@ -278,11 +278,11 @@ class OptionsBase extends Component<Props, State> {
         break;
       case 38: // Up Arrow key: moves highlighted selection 'up' 1 index
         event.preventDefault(); // prevent caret move
-        this._handleHighlightMove(highlightOptionIndex, "up");
+        this._handleHighlightMove(highlightOptionIndex, 'up');
         break;
       case 40: // Down Arrow key: moves highlighted selection 'down' 1 index
         event.preventDefault(); // prevent caret move
-        this._handleHighlightMove(highlightOptionIndex, "down");
+        this._handleHighlightMove(highlightOptionIndex, 'down');
         break;
       default:
         this.props.resetOnClose && this.setHighlightedOptionIndex(0);
@@ -301,7 +301,7 @@ class OptionsBase extends Component<Props, State> {
       setMouseIsOverOptions(isMouseOverOptions);
     }
     this.setState({
-      isMouseOverOptions,
+      isMouseOverOptions
     });
   };
 

--- a/source/components/ProgressBar.js
+++ b/source/components/ProgressBar.js
@@ -1,14 +1,14 @@
 // @flow
-import React, { Component } from "react";
-import type { ComponentType } from "react";
+import React, { Component } from 'react';
+import type { ComponentType } from 'react';
 
 // internal utility functions
-import { createEmptyContext, withTheme } from "./HOC/withTheme";
-import { composeTheme, addThemeId, didThemePropsChange } from "../utils/themes";
+import { createEmptyContext, withTheme } from './HOC/withTheme';
+import { composeTheme, addThemeId, didThemePropsChange } from '../utils/themes';
 
 // import constants
-import { IDENTIFIERS } from ".";
-import type { ThemeContextProp } from "./HOC/withTheme";
+import { IDENTIFIERS } from '.';
+import type { ThemeContextProp } from './HOC/withTheme';
 
 type Props = {
   className?: string,
@@ -18,22 +18,22 @@ type Props = {
   skin?: ComponentType<any>,
   theme: ?Object, // will take precedence over theme in context if passed
   themeId: string,
-  themeOverrides: Object, // custom css/scss from user that adheres to component's theme API
+  themeOverrides: Object // custom css/scss from user that adheres to component's theme API
 };
 
 type State = {
-  composedTheme: Object,
+  composedTheme: Object
 };
 
 class ProgressBarBase extends Component<Props, State> {
   // define static properties
-  static displayName = "ProgressBar";
+  static displayName = 'ProgressBar';
   static defaultProps = {
     context: createEmptyContext(),
     progress: 100,
     theme: null,
     themeId: IDENTIFIERS.PROGRESS_BAR,
-    themeOverrides: {},
+    themeOverrides: {}
   };
 
   constructor(props: Props) {
@@ -46,7 +46,7 @@ class ProgressBarBase extends Component<Props, State> {
         addThemeId(theme || context.theme, themeId),
         addThemeId(themeOverrides, themeId),
         context.ROOT_THEME_API
-      ),
+      )
     };
   }
 

--- a/source/components/ProgressBar.js
+++ b/source/components/ProgressBar.js
@@ -1,14 +1,14 @@
 // @flow
-import React, { Component } from 'react';
-import type { ComponentType } from 'react';
+import React, { Component } from "react";
+import type { ComponentType } from "react";
 
 // internal utility functions
-import { createEmptyContext, withTheme } from './HOC/withTheme';
-import { composeTheme, addThemeId, didThemePropsChange } from '../utils/themes';
+import { createEmptyContext, withTheme } from "./HOC/withTheme";
+import { composeTheme, addThemeId, didThemePropsChange } from "../utils/themes";
 
 // import constants
-import { IDENTIFIERS } from '.';
-import type { ThemeContextProp } from './HOC/withTheme';
+import { IDENTIFIERS } from ".";
+import type { ThemeContextProp } from "./HOC/withTheme";
 
 type Props = {
   className?: string,
@@ -18,22 +18,22 @@ type Props = {
   skin?: ComponentType<any>,
   theme: ?Object, // will take precedence over theme in context if passed
   themeId: string,
-  themeOverrides: Object // custom css/scss from user that adheres to component's theme API
+  themeOverrides: Object, // custom css/scss from user that adheres to component's theme API
 };
 
 type State = {
-  composedTheme: Object
+  composedTheme: Object,
 };
 
 class ProgressBarBase extends Component<Props, State> {
   // define static properties
-  static displayName = 'ProgressBar';
+  static displayName = "ProgressBar";
   static defaultProps = {
     context: createEmptyContext(),
     progress: 100,
     theme: null,
     themeId: IDENTIFIERS.PROGRESS_BAR,
-    themeOverrides: {}
+    themeOverrides: {},
   };
 
   constructor(props: Props) {
@@ -46,23 +46,19 @@ class ProgressBarBase extends Component<Props, State> {
         addThemeId(theme || context.theme, themeId),
         addThemeId(themeOverrides, themeId),
         context.ROOT_THEME_API
-      )
+      ),
     };
   }
 
-  componentWillReceiveProps(nextProps: Props) {
-    didThemePropsChange(this.props, nextProps, this.setState.bind(this));
+  componentDidUpdate(prevProps: Props) {
+    if (prevProps !== this.props) {
+      didThemePropsChange(prevProps, this.props, this.setState.bind(this));
+    }
   }
 
   render() {
     // destructuring props ensures only the "...rest" get passed down
-    const {
-      skin,
-      theme,
-      themeOverrides,
-      context,
-      ...rest
-    } = this.props;
+    const { skin, theme, themeOverrides, context, ...rest } = this.props;
 
     const ProgressBarSkin = skin || context.skins[IDENTIFIERS.PROGRESS_BAR];
 

--- a/source/components/Radio.js
+++ b/source/components/Radio.js
@@ -1,14 +1,14 @@
 // @flow
-import React, { Component } from 'react';
-import type { ComponentType, Element } from 'react';
+import React, { Component } from "react";
+import type { ComponentType, Element } from "react";
 
 // internal utility functions
-import { createEmptyContext, withTheme } from './HOC/withTheme';
-import { composeTheme, addThemeId, didThemePropsChange } from '../utils/themes';
+import { createEmptyContext, withTheme } from "./HOC/withTheme";
+import { composeTheme, addThemeId, didThemePropsChange } from "../utils/themes";
 
 // import constants
-import { IDENTIFIERS } from '.';
-import type { ThemeContextProp } from './HOC/withTheme';
+import { IDENTIFIERS } from ".";
+import type { ThemeContextProp } from "./HOC/withTheme";
 
 type Props = {
   context: ThemeContextProp,
@@ -21,22 +21,22 @@ type Props = {
   skin?: ComponentType<any>,
   theme: ?Object, // will take precedence over theme in context if passed
   themeId: string,
-  themeOverrides: Object
+  themeOverrides: Object,
 };
 
 type State = {
-  composedTheme: Object
+  composedTheme: Object,
 };
 
 class RadioBase extends Component<Props, State> {
   // define static properties
-  static displayName = 'Radio';
+  static displayName = "Radio";
   static defaultProps = {
     context: createEmptyContext(),
     selected: false,
     theme: null,
     themeId: IDENTIFIERS.RADIO,
-    themeOverrides: {}
+    themeOverrides: {},
   };
 
   constructor(props: Props) {
@@ -49,23 +49,19 @@ class RadioBase extends Component<Props, State> {
         addThemeId(theme || context.theme, themeId),
         addThemeId(themeOverrides, themeId),
         context.ROOT_THEME_API
-      )
+      ),
     };
   }
 
-  componentWillReceiveProps(nextProps: Props) {
-    didThemePropsChange(this.props, nextProps, this.setState.bind(this));
+  componentDidUpdate(prevProps: Props) {
+    if (prevProps !== this.props) {
+      didThemePropsChange(prevProps, this.props, this.setState.bind(this));
+    }
   }
 
   render() {
     // destructuring props ensures only the "...rest" get passed down
-    const {
-      skin,
-      theme,
-      themeOverrides,
-      context,
-      ...rest
-    } = this.props;
+    const { skin, theme, themeOverrides, context, ...rest } = this.props;
 
     const RadioSkin = skin || context.skins[IDENTIFIERS.RADIO];
 

--- a/source/components/Radio.js
+++ b/source/components/Radio.js
@@ -1,14 +1,14 @@
 // @flow
-import React, { Component } from "react";
-import type { ComponentType, Element } from "react";
+import React, { Component } from 'react';
+import type { ComponentType, Element } from 'react';
 
 // internal utility functions
-import { createEmptyContext, withTheme } from "./HOC/withTheme";
-import { composeTheme, addThemeId, didThemePropsChange } from "../utils/themes";
+import { createEmptyContext, withTheme } from './HOC/withTheme';
+import { composeTheme, addThemeId, didThemePropsChange } from '../utils/themes';
 
 // import constants
-import { IDENTIFIERS } from ".";
-import type { ThemeContextProp } from "./HOC/withTheme";
+import { IDENTIFIERS } from '.';
+import type { ThemeContextProp } from './HOC/withTheme';
 
 type Props = {
   context: ThemeContextProp,
@@ -21,22 +21,22 @@ type Props = {
   skin?: ComponentType<any>,
   theme: ?Object, // will take precedence over theme in context if passed
   themeId: string,
-  themeOverrides: Object,
+  themeOverrides: Object
 };
 
 type State = {
-  composedTheme: Object,
+  composedTheme: Object
 };
 
 class RadioBase extends Component<Props, State> {
   // define static properties
-  static displayName = "Radio";
+  static displayName = 'Radio';
   static defaultProps = {
     context: createEmptyContext(),
     selected: false,
     theme: null,
     themeId: IDENTIFIERS.RADIO,
-    themeOverrides: {},
+    themeOverrides: {}
   };
 
   constructor(props: Props) {
@@ -49,7 +49,7 @@ class RadioBase extends Component<Props, State> {
         addThemeId(theme || context.theme, themeId),
         addThemeId(themeOverrides, themeId),
         context.ROOT_THEME_API
-      ),
+      )
     };
   }
 

--- a/source/components/ScrollBar.js
+++ b/source/components/ScrollBar.js
@@ -1,14 +1,14 @@
 // @flow
-import React, { Component } from 'react';
-import type { ComponentType } from 'react';
+import React, { Component } from "react";
+import type { ComponentType } from "react";
 
 // internal utility functions
-import { createEmptyContext, withTheme } from './HOC/withTheme';
-import { composeTheme, addThemeId, didThemePropsChange } from '../utils/themes';
+import { createEmptyContext, withTheme } from "./HOC/withTheme";
+import { composeTheme, addThemeId, didThemePropsChange } from "../utils/themes";
 
 // import constants
-import { IDENTIFIERS } from '.';
-import type { ThemeContextProp } from './HOC/withTheme';
+import { IDENTIFIERS } from ".";
+import type { ThemeContextProp } from "./HOC/withTheme";
 
 type Props = {
   className?: string,
@@ -16,21 +16,21 @@ type Props = {
   skin?: ComponentType<any>,
   theme: ?Object, // will take precedence over theme in context if passed
   themeId: string,
-  themeOverrides: Object // custom css/scss from user that adheres to component's theme API
+  themeOverrides: Object, // custom css/scss from user that adheres to component's theme API
 };
 
 type State = {
-  composedTheme: Object
+  composedTheme: Object,
 };
 
 class ScrollBarBase extends Component<Props, State> {
   // define static properties
-  static displayName = 'ScrollBar';
+  static displayName = "ScrollBar";
   static defaultProps = {
     context: createEmptyContext(),
     theme: null,
     themeId: IDENTIFIERS.SCROLLBAR,
-    themeOverrides: {}
+    themeOverrides: {},
   };
 
   constructor(props: Props) {
@@ -43,23 +43,19 @@ class ScrollBarBase extends Component<Props, State> {
         addThemeId(theme || context.theme, themeId),
         addThemeId(themeOverrides, themeId),
         context.ROOT_THEME_API
-      )
+      ),
     };
   }
 
-  componentWillReceiveProps(nextProps: Props) {
-    didThemePropsChange(this.props, nextProps, this.setState.bind(this));
+  componentDidUpdate(prevProps: Props) {
+    if (prevProps !== this.props) {
+      didThemePropsChange(prevProps, this.props, this.setState.bind(this));
+    }
   }
 
   render() {
     // destructuring props ensures only the "...rest" get passed down
-    const {
-      skin,
-      theme,
-      themeOverrides,
-      context,
-      ...rest
-    } = this.props;
+    const { skin, theme, themeOverrides, context, ...rest } = this.props;
 
     const ScrollBarSkin = skin || context.skins[IDENTIFIERS.SCROLLBAR];
 

--- a/source/components/ScrollBar.js
+++ b/source/components/ScrollBar.js
@@ -1,14 +1,14 @@
 // @flow
-import React, { Component } from "react";
-import type { ComponentType } from "react";
+import React, { Component } from 'react';
+import type { ComponentType } from 'react';
 
 // internal utility functions
-import { createEmptyContext, withTheme } from "./HOC/withTheme";
-import { composeTheme, addThemeId, didThemePropsChange } from "../utils/themes";
+import { createEmptyContext, withTheme } from './HOC/withTheme';
+import { composeTheme, addThemeId, didThemePropsChange } from '../utils/themes';
 
 // import constants
-import { IDENTIFIERS } from ".";
-import type { ThemeContextProp } from "./HOC/withTheme";
+import { IDENTIFIERS } from '.';
+import type { ThemeContextProp } from './HOC/withTheme';
 
 type Props = {
   className?: string,
@@ -16,21 +16,21 @@ type Props = {
   skin?: ComponentType<any>,
   theme: ?Object, // will take precedence over theme in context if passed
   themeId: string,
-  themeOverrides: Object, // custom css/scss from user that adheres to component's theme API
+  themeOverrides: Object // custom css/scss from user that adheres to component's theme API
 };
 
 type State = {
-  composedTheme: Object,
+  composedTheme: Object
 };
 
 class ScrollBarBase extends Component<Props, State> {
   // define static properties
-  static displayName = "ScrollBar";
+  static displayName = 'ScrollBar';
   static defaultProps = {
     context: createEmptyContext(),
     theme: null,
     themeId: IDENTIFIERS.SCROLLBAR,
-    themeOverrides: {},
+    themeOverrides: {}
   };
 
   constructor(props: Props) {
@@ -43,7 +43,7 @@ class ScrollBarBase extends Component<Props, State> {
         addThemeId(theme || context.theme, themeId),
         addThemeId(themeOverrides, themeId),
         context.ROOT_THEME_API
-      ),
+      )
     };
   }
 

--- a/source/components/Select.js
+++ b/source/components/Select.js
@@ -1,18 +1,18 @@
 // @flow
-import React, { Component } from 'react';
-import type { ComponentType, Element } from 'react';
-import createRef from 'create-react-ref/lib/createRef';
+import React, { Component } from "react";
+import type { ComponentType, Element } from "react";
+import createRef from "create-react-ref/lib/createRef";
 
 // internal components
-import { GlobalListeners } from './HOC/GlobalListeners';
+import { GlobalListeners } from "./HOC/GlobalListeners";
 
 // internal utility functions
-import { createEmptyContext, withTheme } from './HOC/withTheme';
-import { composeTheme, addThemeId, didThemePropsChange } from '../utils/themes';
+import { createEmptyContext, withTheme } from "./HOC/withTheme";
+import { composeTheme, addThemeId, didThemePropsChange } from "../utils/themes";
 
 // import constants
-import { IDENTIFIERS } from '.';
-import type { ThemeContextProp } from './HOC/withTheme';
+import { IDENTIFIERS } from ".";
+import type { ThemeContextProp } from "./HOC/withTheme";
 
 type Props = {
   allowBlank: boolean,
@@ -46,11 +46,11 @@ type State = {
 class SelectBase extends Component<Props, State> {
   // declare ref types
   rootElement: ?Element<*>;
-  inputElement: Element<'input'>;
+  inputElement: Element<"input">;
   optionsElement: ?Element<*>;
 
   // define static properties
-  static displayName = 'Select';
+  static displayName = "Select";
   static defaultProps = {
     allowBlank: true,
     autoFocus: false,
@@ -60,7 +60,7 @@ class SelectBase extends Component<Props, State> {
     theme: null,
     themeOverrides: {},
     themeId: IDENTIFIERS.SELECT,
-    value: ''
+    value: "",
   };
 
   constructor(props: Props) {
@@ -91,8 +91,10 @@ class SelectBase extends Component<Props, State> {
     }
   }
 
-  componentWillReceiveProps(nextProps: Props) {
-    didThemePropsChange(this.props, nextProps, this.setState.bind(this));
+  componentDidUpdate(prevProps: Props) {
+    if (prevProps !== this.props) {
+      didThemePropsChange(prevProps, this.props, this.setState.bind(this));
+    }
   }
 
   // ========= PUBLIC SKIN API =========
@@ -102,23 +104,29 @@ class SelectBase extends Component<Props, State> {
   focus = () => this.toggleOpen();
 
   toggleOpen = () => {
-    if (this.state.isOpen && this.optionsElement && this.optionsElement.current) {
+    if (
+      this.state.isOpen &&
+      this.optionsElement &&
+      this.optionsElement.current
+    ) {
       // set Options scroll position to top on close
       this.optionsElement.current.scrollTop = 0;
     }
     this.setState({ isOpen: !this.state.isOpen });
   };
 
-  toggleMouseLocation = () => (
-    this.setState({ mouseIsOverOptions: !this.state.mouseIsOverOptions })
-  );
+  toggleMouseLocation = () =>
+    this.setState({ mouseIsOverOptions: !this.state.mouseIsOverOptions });
 
   handleInputClick = (event: SyntheticMouseEvent<>) => {
     event.stopPropagation();
     event.preventDefault();
 
     const { inputElement } = this;
-    if (inputElement.current && document.activeElement === inputElement.current) {
+    if (
+      inputElement.current &&
+      document.activeElement === inputElement.current
+    ) {
       inputElement.current.blur();
     }
     this.toggleOpen();

--- a/source/components/Select.js
+++ b/source/components/Select.js
@@ -1,18 +1,18 @@
 // @flow
-import React, { Component } from "react";
-import type { ComponentType, Element } from "react";
-import createRef from "create-react-ref/lib/createRef";
+import React, { Component } from 'react';
+import type { ComponentType, Element } from 'react';
+import createRef from 'create-react-ref/lib/createRef';
 
 // internal components
-import { GlobalListeners } from "./HOC/GlobalListeners";
+import { GlobalListeners } from './HOC/GlobalListeners';
 
 // internal utility functions
-import { createEmptyContext, withTheme } from "./HOC/withTheme";
-import { composeTheme, addThemeId, didThemePropsChange } from "../utils/themes";
+import { createEmptyContext, withTheme } from './HOC/withTheme';
+import { composeTheme, addThemeId, didThemePropsChange } from '../utils/themes';
 
 // import constants
-import { IDENTIFIERS } from ".";
-import type { ThemeContextProp } from "./HOC/withTheme";
+import { IDENTIFIERS } from '.';
+import type { ThemeContextProp } from './HOC/withTheme';
 
 type Props = {
   allowBlank: boolean,
@@ -34,23 +34,23 @@ type Props = {
   themeId: string,
   themeOverrides: Object,
   value: string,
-  optionHeight?: number,
+  optionHeight?: number
 };
 
 type State = {
   composedTheme: Object,
   isOpen: boolean,
-  mouseIsOverOptions: boolean,
+  mouseIsOverOptions: boolean
 };
 
 class SelectBase extends Component<Props, State> {
   // declare ref types
   rootElement: ?Element<*>;
-  inputElement: Element<"input">;
+  inputElement: Element<'input'>;
   optionsElement: ?Element<*>;
 
   // define static properties
-  static displayName = "Select";
+  static displayName = 'Select';
   static defaultProps = {
     allowBlank: true,
     autoFocus: false,
@@ -60,7 +60,7 @@ class SelectBase extends Component<Props, State> {
     theme: null,
     themeOverrides: {},
     themeId: IDENTIFIERS.SELECT,
-    value: "",
+    value: ''
   };
 
   constructor(props: Props) {
@@ -80,7 +80,7 @@ class SelectBase extends Component<Props, State> {
         context.ROOT_THEME_API
       ),
       isOpen: false,
-      mouseIsOverOptions: false,
+      mouseIsOverOptions: false
     };
   }
 

--- a/source/components/Stepper.js
+++ b/source/components/Stepper.js
@@ -1,14 +1,14 @@
 // @flow
-import React, { Component } from 'react';
-import type { ComponentType } from 'react';
+import React, { Component } from "react";
+import type { ComponentType } from "react";
 
 // internal utility functions
-import { createEmptyContext, withTheme } from './HOC/withTheme';
-import { composeTheme, addThemeId, didThemePropsChange } from '../utils/themes';
+import { createEmptyContext, withTheme } from "./HOC/withTheme";
+import { composeTheme, addThemeId, didThemePropsChange } from "../utils/themes";
 
 // import constants
-import { IDENTIFIERS } from '.';
-import type { ThemeContextProp } from './HOC/withTheme';
+import { IDENTIFIERS } from ".";
+import type { ThemeContextProp } from "./HOC/withTheme";
 
 type Props = {
   activeStep?: number,
@@ -25,17 +25,17 @@ type Props = {
 };
 
 type State = {
-  composedTheme: Object
+  composedTheme: Object,
 };
 
 class StepperBase extends Component<Props, State> {
   // define static properties
-  static displayName = 'Stepper';
+  static displayName = "Stepper";
   static defaultProps = {
     context: createEmptyContext(),
     theme: null,
     themeId: IDENTIFIERS.STEPPER,
-    themeOverrides: {}
+    themeOverrides: {},
   };
 
   constructor(props: Props) {
@@ -48,23 +48,19 @@ class StepperBase extends Component<Props, State> {
         addThemeId(theme || context.theme, themeId),
         addThemeId(themeOverrides, themeId),
         context.ROOT_THEME_API
-      )
+      ),
     };
   }
 
-  componentWillReceiveProps(nextProps: Props) {
-    didThemePropsChange(this.props, nextProps, this.setState.bind(this));
+  componentDidUpdate(prevProps: Props) {
+    if (prevProps !== this.props) {
+      didThemePropsChange(prevProps, this.props, this.setState.bind(this));
+    }
   }
 
   render() {
     // destructuring props ensures only the "...rest" get passed down
-    const {
-      skin,
-      theme,
-      themeOverrides,
-      context,
-      ...rest
-    } = this.props;
+    const { skin, theme, themeOverrides, context, ...rest } = this.props;
 
     const StepperSkin = skin || context.skins[this.props.themeId];
 

--- a/source/components/Stepper.js
+++ b/source/components/Stepper.js
@@ -1,14 +1,14 @@
 // @flow
-import React, { Component } from "react";
-import type { ComponentType } from "react";
+import React, { Component } from 'react';
+import type { ComponentType } from 'react';
 
 // internal utility functions
-import { createEmptyContext, withTheme } from "./HOC/withTheme";
-import { composeTheme, addThemeId, didThemePropsChange } from "../utils/themes";
+import { createEmptyContext, withTheme } from './HOC/withTheme';
+import { composeTheme, addThemeId, didThemePropsChange } from '../utils/themes';
 
 // import constants
-import { IDENTIFIERS } from ".";
-import type { ThemeContextProp } from "./HOC/withTheme";
+import { IDENTIFIERS } from '.';
+import type { ThemeContextProp } from './HOC/withTheme';
 
 type Props = {
   activeStep?: number,
@@ -21,21 +21,21 @@ type Props = {
   steps: Array<string>,
   theme: ?Object, // will take precedence over theme in context if passed
   themeId: string,
-  themeOverrides: Object,
+  themeOverrides: Object
 };
 
 type State = {
-  composedTheme: Object,
+  composedTheme: Object
 };
 
 class StepperBase extends Component<Props, State> {
   // define static properties
-  static displayName = "Stepper";
+  static displayName = 'Stepper';
   static defaultProps = {
     context: createEmptyContext(),
     theme: null,
     themeId: IDENTIFIERS.STEPPER,
-    themeOverrides: {},
+    themeOverrides: {}
   };
 
   constructor(props: Props) {
@@ -48,7 +48,7 @@ class StepperBase extends Component<Props, State> {
         addThemeId(theme || context.theme, themeId),
         addThemeId(themeOverrides, themeId),
         context.ROOT_THEME_API
-      ),
+      )
     };
   }
 

--- a/source/components/TextArea.js
+++ b/source/components/TextArea.js
@@ -1,18 +1,18 @@
 // @flow
-import React, { Component } from "react";
-import type { ComponentType, Node, Element } from "react";
+import React, { Component } from 'react';
+import type { ComponentType, Node, Element } from 'react';
 
 // external libraries
-import createRef from "create-react-ref/lib/createRef";
-import { isString, flow } from "lodash";
+import createRef from 'create-react-ref/lib/createRef';
+import { isString, flow } from 'lodash';
 
 // internal utility functions
-import { createEmptyContext, withTheme } from "./HOC/withTheme";
-import { composeTheme, addThemeId, didThemePropsChange } from "../utils/themes";
+import { createEmptyContext, withTheme } from './HOC/withTheme';
+import { composeTheme, addThemeId, didThemePropsChange } from '../utils/themes';
 
 // import constants
-import { IDENTIFIERS } from ".";
-import type { ThemeContextProp } from "./HOC/withTheme";
+import { IDENTIFIERS } from '.';
+import type { ThemeContextProp } from './HOC/withTheme';
 
 type Props = {
   autoFocus: boolean,
@@ -33,20 +33,20 @@ type Props = {
   theme: ?Object, // will take precedence over theme in context if passed
   themeId: string,
   themeOverrides: Object,
-  value: string,
+  value: string
 };
 
 type State = {
   error: string,
-  composedTheme: Object,
+  composedTheme: Object
 };
 
 class TextAreaBase extends Component<Props, State> {
   // declare ref types
-  textareaElement: Element<"textarea">;
+  textareaElement: Element<'textarea'>;
 
   // define static properties
-  static displayName = "TextArea";
+  static displayName = 'TextArea';
   static defaultProps = {
     autoFocus: false,
     autoResize: true,
@@ -54,7 +54,7 @@ class TextAreaBase extends Component<Props, State> {
     theme: null,
     themeId: IDENTIFIERS.TEXT_AREA,
     themeOverrides: {},
-    value: "",
+    value: ''
   };
 
   constructor(props: Props) {
@@ -71,7 +71,7 @@ class TextAreaBase extends Component<Props, State> {
         addThemeId(themeOverrides, themeId),
         context.ROOT_THEME_API
       ),
-      error: "",
+      error: ''
     };
   }
 
@@ -79,7 +79,7 @@ class TextAreaBase extends Component<Props, State> {
     const { autoResize, autoFocus } = this.props;
 
     if (autoResize) {
-      window.addEventListener("resize", this._handleAutoresize);
+      window.addEventListener('resize', this._handleAutoresize);
       this._handleAutoresize();
     }
 
@@ -93,9 +93,9 @@ class TextAreaBase extends Component<Props, State> {
 
     if (prevProps !== this.props) {
       if (!prevProps.autoResize && this.props.autoResize) {
-        window.addEventListener("resize", this._handleAutoresize);
+        window.addEventListener('resize', this._handleAutoresize);
       } else if (prevProps.autoResize && !this.props.autoResize) {
-        window.removeEventListener("resize", this._handleAutoresize);
+        window.removeEventListener('resize', this._handleAutoresize);
       }
 
       didThemePropsChange(prevProps, this.props, this.setState.bind(this));
@@ -104,7 +104,7 @@ class TextAreaBase extends Component<Props, State> {
 
   componentWillUnmount() {
     if (this.props.autoResize) {
-      window.removeEventListener("resize", this._handleAutoresize);
+      window.removeEventListener('resize', this._handleAutoresize);
     }
   }
 
@@ -127,13 +127,13 @@ class TextAreaBase extends Component<Props, State> {
     return flow([
       this._enforceStringValue,
       this._enforceMaxLength,
-      this._enforceMinLength,
+      this._enforceMinLength
     ]).call(this, value);
   }
 
   _enforceStringValue(value: string) {
     if (!isString(value)) {
-      throw new Error("Values passed to TextArea::onChange must be strings");
+      throw new Error('Values passed to TextArea::onChange must be strings');
     }
     return value;
   }
@@ -149,9 +149,9 @@ class TextAreaBase extends Component<Props, State> {
     const isTooShort = minLength != null && value.length < minLength;
 
     if (isTooShort) {
-      this._setError("Please enter a valid input");
-    } else if (this.state.error !== "") {
-      this._setError("");
+      this._setError('Please enter a valid input');
+    } else if (this.state.error !== '') {
+      this._setError('');
     }
 
     return value;
@@ -163,15 +163,15 @@ class TextAreaBase extends Component<Props, State> {
     if (!textareaElement.current) return;
 
     // compute the height difference between inner height and outer height
-    const style = getComputedStyle(textareaElement.current, "");
+    const style = getComputedStyle(textareaElement.current, '');
     const heightOffset =
-      style.boxSizing === "content-box"
+      style.boxSizing === 'content-box'
         ? -(parseFloat(style.paddingTop) + parseFloat(style.paddingBottom))
         : parseFloat(style.borderTopWidth) +
           parseFloat(style.borderBottomWidth);
 
     // resize the input to its content size
-    textareaElement.current.style.height = "auto";
+    textareaElement.current.style.height = 'auto';
     textareaElement.current.style.height = `${
       textareaElement.current.scrollHeight + heightOffset
     }px`;

--- a/source/components/TextArea.js
+++ b/source/components/TextArea.js
@@ -1,18 +1,18 @@
 // @flow
-import React, { Component } from 'react';
-import type { ComponentType, Node, Element } from 'react';
+import React, { Component } from "react";
+import type { ComponentType, Node, Element } from "react";
 
 // external libraries
-import createRef from 'create-react-ref/lib/createRef';
-import { isString, flow } from 'lodash';
+import createRef from "create-react-ref/lib/createRef";
+import { isString, flow } from "lodash";
 
 // internal utility functions
-import { createEmptyContext, withTheme } from './HOC/withTheme';
-import { composeTheme, addThemeId, didThemePropsChange } from '../utils/themes';
+import { createEmptyContext, withTheme } from "./HOC/withTheme";
+import { composeTheme, addThemeId, didThemePropsChange } from "../utils/themes";
 
 // import constants
-import { IDENTIFIERS } from '.';
-import type { ThemeContextProp } from './HOC/withTheme';
+import { IDENTIFIERS } from ".";
+import type { ThemeContextProp } from "./HOC/withTheme";
 
 type Props = {
   autoFocus: boolean,
@@ -33,20 +33,20 @@ type Props = {
   theme: ?Object, // will take precedence over theme in context if passed
   themeId: string,
   themeOverrides: Object,
-  value: string
+  value: string,
 };
 
 type State = {
   error: string,
-  composedTheme: Object
+  composedTheme: Object,
 };
 
 class TextAreaBase extends Component<Props, State> {
   // declare ref types
-  textareaElement: Element<'textarea'>;
+  textareaElement: Element<"textarea">;
 
   // define static properties
-  static displayName = 'TextArea';
+  static displayName = "TextArea";
   static defaultProps = {
     autoFocus: false,
     autoResize: true,
@@ -54,7 +54,7 @@ class TextAreaBase extends Component<Props, State> {
     theme: null,
     themeId: IDENTIFIERS.TEXT_AREA,
     themeOverrides: {},
-    value: ''
+    value: "",
   };
 
   constructor(props: Props) {
@@ -71,7 +71,7 @@ class TextAreaBase extends Component<Props, State> {
         addThemeId(themeOverrides, themeId),
         context.ROOT_THEME_API
       ),
-      error: ''
+      error: "",
     };
   }
 
@@ -79,30 +79,32 @@ class TextAreaBase extends Component<Props, State> {
     const { autoResize, autoFocus } = this.props;
 
     if (autoResize) {
-      window.addEventListener('resize', this._handleAutoresize);
+      window.addEventListener("resize", this._handleAutoresize);
       this._handleAutoresize();
     }
 
-    if (autoFocus) { this.focus(); }
-  }
-
-  componentWillReceiveProps(nextProps: Props) {
-    if (!this.props.autoResize && nextProps.autoResize) {
-      window.addEventListener('resize', this._handleAutoresize);
-    } else if (this.props.autoResize && !nextProps.autoResize) {
-      window.removeEventListener('resize', this._handleAutoresize);
+    if (autoFocus) {
+      this.focus();
     }
-
-    didThemePropsChange(this.props, nextProps, this.setState.bind(this));
   }
 
-  componentDidUpdate() {
+  componentDidUpdate(prevProps: Props) {
     if (this.props.autoResize) this._handleAutoresize();
+
+    if (prevProps !== this.props) {
+      if (!prevProps.autoResize && this.props.autoResize) {
+        window.addEventListener("resize", this._handleAutoresize);
+      } else if (prevProps.autoResize && !this.props.autoResize) {
+        window.removeEventListener("resize", this._handleAutoresize);
+      }
+
+      didThemePropsChange(prevProps, this.props, this.setState.bind(this));
+    }
   }
 
   componentWillUnmount() {
     if (this.props.autoResize) {
-      window.removeEventListener('resize', this._handleAutoresize);
+      window.removeEventListener("resize", this._handleAutoresize);
     }
   }
 
@@ -125,13 +127,13 @@ class TextAreaBase extends Component<Props, State> {
     return flow([
       this._enforceStringValue,
       this._enforceMaxLength,
-      this._enforceMinLength
+      this._enforceMinLength,
     ]).call(this, value);
   }
 
   _enforceStringValue(value: string) {
     if (!isString(value)) {
-      throw new Error('Values passed to TextArea::onChange must be strings');
+      throw new Error("Values passed to TextArea::onChange must be strings");
     }
     return value;
   }
@@ -147,9 +149,9 @@ class TextAreaBase extends Component<Props, State> {
     const isTooShort = minLength != null && value.length < minLength;
 
     if (isTooShort) {
-      this._setError('Please enter a valid input');
-    } else if (this.state.error !== '') {
-      this._setError('');
+      this._setError("Please enter a valid input");
+    } else if (this.state.error !== "") {
+      this._setError("");
     }
 
     return value;
@@ -161,17 +163,18 @@ class TextAreaBase extends Component<Props, State> {
     if (!textareaElement.current) return;
 
     // compute the height difference between inner height and outer height
-    const style = getComputedStyle(textareaElement.current, '');
+    const style = getComputedStyle(textareaElement.current, "");
     const heightOffset =
-      style.boxSizing === 'content-box'
+      style.boxSizing === "content-box"
         ? -(parseFloat(style.paddingTop) + parseFloat(style.paddingBottom))
         : parseFloat(style.borderTopWidth) +
           parseFloat(style.borderBottomWidth);
 
     // resize the input to its content size
-    textareaElement.current.style.height = 'auto';
-    textareaElement.current.style.height = `${textareaElement.current.scrollHeight +
-      heightOffset}px`;
+    textareaElement.current.style.height = "auto";
+    textareaElement.current.style.height = `${
+      textareaElement.current.scrollHeight + heightOffset
+    }px`;
   }
 
   render() {

--- a/source/components/ThemeProvider.js
+++ b/source/components/ThemeProvider.js
@@ -1,39 +1,39 @@
 // @flow
-import React, { Component } from "react";
-import type { Node } from "react";
+import React, { Component } from 'react';
+import type { Node } from 'react';
 
 // external libraries
-import { isEmpty, isEqual, cloneDeep } from "lodash";
+import { isEmpty, isEqual, cloneDeep } from 'lodash';
 
 // contains default theme and context provider
-import { ThemeContext } from "./HOC/ThemeContext";
+import { ThemeContext } from './HOC/ThemeContext';
 
 // imports the Root Theme API object which specifies the shape
 // of a complete theme for every component in this library, used in this.composeLibraryTheme
-import { ROOT_THEME_API } from "../themes/API";
+import { ROOT_THEME_API } from '../themes/API';
 
 // internal utility functions
-import { appendToProperty } from "../utils/themes";
-import { hasProperty } from "../utils/props";
+import { appendToProperty } from '../utils/themes';
+import { hasProperty } from '../utils/props';
 
 type Props = {
   children?: ?Node,
   skins: Object,
   theme: Object,
-  themeOverrides: Object, // custom css/scss from user that adheres to shape of ROOT_THEME_API
+  themeOverrides: Object // custom css/scss from user that adheres to shape of ROOT_THEME_API
 };
 
 type State = {
-  theme: Object,
+  theme: Object
 };
 
 export class ThemeProvider extends Component<Props, State> {
   // define static properties
-  static displayName = "ThemeProvider";
+  static displayName = 'ThemeProvider';
   static defaultProps = {
     skins: {},
     theme: {},
-    themeOverrides: {},
+    themeOverrides: {}
   };
 
   constructor(props: Props) {
@@ -42,7 +42,7 @@ export class ThemeProvider extends Component<Props, State> {
     const { theme, themeOverrides } = props;
 
     this.state = {
-      theme: this._composeLibraryTheme(theme, themeOverrides),
+      theme: this._composeLibraryTheme(theme, themeOverrides)
     };
   }
 
@@ -55,7 +55,7 @@ export class ThemeProvider extends Component<Props, State> {
       !isEqual(prevThemeOverrides, themeOverrides)
     ) {
       this.setState(() => ({
-        theme: this._composeLibraryTheme(theme, themeOverrides),
+        theme: this._composeLibraryTheme(theme, themeOverrides)
       }));
     }
   }

--- a/source/components/ThemeProvider.js
+++ b/source/components/ThemeProvider.js
@@ -1,26 +1,26 @@
 // @flow
-import React, { Component } from 'react';
-import type { Node } from 'react';
+import React, { Component } from "react";
+import type { Node } from "react";
 
 // external libraries
-import { isEmpty, isEqual, cloneDeep } from 'lodash';
+import { isEmpty, isEqual, cloneDeep } from "lodash";
 
 // contains default theme and context provider
-import { ThemeContext } from './HOC/ThemeContext';
+import { ThemeContext } from "./HOC/ThemeContext";
 
 // imports the Root Theme API object which specifies the shape
 // of a complete theme for every component in this library, used in this.composeLibraryTheme
-import { ROOT_THEME_API } from '../themes/API';
+import { ROOT_THEME_API } from "../themes/API";
 
 // internal utility functions
-import { appendToProperty } from '../utils/themes';
-import { hasProperty } from '../utils/props';
+import { appendToProperty } from "../utils/themes";
+import { hasProperty } from "../utils/props";
 
 type Props = {
   children?: ?Node,
   skins: Object,
   theme: Object,
-  themeOverrides: Object // custom css/scss from user that adheres to shape of ROOT_THEME_API
+  themeOverrides: Object, // custom css/scss from user that adheres to shape of ROOT_THEME_API
 };
 
 type State = {
@@ -29,11 +29,11 @@ type State = {
 
 export class ThemeProvider extends Component<Props, State> {
   // define static properties
-  static displayName = 'ThemeProvider';
+  static displayName = "ThemeProvider";
   static defaultProps = {
     skins: {},
     theme: {},
-    themeOverrides: {}
+    themeOverrides: {},
   };
 
   constructor(props: Props) {
@@ -42,17 +42,20 @@ export class ThemeProvider extends Component<Props, State> {
     const { theme, themeOverrides } = props;
 
     this.state = {
-      theme: this._composeLibraryTheme(theme, themeOverrides)
+      theme: this._composeLibraryTheme(theme, themeOverrides),
     };
   }
 
-  componentWillReceiveProps(nextProps: Props) {
+  componentDidUpdate(prevProps: Props) {
+    const { theme: prevTheme, themeOverrides: prevThemeOverrides } = prevProps;
     const { theme, themeOverrides } = this.props;
-    const { theme: nextTheme, themeOverrides: nextOverrides } = nextProps;
 
-    if (!isEqual(theme, nextTheme) || !isEqual(themeOverrides, nextOverrides)) {
+    if (
+      !isEqual(prevTheme, theme) ||
+      !isEqual(prevThemeOverrides, themeOverrides)
+    ) {
       this.setState(() => ({
-        theme: this._composeLibraryTheme(nextTheme, nextOverrides)
+        theme: this._composeLibraryTheme(theme, themeOverrides),
       }));
     }
   }
@@ -70,7 +73,9 @@ export class ThemeProvider extends Component<Props, State> {
   //  }
   _composeLibraryTheme = (theme: Object, themeOverrides: Object) => {
     // if themeOverrides is empty, no need for composition
-    if (isEmpty(themeOverrides)) { return theme; }
+    if (isEmpty(themeOverrides)) {
+      return theme;
+    }
 
     // final object to be returned
     const composedTheme = {};
@@ -78,7 +83,6 @@ export class ThemeProvider extends Component<Props, State> {
     for (const componentName in ROOT_THEME_API) {
       // check if ROOT_THEME_API contains the key of componentName
       if (hasProperty(ROOT_THEME_API, componentName)) {
-
         // check if theme contains a key of componentName
         if (hasProperty(theme, componentName)) {
           // add componentName as a key to final return obj
@@ -105,7 +109,9 @@ export class ThemeProvider extends Component<Props, State> {
     componentThemeAPI: Object
   ) => {
     // Return componentTheme if there are no overrides provided
-    if (isEmpty(componentThemeOverrides)) { return componentTheme; }
+    if (isEmpty(componentThemeOverrides)) {
+      return componentTheme;
+    }
 
     // final composed theme obj to be returned at end
     const composedComponentTheme = cloneDeep(componentThemeAPI);
@@ -113,16 +119,24 @@ export class ThemeProvider extends Component<Props, State> {
     for (const className in componentThemeAPI) {
       if (hasProperty(componentThemeAPI, className)) {
         if (hasProperty(componentTheme, className)) {
-          appendToProperty(composedComponentTheme, className, componentTheme[className]);
+          appendToProperty(
+            composedComponentTheme,
+            className,
+            componentTheme[className]
+          );
         }
 
         if (hasProperty(componentThemeOverrides, className)) {
-          appendToProperty(composedComponentTheme, className, componentThemeOverrides[className]);
+          appendToProperty(
+            composedComponentTheme,
+            className,
+            componentThemeOverrides[className]
+          );
         }
       }
     }
     return composedComponentTheme;
-  }
+  };
 
   render() {
     const { theme } = this.state;

--- a/source/components/Tooltip.js
+++ b/source/components/Tooltip.js
@@ -1,14 +1,14 @@
 // @flow
-import React, { Component } from "react";
-import type { ComponentType, Element, Node } from "react";
+import React, { Component } from 'react';
+import type { ComponentType, Element, Node } from 'react';
 
 // internal utility functions
-import { createEmptyContext, withTheme } from "./HOC/withTheme";
-import { composeTheme, addThemeId, didThemePropsChange } from "../utils/themes";
+import { createEmptyContext, withTheme } from './HOC/withTheme';
+import { composeTheme, addThemeId, didThemePropsChange } from '../utils/themes';
 
 // import constants
-import { IDENTIFIERS } from ".";
-import type { ThemeContextProp } from "./HOC/withTheme";
+import { IDENTIFIERS } from '.';
+import type { ThemeContextProp } from './HOC/withTheme';
 
 export type TooltipProps = {
   children: ?Node,
@@ -25,16 +25,16 @@ export type TooltipProps = {
   theme: ?Object, // will take precedence over theme in context if passed
   themeOverrides: Object, // custom css/scss from user that adheres to component's theme API
   themeId: string,
-  tip?: string | Element<any>,
+  tip?: string | Element<any>
 };
 
 type State = {
-  composedTheme: Object,
+  composedTheme: Object
 };
 
 class TooltipBase extends Component<TooltipProps, State> {
   // define static properties
-  static displayName = "Tooltip";
+  static displayName = 'Tooltip';
   static defaultProps = {
     context: createEmptyContext(),
     isBounded: false,
@@ -45,7 +45,7 @@ class TooltipBase extends Component<TooltipProps, State> {
     arrowRelativeToTip: false,
     theme: null,
     themeId: IDENTIFIERS.TOOLTIP,
-    themeOverrides: {},
+    themeOverrides: {}
   };
 
   constructor(props: TooltipProps) {
@@ -58,7 +58,7 @@ class TooltipBase extends Component<TooltipProps, State> {
         addThemeId(theme || context.theme, themeId),
         addThemeId(themeOverrides, themeId),
         context.ROOT_THEME_API
-      ),
+      )
     };
   }
 

--- a/source/components/Tooltip.js
+++ b/source/components/Tooltip.js
@@ -1,14 +1,14 @@
 // @flow
-import React, { Component } from 'react';
-import type { ComponentType, Element, Node } from 'react';
+import React, { Component } from "react";
+import type { ComponentType, Element, Node } from "react";
 
 // internal utility functions
-import { createEmptyContext, withTheme } from './HOC/withTheme';
-import { composeTheme, addThemeId, didThemePropsChange } from '../utils/themes';
+import { createEmptyContext, withTheme } from "./HOC/withTheme";
+import { composeTheme, addThemeId, didThemePropsChange } from "../utils/themes";
 
 // import constants
-import { IDENTIFIERS } from '.';
-import type { ThemeContextProp } from './HOC/withTheme';
+import { IDENTIFIERS } from ".";
+import type { ThemeContextProp } from "./HOC/withTheme";
 
 export type TooltipProps = {
   children: ?Node,
@@ -25,16 +25,16 @@ export type TooltipProps = {
   theme: ?Object, // will take precedence over theme in context if passed
   themeOverrides: Object, // custom css/scss from user that adheres to component's theme API
   themeId: string,
-  tip?: string | Element<any>
+  tip?: string | Element<any>,
 };
 
 type State = {
-  composedTheme: Object
+  composedTheme: Object,
 };
 
 class TooltipBase extends Component<TooltipProps, State> {
   // define static properties
-  static displayName = 'Tooltip';
+  static displayName = "Tooltip";
   static defaultProps = {
     context: createEmptyContext(),
     isBounded: false,
@@ -45,7 +45,7 @@ class TooltipBase extends Component<TooltipProps, State> {
     arrowRelativeToTip: false,
     theme: null,
     themeId: IDENTIFIERS.TOOLTIP,
-    themeOverrides: {}
+    themeOverrides: {},
   };
 
   constructor(props: TooltipProps) {
@@ -58,12 +58,14 @@ class TooltipBase extends Component<TooltipProps, State> {
         addThemeId(theme || context.theme, themeId),
         addThemeId(themeOverrides, themeId),
         context.ROOT_THEME_API
-      )
+      ),
     };
   }
 
-  componentWillReceiveProps(nextProps: TooltipProps) {
-    didThemePropsChange(this.props, nextProps, this.setState.bind(this));
+  componentDidUpdate(prevProps: Props) {
+    if (prevProps !== this.props) {
+      didThemePropsChange(prevProps, this.props, this.setState.bind(this));
+    }
   }
 
   render() {

--- a/source/components/Tooltip.js
+++ b/source/components/Tooltip.js
@@ -62,7 +62,7 @@ class TooltipBase extends Component<TooltipProps, State> {
     };
   }
 
-  componentDidUpdate(prevProps: Props) {
+  componentDidUpdate(prevProps: TooltipProps) {
     if (prevProps !== this.props) {
       didThemePropsChange(prevProps, this.props, this.setState.bind(this));
     }

--- a/source/components/layout/Flex.js
+++ b/source/components/layout/Flex.js
@@ -1,22 +1,22 @@
 // @flow
-import React, { Component } from "react";
-import type { Node } from "react";
-import { pickBy } from "lodash";
+import React, { Component } from 'react';
+import type { Node } from 'react';
+import { pickBy } from 'lodash';
 
 // components
-import { Base } from "./Base";
+import { Base } from './Base';
 
 // utilities
-import { createEmptyContext, withTheme } from "../HOC/withTheme";
+import { createEmptyContext, withTheme } from '../HOC/withTheme';
 import {
   composeTheme,
   addThemeId,
-  didThemePropsChange,
-} from "../../utils/themes";
+  didThemePropsChange
+} from '../../utils/themes';
 
 // constants
-import { IDENTIFIERS } from "..";
-import type { ThemeContextProp } from "../HOC/withTheme";
+import { IDENTIFIERS } from '..';
+import type { ThemeContextProp } from '../HOC/withTheme';
 
 type Props = {
   alignItems?: string,
@@ -31,19 +31,19 @@ type Props = {
   rowReverse?: boolean,
   theme: ?Object,
   themeId: string,
-  themeOverrides: Object,
+  themeOverrides: Object
 };
 
 type State = { composedTheme: Object };
 
 class FlexBase extends Component<Props, State> {
   // define static properties
-  static displayName = "Flex";
+  static displayName = 'Flex';
   static defaultProps = {
     context: createEmptyContext(),
     theme: null,
     themeId: IDENTIFIERS.FLEX,
-    themeOverrides: {},
+    themeOverrides: {}
   };
 
   constructor(props: Props) {
@@ -56,7 +56,7 @@ class FlexBase extends Component<Props, State> {
         addThemeId(theme || context.theme, themeId),
         addThemeId(themeOverrides, themeId),
         context.ROOT_THEME_API
-      ),
+      )
     };
   }
 
@@ -67,13 +67,13 @@ class FlexBase extends Component<Props, State> {
   }
 
   _getActiveClasses = ({ center, column, columnReverse, row, rowReverse }) => {
-    const activeClasses = ["container"];
+    const activeClasses = ['container'];
     const activeProps = pickBy({
       center,
       column,
       columnReverse,
       row,
-      rowReverse,
+      rowReverse
     });
     return [...activeClasses, ...Object.keys(activeProps)].filter((val) => val);
   };
@@ -91,7 +91,7 @@ class FlexBase extends Component<Props, State> {
 
   renderChildren(theme: Object) {
     return React.Children.map(this.props.children, (child) => {
-      if (child.type.displayName === "FlexItem") {
+      if (child.type.displayName === 'FlexItem') {
         return React.cloneElement(child, { theme });
       }
       return child;

--- a/source/components/layout/Flex.js
+++ b/source/components/layout/Flex.js
@@ -1,18 +1,22 @@
 // @flow
-import React, { Component } from 'react';
-import type { Node } from 'react';
-import { pickBy } from 'lodash';
+import React, { Component } from "react";
+import type { Node } from "react";
+import { pickBy } from "lodash";
 
 // components
-import { Base } from './Base';
+import { Base } from "./Base";
 
 // utilities
-import { createEmptyContext, withTheme } from '../HOC/withTheme';
-import { composeTheme, addThemeId, didThemePropsChange } from '../../utils/themes';
+import { createEmptyContext, withTheme } from "../HOC/withTheme";
+import {
+  composeTheme,
+  addThemeId,
+  didThemePropsChange,
+} from "../../utils/themes";
 
 // constants
-import { IDENTIFIERS } from '..';
-import type { ThemeContextProp } from '../HOC/withTheme';
+import { IDENTIFIERS } from "..";
+import type { ThemeContextProp } from "../HOC/withTheme";
 
 type Props = {
   alignItems?: string,
@@ -27,19 +31,19 @@ type Props = {
   rowReverse?: boolean,
   theme: ?Object,
   themeId: string,
-  themeOverrides: Object
+  themeOverrides: Object,
 };
 
 type State = { composedTheme: Object };
 
 class FlexBase extends Component<Props, State> {
   // define static properties
-  static displayName = 'Flex';
+  static displayName = "Flex";
   static defaultProps = {
     context: createEmptyContext(),
     theme: null,
     themeId: IDENTIFIERS.FLEX,
-    themeOverrides: {}
+    themeOverrides: {},
   };
 
   constructor(props: Props) {
@@ -52,18 +56,26 @@ class FlexBase extends Component<Props, State> {
         addThemeId(theme || context.theme, themeId),
         addThemeId(themeOverrides, themeId),
         context.ROOT_THEME_API
-      )
+      ),
     };
   }
 
-  componentWillReceiveProps(nextProps: Props) {
-    didThemePropsChange(this.props, nextProps, this.setState.bind(this));
+  componentDidUpdate(prevProps: Props) {
+    if (prevProps !== this.props) {
+      didThemePropsChange(prevProps, this.props, this.setState.bind(this));
+    }
   }
 
   _getActiveClasses = ({ center, column, columnReverse, row, rowReverse }) => {
-    const activeClasses = ['container'];
-    const activeProps = pickBy({ center, column, columnReverse, row, rowReverse });
-    return [...activeClasses, ...Object.keys(activeProps)].filter(val => val);
+    const activeClasses = ["container"];
+    const activeProps = pickBy({
+      center,
+      column,
+      columnReverse,
+      row,
+      rowReverse,
+    });
+    return [...activeClasses, ...Object.keys(activeProps)].filter((val) => val);
   };
 
   _assembleFlexTheme = (activeClasses: Array<string>) => {
@@ -78,8 +90,8 @@ class FlexBase extends Component<Props, State> {
   };
 
   renderChildren(theme: Object) {
-    return React.Children.map(this.props.children, child => {
-      if (child.type.displayName === 'FlexItem') {
+    return React.Children.map(this.props.children, (child) => {
+      if (child.type.displayName === "FlexItem") {
         return React.cloneElement(child, { theme });
       }
       return child;
@@ -87,7 +99,13 @@ class FlexBase extends Component<Props, State> {
   }
 
   render() {
-    const { alignItems, className, justifyContent, themeId, ...directionProps } = this.props;
+    const {
+      alignItems,
+      className,
+      justifyContent,
+      themeId,
+      ...directionProps
+    } = this.props;
 
     const inlineStyles = pickBy({ alignItems, justifyContent });
     const activeClasses = this._getActiveClasses(directionProps);

--- a/source/components/layout/Grid.js
+++ b/source/components/layout/Grid.js
@@ -1,20 +1,24 @@
 // @flow
-import React, { Component } from 'react';
-import type { Node } from 'react';
-import { pickBy, isEmpty } from 'lodash';
+import React, { Component } from "react";
+import type { Node } from "react";
+import { pickBy, isEmpty } from "lodash";
 
 // components
-import { Base } from './Base';
+import { Base } from "./Base";
 
 // utilities
-import { createEmptyContext, withTheme } from '../HOC/withTheme';
-import { numberToPx } from '../../utils/props';
-import { formatTemplateAreas } from '../../utils/layout';
-import { composeTheme, addThemeId, didThemePropsChange } from '../../utils/themes';
+import { createEmptyContext, withTheme } from "../HOC/withTheme";
+import { numberToPx } from "../../utils/props";
+import { formatTemplateAreas } from "../../utils/layout";
+import {
+  composeTheme,
+  addThemeId,
+  didThemePropsChange,
+} from "../../utils/themes";
 
 // constants
-import { IDENTIFIERS } from '..';
-import type { ThemeContextProp } from '../HOC/withTheme';
+import { IDENTIFIERS } from "..";
+import type { ThemeContextProp } from "../HOC/withTheme";
 
 type Props = {
   alignItems?: string,
@@ -34,14 +38,14 @@ type Props = {
   templateAreas: Array<string>,
   theme: ?Object,
   themeId: string,
-  themeOverrides: Object
+  themeOverrides: Object,
 };
 
 type State = { composedTheme: Object };
 
 class GridBase extends Component<Props, State> {
   // define static properties
-  static displayName = 'Grid';
+  static displayName = "Grid";
   static defaultProps = {
     columnGap: 5,
     context: createEmptyContext(),
@@ -50,7 +54,7 @@ class GridBase extends Component<Props, State> {
     templateAreas: [],
     theme: null,
     themeId: IDENTIFIERS.GRID,
-    themeOverrides: {}
+    themeOverrides: {},
   };
 
   constructor(props: Props) {
@@ -63,12 +67,14 @@ class GridBase extends Component<Props, State> {
         addThemeId(theme || context.theme, themeId),
         addThemeId(themeOverrides, themeId),
         context.ROOT_THEME_API
-      )
+      ),
     };
   }
 
-  componentWillReceiveProps(nextProps: Props) {
-    didThemePropsChange(this.props, nextProps, this.setState.bind(this));
+  componentDidUpdate(prevProps: Props) {
+    if (prevProps !== this.props) {
+      didThemePropsChange(prevProps, this.props, this.setState.bind(this));
+    }
   }
 
   // creates obj passed Base component's inline styles (see render)
@@ -76,7 +82,9 @@ class GridBase extends Component<Props, State> {
     const { className, ...gridProps } = this.props;
 
     // return early if gridProps are empty
-    if (isEmpty(pickBy({ ...gridProps }))) { return; }
+    if (isEmpty(pickBy({ ...gridProps }))) {
+      return;
+    }
 
     const {
       alignItems,
@@ -90,12 +98,12 @@ class GridBase extends Component<Props, State> {
       rowGap,
       rows,
       template,
-      templateAreas
+      templateAreas,
     } = gridProps;
 
     // obj with correct css grid class names
     const inlineClasses = {
-      alignItems: center ? 'center' : alignItems,
+      alignItems: center ? "center" : alignItems,
       gridAutoColumns: autoColumns,
       gridAutoRows: autoRows,
       gridTemplateColumns: columns,
@@ -105,16 +113,16 @@ class GridBase extends Component<Props, State> {
       gridRowGap: gap ? false : numberToPx(rowGap),
       gridTemplate: template,
       gridTemplateAreas: formatTemplateAreas(templateAreas),
-      justifyItems: center ? 'center' : justifyItems
+      justifyItems: center ? "center" : justifyItems,
     };
 
     // filters out keys with false(sy) values
     return pickBy(inlineClasses);
-  }
+  };
 
   renderChildren(theme: Object) {
-    return React.Children.map(this.props.children, child => {
-      if (child.type.displayName === 'GridItem') {
+    return React.Children.map(this.props.children, (child) => {
+      if (child.type.displayName === "GridItem") {
         return React.cloneElement(child, { theme });
       }
       return child;
@@ -131,7 +139,7 @@ class GridBase extends Component<Props, State> {
       <Base
         className={className}
         stylesToAdd={theme}
-        activeClasses={['container']}
+        activeClasses={["container"]}
         inlineStyles={inlineGrid}
       >
         {this.renderChildren(theme)}

--- a/source/components/layout/Grid.js
+++ b/source/components/layout/Grid.js
@@ -1,24 +1,24 @@
 // @flow
-import React, { Component } from "react";
-import type { Node } from "react";
-import { pickBy, isEmpty } from "lodash";
+import React, { Component } from 'react';
+import type { Node } from 'react';
+import { pickBy, isEmpty } from 'lodash';
 
 // components
-import { Base } from "./Base";
+import { Base } from './Base';
 
 // utilities
-import { createEmptyContext, withTheme } from "../HOC/withTheme";
-import { numberToPx } from "../../utils/props";
-import { formatTemplateAreas } from "../../utils/layout";
+import { createEmptyContext, withTheme } from '../HOC/withTheme';
+import { numberToPx } from '../../utils/props';
+import { formatTemplateAreas } from '../../utils/layout';
 import {
   composeTheme,
   addThemeId,
-  didThemePropsChange,
-} from "../../utils/themes";
+  didThemePropsChange
+} from '../../utils/themes';
 
 // constants
-import { IDENTIFIERS } from "..";
-import type { ThemeContextProp } from "../HOC/withTheme";
+import { IDENTIFIERS } from '..';
+import type { ThemeContextProp } from '../HOC/withTheme';
 
 type Props = {
   alignItems?: string,
@@ -38,14 +38,14 @@ type Props = {
   templateAreas: Array<string>,
   theme: ?Object,
   themeId: string,
-  themeOverrides: Object,
+  themeOverrides: Object
 };
 
 type State = { composedTheme: Object };
 
 class GridBase extends Component<Props, State> {
   // define static properties
-  static displayName = "Grid";
+  static displayName = 'Grid';
   static defaultProps = {
     columnGap: 5,
     context: createEmptyContext(),
@@ -54,7 +54,7 @@ class GridBase extends Component<Props, State> {
     templateAreas: [],
     theme: null,
     themeId: IDENTIFIERS.GRID,
-    themeOverrides: {},
+    themeOverrides: {}
   };
 
   constructor(props: Props) {
@@ -67,7 +67,7 @@ class GridBase extends Component<Props, State> {
         addThemeId(theme || context.theme, themeId),
         addThemeId(themeOverrides, themeId),
         context.ROOT_THEME_API
-      ),
+      )
     };
   }
 
@@ -98,12 +98,12 @@ class GridBase extends Component<Props, State> {
       rowGap,
       rows,
       template,
-      templateAreas,
+      templateAreas
     } = gridProps;
 
     // obj with correct css grid class names
     const inlineClasses = {
-      alignItems: center ? "center" : alignItems,
+      alignItems: center ? 'center' : alignItems,
       gridAutoColumns: autoColumns,
       gridAutoRows: autoRows,
       gridTemplateColumns: columns,
@@ -113,7 +113,7 @@ class GridBase extends Component<Props, State> {
       gridRowGap: gap ? false : numberToPx(rowGap),
       gridTemplate: template,
       gridTemplateAreas: formatTemplateAreas(templateAreas),
-      justifyItems: center ? "center" : justifyItems,
+      justifyItems: center ? 'center' : justifyItems
     };
 
     // filters out keys with false(sy) values
@@ -122,7 +122,7 @@ class GridBase extends Component<Props, State> {
 
   renderChildren(theme: Object) {
     return React.Children.map(this.props.children, (child) => {
-      if (child.type.displayName === "GridItem") {
+      if (child.type.displayName === 'GridItem') {
         return React.cloneElement(child, { theme });
       }
       return child;
@@ -139,7 +139,7 @@ class GridBase extends Component<Props, State> {
       <Base
         className={className}
         stylesToAdd={theme}
-        activeClasses={["container"]}
+        activeClasses={['container']}
         inlineStyles={inlineGrid}
       >
         {this.renderChildren(theme)}

--- a/source/components/layout/Gutter.js
+++ b/source/components/layout/Gutter.js
@@ -1,22 +1,22 @@
 // @flow
-import React, { Component } from "react";
-import type { Node } from "react";
+import React, { Component } from 'react';
+import type { Node } from 'react';
 
 // components
-import { Base } from "./Base";
+import { Base } from './Base';
 
 // utility functions
-import { createEmptyContext, withTheme } from "../HOC/withTheme";
+import { createEmptyContext, withTheme } from '../HOC/withTheme';
 import {
   composeTheme,
   addThemeId,
-  didThemePropsChange,
-} from "../../utils/themes";
-import { numberToPx } from "../../utils/props";
+  didThemePropsChange
+} from '../../utils/themes';
+import { numberToPx } from '../../utils/props';
 
 // constants
-import { IDENTIFIERS } from "..";
-import type { ThemeContextProp } from "../HOC/withTheme";
+import { IDENTIFIERS } from '..';
+import type { ThemeContextProp } from '../HOC/withTheme';
 
 type Props = {
   className?: string,
@@ -25,19 +25,19 @@ type Props = {
   padding?: string | number,
   theme: ?Object,
   themeId: string,
-  themeOverrides: Object,
+  themeOverrides: Object
 };
 
 type State = { composedTheme: Object };
 
 class GutterBase extends Component<Props, State> {
   // define static properties
-  static displayName = "Gutter";
+  static displayName = 'Gutter';
   static defaultProps = {
     context: createEmptyContext(),
     theme: null,
     themeId: IDENTIFIERS.GUTTER,
-    themeOverrides: {},
+    themeOverrides: {}
   };
 
   constructor(props: Props) {
@@ -50,7 +50,7 @@ class GutterBase extends Component<Props, State> {
         addThemeId(theme || context.theme, themeId),
         addThemeId(themeOverrides, themeId),
         context.ROOT_THEME_API
-      ),
+      )
     };
   }
 
@@ -67,7 +67,7 @@ class GutterBase extends Component<Props, State> {
 
     return (
       <Base
-        activeClasses={["gutter"]}
+        activeClasses={['gutter']}
         className={className}
         inlineStyles={{ padding }}
         stylesToAdd={theme}

--- a/source/components/layout/Gutter.js
+++ b/source/components/layout/Gutter.js
@@ -1,18 +1,22 @@
 // @flow
-import React, { Component } from 'react';
-import type { Node } from 'react';
+import React, { Component } from "react";
+import type { Node } from "react";
 
 // components
-import { Base } from './Base';
+import { Base } from "./Base";
 
 // utility functions
-import { createEmptyContext, withTheme } from '../HOC/withTheme';
-import { composeTheme, addThemeId, didThemePropsChange } from '../../utils/themes';
-import { numberToPx } from '../../utils/props';
+import { createEmptyContext, withTheme } from "../HOC/withTheme";
+import {
+  composeTheme,
+  addThemeId,
+  didThemePropsChange,
+} from "../../utils/themes";
+import { numberToPx } from "../../utils/props";
 
 // constants
-import { IDENTIFIERS } from '..';
-import type { ThemeContextProp } from '../HOC/withTheme';
+import { IDENTIFIERS } from "..";
+import type { ThemeContextProp } from "../HOC/withTheme";
 
 type Props = {
   className?: string,
@@ -21,19 +25,19 @@ type Props = {
   padding?: string | number,
   theme: ?Object,
   themeId: string,
-  themeOverrides: Object
+  themeOverrides: Object,
 };
 
 type State = { composedTheme: Object };
 
 class GutterBase extends Component<Props, State> {
   // define static properties
-  static displayName = 'Gutter';
+  static displayName = "Gutter";
   static defaultProps = {
     context: createEmptyContext(),
     theme: null,
     themeId: IDENTIFIERS.GUTTER,
-    themeOverrides: {}
+    themeOverrides: {},
   };
 
   constructor(props: Props) {
@@ -46,12 +50,14 @@ class GutterBase extends Component<Props, State> {
         addThemeId(theme || context.theme, themeId),
         addThemeId(themeOverrides, themeId),
         context.ROOT_THEME_API
-      )
+      ),
     };
   }
 
-  componentWillReceiveProps(nextProps: Props) {
-    didThemePropsChange(this.props, nextProps, this.setState.bind(this));
+  componentDidUpdate(prevProps: Props) {
+    if (prevProps !== this.props) {
+      didThemePropsChange(prevProps, this.props, this.setState.bind(this));
+    }
   }
 
   render() {
@@ -61,7 +67,7 @@ class GutterBase extends Component<Props, State> {
 
     return (
       <Base
-        activeClasses={['gutter']}
+        activeClasses={["gutter"]}
         className={className}
         inlineStyles={{ padding }}
         stylesToAdd={theme}

--- a/source/utils/themes.js
+++ b/source/utils/themes.js
@@ -1,10 +1,10 @@
 // @flow
-import { cloneDeep, isEmpty, isEqual } from "lodash";
-import { hasProperty } from "./props";
-import type { ThemeContextProp } from "../components/HOC/withTheme";
+import { cloneDeep, isEmpty, isEqual } from 'lodash';
+import { hasProperty } from './props';
+import type { ThemeContextProp } from '../components/HOC/withTheme';
 
 export const appendToProperty = (dest: {}, name: string, value: string) => {
-  dest[name] === "" ? (dest[name] = value) : (dest[name] += " " + value);
+  dest[name] === '' ? (dest[name] = value) : (dest[name] += ' ' + value);
 };
 
 export const composeComponentStyles = (
@@ -28,7 +28,7 @@ export const composeComponentStyles = (
 export const addThemeId = (theme: Object = {}, themeId: string): Object => {
   if (theme && !isEmpty(theme) && themeId) {
     const themeIdExists = hasProperty(theme, themeId);
-    const themeIdIsObj = typeof theme[themeId] === "object";
+    const themeIdIsObj = typeof theme[themeId] === 'object';
     return themeIdExists && themeIdIsObj ? theme : { [themeId]: theme };
   }
   return theme;
@@ -69,7 +69,7 @@ type ThemeProps = Object & {
   context: ThemeContextProp,
   themeId: string,
   theme: ?Object,
-  themeOverrides: Object,
+  themeOverrides: Object
 };
 
 // Used in componentDidUpdate, this function compares the current
@@ -81,7 +81,7 @@ export const didThemePropsChange = (
     context: nextContext,
     themeId: nextThemeId,
     theme: nextTheme,
-    themeOverrides: nextOverrides,
+    themeOverrides: nextOverrides
   }: ThemeProps,
   setState: Function
 ) => {
@@ -96,7 +96,7 @@ export const didThemePropsChange = (
         addThemeId(nextTheme || nextContext.theme, nextThemeId),
         addThemeId(nextOverrides, nextThemeId),
         nextContext.ROOT_THEME_API
-      ),
+      )
     }));
   }
 };

--- a/source/utils/themes.js
+++ b/source/utils/themes.js
@@ -1,13 +1,16 @@
 // @flow
-import { cloneDeep, isEmpty, isEqual } from 'lodash';
-import { hasProperty } from './props';
-import type { ThemeContextProp } from '../components/HOC/withTheme';
+import { cloneDeep, isEmpty, isEqual } from "lodash";
+import { hasProperty } from "./props";
+import type { ThemeContextProp } from "../components/HOC/withTheme";
 
 export const appendToProperty = (dest: {}, name: string, value: string) => {
-  dest[name] === '' ? (dest[name] = value) : (dest[name] += ' ' + value);
+  dest[name] === "" ? (dest[name] = value) : (dest[name] += " " + value);
 };
 
-export const composeComponentStyles = (componentStyles: {}, componentTheme: {}) => {
+export const composeComponentStyles = (
+  componentStyles: {},
+  componentTheme: {}
+) => {
   if (!componentTheme) return;
   for (const property in componentStyles) {
     if (hasProperty(componentStyles, property)) {
@@ -25,8 +28,8 @@ export const composeComponentStyles = (componentStyles: {}, componentTheme: {}) 
 export const addThemeId = (theme: Object = {}, themeId: string): Object => {
   if (theme && !isEmpty(theme) && themeId) {
     const themeIdExists = hasProperty(theme, themeId);
-    const themeIdIsObj = typeof theme[themeId] === 'object';
-    return (themeIdExists && themeIdIsObj) ? theme : { [themeId]: theme };
+    const themeIdIsObj = typeof theme[themeId] === "object";
+    return themeIdExists && themeIdIsObj ? theme : { [themeId]: theme };
   }
   return theme;
 };
@@ -66,24 +69,19 @@ type ThemeProps = Object & {
   context: ThemeContextProp,
   themeId: string,
   theme: ?Object,
-  themeOverrides: Object
+  themeOverrides: Object,
 };
 
-// Used in componentWillReceiveProps, this function compares the current
+// Used in componentDidUpdate, this function compares the current
 // set of theme related props against the next set to see if any have changed.
 // If true, a component's theme is recomposed and local state is updated
 export const didThemePropsChange = (
-  {
-    context,
-    themeId,
-    theme,
-    themeOverrides
-  }: ThemeProps,
+  { context, themeId, theme, themeOverrides }: ThemeProps,
   {
     context: nextContext,
     themeId: nextThemeId,
     theme: nextTheme,
-    themeOverrides: nextOverrides
+    themeOverrides: nextOverrides,
   }: ThemeProps,
   setState: Function
 ) => {
@@ -98,7 +96,7 @@ export const didThemePropsChange = (
         addThemeId(nextTheme || nextContext.theme, nextThemeId),
         addThemeId(nextOverrides, nextThemeId),
         nextContext.ROOT_THEME_API
-      )
+      ),
     }));
   }
 };


### PR DESCRIPTION
Moved blocks inside `componentWillMount`, `componentWillUpdate`, and `componentWillReceiveProps` into `componentDidMount` and `componentDidUpdate` methods.