### PR TITLE
[DDW-170] Improve password repeat feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ vNext
 
 ### Features
 
-- Adds new `PasswordInput` component [PR 134](https://github.com/input-output-hk/react-polymorph/pull/134)
+- Adds new `PasswordInput` component ([PR 134](https://github.com/input-output-hk/react-polymorph/pull/134), [PR 140](https://github.com/input-output-hk/react-polymorph/pull/140), [PR 141](https://github.com/input-output-hk/react-polymorph/pull/141))
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,14 @@ The history of all changes to react-polymorph.
 vNext
 =====
 
+- Improved `PasswordInput` component ([PR 140](https://github.com/input-output-hk/react-polymorph/pull/140), [PR 141](https://github.com/input-output-hk/react-polymorph/pull/141))
+
 0.9.3
 =====
 
 ### Features
 
-- Adds new `PasswordInput` component ([PR 134](https://github.com/input-output-hk/react-polymorph/pull/134), [PR 140](https://github.com/input-output-hk/react-polymorph/pull/140), [PR 141](https://github.com/input-output-hk/react-polymorph/pull/141))
+- Adds new `PasswordInput` component ([PR 134](https://github.com/input-output-hk/react-polymorph/pull/134))
 
 ### Fixes
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-polymorph",
   "description": "React components with highly customizable logic, markup and styles.",
-  "version": "0.9.4-rc.6",
+  "version": "0.9.4-rc.7",
   "scripts": {
     "build": "cross-env yarn clean && yarn sass && yarn js",
     "build:watch": "concurrently 'yarn js:watch' 'yarn sass:watch'",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-polymorph",
   "description": "React components with highly customizable logic, markup and styles.",
-  "version": "0.9.4-rc.4",
+  "version": "0.9.4-rc.5",
   "scripts": {
     "build": "cross-env yarn clean && yarn sass && yarn js",
     "build:watch": "concurrently 'yarn js:watch' 'yarn sass:watch'",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-polymorph",
   "description": "React components with highly customizable logic, markup and styles.",
-  "version": "0.9.4-rc.3",
+  "version": "0.9.4-rc.4",
   "scripts": {
     "build": "cross-env yarn clean && yarn sass && yarn js",
     "build:watch": "concurrently 'yarn js:watch' 'yarn sass:watch'",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-polymorph",
   "description": "React components with highly customizable logic, markup and styles.",
-  "version": "0.9.4-rc.2",
+  "version": "0.9.4-rc.3",
   "scripts": {
     "build": "cross-env yarn clean && yarn sass && yarn js",
     "build:watch": "concurrently 'yarn js:watch' 'yarn sass:watch'",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-polymorph",
   "description": "React components with highly customizable logic, markup and styles.",
-  "version": "0.9.4-rc.5",
+  "version": "0.9.4-rc.6",
   "scripts": {
     "build": "cross-env yarn clean && yarn sass && yarn js",
     "build:watch": "concurrently 'yarn js:watch' 'yarn sass:watch'",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-polymorph",
   "description": "React components with highly customizable logic, markup and styles.",
-  "version": "0.9.3",
+  "version": "0.9.4-rc.1",
   "scripts": {
     "build": "cross-env yarn clean && yarn sass && yarn js",
     "build:watch": "concurrently 'yarn js:watch' 'yarn sass:watch'",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-polymorph",
   "description": "React components with highly customizable logic, markup and styles.",
-  "version": "0.9.4-rc.1",
+  "version": "0.9.4-rc.2",
   "scripts": {
     "build": "cross-env yarn clean && yarn sass && yarn js",
     "build:watch": "concurrently 'yarn js:watch' 'yarn sass:watch'",

--- a/source/components/PasswordInput.js
+++ b/source/components/PasswordInput.js
@@ -85,6 +85,8 @@ export const PasswordInput: StatelessFunctionalComponent<PasswordInputProps> = (
   if (error) {
     dynamicState = PasswordInput.STATE.ERROR;
     passwordFeedback = error;
+  } else if (tooltip) {
+    passwordFeedback = tooltip;
   } else if (isRepeat) {
     if (repeatPassword === props.value) {
       dynamicState = PasswordInput.STATE.DEFAULT;
@@ -111,7 +113,7 @@ export const PasswordInput: StatelessFunctionalComponent<PasswordInputProps> = (
       theme={composedTheme}
       score={score}
       state={state || dynamicState}
-      tooltip={error || tooltip === false ? null : tooltip || passwordFeedback}
+      tooltip={passwordFeedback}
       {...rest}
     />
   );

--- a/source/components/PasswordInput.js
+++ b/source/components/PasswordInput.js
@@ -24,20 +24,22 @@ const STATE = {
 };
 
 export type PasswordInputProps = InputProps & {
-  entropyFactor?: number,
   debounceDelay?: number,
-  strengthFeedbacks?: {
+  entropyFactor?: number,
+  isShowingTooltipOnFocus: boolean,
+  isShowingTooltipOnHover: boolean,
+  isTooltipOpen: boolean,
+  minLength?: number,
+  minStrongScore?: number,
+  repeatPassword?: string,
+  state?: $Values<typeof STATE>,
+  passwordFeedbacks?: {
     insecure: string,
     weak: string,
     strong: string,
+    noMatch: string,
   },
-  isTooltipOpen: boolean,
-  isShowingTooltipOnFocus: boolean,
-  isShowingTooltipOnHover: boolean,
-  minLength?: number,
-  minStrongScore?: number,
   tooltip?: string | boolean,
-  state?: $Values<typeof STATE>,
   useDebounce?: boolean,
 };
 
@@ -46,11 +48,12 @@ export const PasswordInput: StatelessFunctionalComponent<PasswordInputProps> = (
 ) => {
   const {
     context,
-    strengthFeedbacks,
+    passwordFeedbacks,
     entropyFactor,
     error,
     minLength,
     minStrongScore,
+    repeatPassword,
     skin,
     state,
     theme,
@@ -77,21 +80,30 @@ export const PasswordInput: StatelessFunctionalComponent<PasswordInputProps> = (
   const score = calculatePasswordScore(password, entropyFactor);
   const isValidPassword = password.length >= minLength;
   const isNotEmpty = password.length > 0;
+  const isRepeat = !!repeatPassword;
 
   if (error) {
     dynamicState = PasswordInput.STATE.ERROR;
     passwordFeedback = error;
+  } else if (isRepeat) {
+    if (repeatPassword === props.value) {
+      dynamicState = PasswordInput.STATE.DEFAULT;
+      passwordFeedback = null;
+    } else {
+      dynamicState = PasswordInput.STATE.ERROR;
+      passwordFeedback = passwordFeedbacks.noMatch;
+    }
   } else if (isValidPassword) {
     if (score < minStrongScore) {
       dynamicState = PasswordInput.STATE.WEAK;
-      passwordFeedback = strengthFeedbacks[PasswordInput.STATE.WEAK];
+      passwordFeedback = passwordFeedbacks[PasswordInput.STATE.WEAK];
     } else {
       dynamicState = PasswordInput.STATE.STRONG;
-      passwordFeedback = strengthFeedbacks[PasswordInput.STATE.STRONG];
+      passwordFeedback = passwordFeedbacks[PasswordInput.STATE.STRONG];
     }
   } else if (isNotEmpty) {
     dynamicState = PasswordInput.STATE.INSECURE;
-    passwordFeedback = strengthFeedbacks[PasswordInput.STATE.INSECURE];
+    passwordFeedback = passwordFeedbacks[PasswordInput.STATE.INSECURE];
   }
   return (
     <PasswordInputSkin
@@ -114,10 +126,11 @@ PasswordInput.displayName = 'PasswordInput';
 PasswordInput.defaultProps = {
   debounceDelay: 1000,
   entropyFactor: 0.01,
-  strengthFeedbacks: {
+  passwordFeedbacks: {
     insecure: 'insecure',
     weak: 'weak',
     strong: 'strong',
+    noMatch: "doesn't match",
   },
   isTooltipOpen: false,
   isShowingTooltipOnFocus: true,

--- a/source/skins/simple/PasswordInputSkin.js
+++ b/source/skins/simple/PasswordInputSkin.js
@@ -16,6 +16,7 @@ type Props = PasswordInputProps & {
 export const PasswordInputSkin = (props: Props) => {
   const [hasInputFocus, setHasInputFocus] = useState(false);
   const {
+    className,
     error,
     debounceDelay,
     isShowingTooltipOnFocus,
@@ -35,7 +36,13 @@ export const PasswordInputSkin = (props: Props) => {
     : true;
   const hasTooltip = hasInitialValueChanged && tooltip != null;
   return (
-    <div className={classnames([theme[themeId].root, theme[themeId][state]])}>
+    <div
+      className={classnames([
+        theme[themeId].root,
+        theme[themeId][state],
+        className,
+      ])}
+    >
       <Tooltip
         arrowRelativeToTip
         isCentered

--- a/source/themes/simple/SimplePasswordInput.scss
+++ b/source/themes/simple/SimplePasswordInput.scss
@@ -3,6 +3,7 @@
 // OVERRIDABLE CONFIGURATION VARIABLES
 
 $password-input-tooltip-font-family: var(--rp-password-input-tooltip-font-family, $theme-font-medium), sans-serif !default;
+$password-input-tooltip-border-radius: var(--rp-password-input-tooltip-border-radius, 5px) !default;
 
 // error
 $password-input-error-bg-color: var(--rp-password-input-error-bg-color, #f4b5bc) !default;
@@ -25,6 +26,7 @@ $password-input-success-score-color: var(--rp-password-input-success-score-color
     }
     .SimpleTooltip_bubble .SimpleBubble_bubble {
       background-color: $color;
+      border-radius: $password-input-tooltip-border-radius;
     }
   }
 }

--- a/source/themes/simple/SimplePasswordInput.scss
+++ b/source/themes/simple/SimplePasswordInput.scss
@@ -32,7 +32,6 @@ $password-input-success-score-color: var(--rp-password-input-success-score-color
 }
 
 .root {
-  margin-bottom: 20px;
   :global {
     .SimpleTooltip_bubble {
       font-family: $password-input-tooltip-font-family;

--- a/source/themes/simple/SimplePasswordInput.scss
+++ b/source/themes/simple/SimplePasswordInput.scss
@@ -6,15 +6,15 @@ $password-input-tooltip-font-family: var(--rp-password-input-tooltip-font-family
 $password-input-tooltip-border-radius: var(--rp-password-input-tooltip-border-radius, 5px) !default;
 
 // error
-$password-input-error-bg-color: var(--rp-password-input-error-bg-color, #f4b5bc) !default;
+$password-input-error-bg-color: var(--rp-password-input-error-bg-color, rgba(234, 76, 91, 0.4)) !default;
 $password-input-error-score-color: var(--rp-password-input-error-score-color, #ea4c5b) !default;
 
 // warning
-$password-input-warning-bg-color: var(--rp-password-input-warning-bg-color, #f7d8a1) !default;
+$password-input-warning-bg-color: var(--rp-password-input-warning-bg-color, rgba(242, 162, 24, 0.4)) !default;
 $password-input-warning-score-color: var(--rp-password-input-warning-score-color, #f2a218) !default;
 
 // success
-$password-input-success-bg-color: var(--rp-password-input-success-bg-color, #a8e4c3) !default;
+$password-input-success-bg-color: var(--rp-password-input-success-bg-color, rgba(45, 192, 108, 0.4)) !default;
 $password-input-success-score-color: var(--rp-password-input-success-score-color, #2dc06c) !default;
 
 @mixin tooltipBubble($color) {
@@ -59,6 +59,14 @@ $password-input-success-score-color: var(--rp-password-input-success-score-color
     }
   }
   @include tooltipBubble($password-input-error-score-color);
+}
+
+.insecure, .weak, .strong {
+  :global {
+    .SimpleInput_input {
+      border-bottom-color: transparent;
+    }
+  }
 }
 
 .insecure {

--- a/source/themes/simple/SimpleTooltip.scss
+++ b/source/themes/simple/SimpleTooltip.scss
@@ -13,6 +13,7 @@ $tooltip-text-color: var(--rp-tooltip-text-color, white) !default;
   &.isShowingOnHover:hover {
     .bubble {
       opacity: 1;
+      visibility: inherit;
     }
   }
 }
@@ -23,6 +24,7 @@ $tooltip-text-color: var(--rp-tooltip-text-color, white) !default;
   color: $tooltip-text-color;
   display: inline-block;
   opacity: 0;
+  visibility: hidden;
   transition: opacity 400ms ease;
 }
 

--- a/source/themes/simple/SimpleTooltip.scss
+++ b/source/themes/simple/SimpleTooltip.scss
@@ -55,6 +55,7 @@ $tooltip-text-color: var(--rp-tooltip-text-color, white) !default;
 .isVisible {
   .bubble {
     opacity: 1;
+    visibility: inherit;
   }
 }
 

--- a/stories/PasswordInput.stories.js
+++ b/stories/PasswordInput.stories.js
@@ -224,6 +224,7 @@ storiesOf('PasswordInput | Integration', module)
     withState({ password: '', repeat: '' }, (store) => (
       <div className={styles.container}>
         <PasswordInput
+          className={styles.firstField}
           label="New Password"
           value={store.state.password}
           placeholder="Enter your password …"

--- a/stories/PasswordInput.stories.js
+++ b/stories/PasswordInput.stories.js
@@ -6,7 +6,6 @@ import { storiesOf } from '@storybook/react';
 import { withState } from '@dump247/storybook-state';
 
 // components
-import { Input } from '../source/components/Input';
 import { PasswordInput } from '../source/components/PasswordInput';
 
 // helpers
@@ -88,10 +87,11 @@ storiesOf('PasswordInput | Skin', module)
     withState({ value: '' }, (store) => (
       <div className={styles.container}>
         <PasswordInput
-          strengthFeedbacks={{
+          passwordFeedbacks={{
             insecure: 'unsicher!',
             weak: 'schwach',
             strong: 'genial!',
+            noMatch: 'Stimmt nicht überein',
           }}
           label="Label"
           value={store.state.value}
@@ -235,17 +235,7 @@ storiesOf('PasswordInput | Integration', module)
           placeholder="Repeat your password …"
           type="password"
           onChange={(value) => store.set({ repeat: value })}
-          state={
-            // eslint-disable-next-line no-nested-ternary
-            store.state.password === store.state.repeat
-              ? PasswordInput.STATE.DEFAULT
-              : PasswordInput.STATE.ERROR
-          }
-          tooltip={
-            store.state.password === store.state.repeat
-              ? false
-              : 'Passwords must match'
-          }
+          repeatPassword={store.state.password}
         />
       </div>
     ))

--- a/stories/PasswordInput.stories.scss
+++ b/stories/PasswordInput.stories.scss
@@ -1,3 +1,7 @@
 .container {
   padding: 20px;
 }
+
+.firstField {
+  margin-bottom: 20px;
+}


### PR DESCRIPTION
This PR improves the password repeat feature, to simplify the integration within Daedalus.
To use an `<PasswordInput>` component for validating a repeated password it's only necessary to pass in `repeatPassword: string` and it does the rest automatically. 