### PR TITLE
[issue-145] Remove deprecated postinstall-build package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The history of all changes to react-polymorph.
 vNext
 =====
 
+0.9.5
+=====
+
+### Fixes
+- Replaced deprecated postinstall-build package with npm `prepare` lifecycle [PR 146](https://github.com/input-output-hk/react-polymorph/pull/146) 
+
 0.9.4
 =====
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-polymorph",
   "description": "React components with highly customizable logic, markup and styles.",
-  "version": "0.9.4",
+  "version": "0.9.5-rc.1",
   "scripts": {
     "build": "cross-env yarn clean && yarn sass && yarn js",
     "build:watch": "concurrently 'yarn js:watch' 'yarn sass:watch'",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "js:watch": "yarn js --watch",
     "lint": "eslint --format=node_modules/eslint-formatter-pretty source stories *.js",
     "prepare": "yarn clean && yarn build",
-    "postinstall": "postinstall-build lib --only-as-dependency",
     "sass": "node 'scripts/prepare-sass-files-for-publishing.js'",
     "sass:watch": "nodemon -e scss --watch source/themes --exec 'yarn sass'",
     "storybook": "start-storybook -p 6543 -c storybook --ci",
@@ -25,7 +24,6 @@
     "create-react-ref": "0.1.0",
     "fast-password-entropy": "1.1.1",
     "filter-react-dom-props": "0.0.2",
-    "postinstall-build": "5.0.1",
     "react-modal": "3.1.12",
     "react-scrollbars-custom": "4.0.21"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -10439,11 +10439,6 @@ postcss@^7.0.0, postcss@^7.0.14, postcss@^7.0.16, postcss@^7.0.17, postcss@^7.0.
     source-map "^0.6.1"
     supports-color "^6.1.0"
 
-postinstall-build@5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/postinstall-build/-/postinstall-build-5.0.1.tgz#b917a9079b26178d9a24af5a5cd8cb4a991d11b9"
-  integrity sha1-uRepB5smF42aJK9aXNjLSpkdEbk=
-
 prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"


### PR DESCRIPTION
This PR replaces the deprecated [postinstall-build](https://www.npmjs.com/package/postinstall-build) package with the npm  `prepare` lifecycle script.