### PR TITLE
[DDW-497] Improve autocomplete required selections ux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,9 @@ The history of all changes to react-polymorph.
 vNext
 =====
 
-0.9.7
-=====
-
 ### Features
 
+- Improve autocomplete required selections ux ([PR 154](https://github.com/input-output-hk/react-polymorph/pull/154))
 - Improve `FormField` UX by using pop overs to show errors ([PR 151](https://github.com/input-output-hk/react-polymorph/pull/151)
 
 0.9.6

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-polymorph",
   "description": "React components with highly customizable logic, markup and styles.",
-  "version": "0.9.7-rc.10",
+  "version": "0.9.7-rc.11",
   "scripts": {
     "build": "cross-env yarn clean && yarn sass && yarn js",
     "build:watch": "concurrently 'yarn js:watch' 'yarn sass:watch'",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-polymorph",
   "description": "React components with highly customizable logic, markup and styles.",
-  "version": "0.9.7-rc.8",
+  "version": "0.9.7-rc.9",
   "scripts": {
     "build": "cross-env yarn clean && yarn sass && yarn js",
     "build:watch": "concurrently 'yarn js:watch' 'yarn sass:watch'",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-polymorph",
   "description": "React components with highly customizable logic, markup and styles.",
-  "version": "0.9.7-rc.7",
+  "version": "0.9.7-rc.8",
   "scripts": {
     "build": "cross-env yarn clean && yarn sass && yarn js",
     "build:watch": "concurrently 'yarn js:watch' 'yarn sass:watch'",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-polymorph",
   "description": "React components with highly customizable logic, markup and styles.",
-  "version": "0.9.7-rc.9",
+  "version": "0.9.7-rc.10",
   "scripts": {
     "build": "cross-env yarn clean && yarn sass && yarn js",
     "build:watch": "concurrently 'yarn js:watch' 'yarn sass:watch'",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-polymorph",
   "description": "React components with highly customizable logic, markup and styles.",
-  "version": "0.9.7-rc.6",
+  "version": "0.9.7-rc.7",
   "scripts": {
     "build": "cross-env yarn clean && yarn sass && yarn js",
     "build:watch": "concurrently 'yarn js:watch' 'yarn sass:watch'",

--- a/source/components/Autocomplete.js
+++ b/source/components/Autocomplete.js
@@ -25,7 +25,7 @@ export type AutocompleteProps = {
   isOpeningUpward: boolean,
   label?: string | Element<any>,
   maxSelections?: number,
-  requiredSelections?: number,
+  requiredSelections: [number],
   requiredSelectionsInfo?: (required: number, actual: number) => string,
   maxVisibleOptions: number,
   multipleSameSelections: boolean,
@@ -69,7 +69,7 @@ class AutocompleteBase extends Component<AutocompleteProps, State> {
     maxVisibleOptions: 10, // max number of visible options
     multipleSameSelections: true, // if true then same word can be selected multiple times
     options: [],
-    requiredSelections: 0,
+    requiredSelections: [],
     sortAlphabetically: true, // options are sorted alphabetically by default
     theme: null,
     themeId: IDENTIFIERS.AUTOCOMPLETE,

--- a/source/components/Autocomplete.js
+++ b/source/components/Autocomplete.js
@@ -26,6 +26,7 @@ export type AutocompleteProps = {
   label?: string | Element<any>,
   maxSelections?: number,
   requiredSelections?: number,
+  requiredSelectionsInfo?: (required: number, actual: number) => string,
   maxVisibleOptions: number,
   multipleSameSelections: boolean,
   onChange?: Function,

--- a/source/components/PasswordInput.js
+++ b/source/components/PasswordInput.js
@@ -53,6 +53,7 @@ export const PasswordInput: StatelessFunctionalComponent<PasswordInputProps> = (
     entropyFactor,
     error,
     minLength,
+    maxLength,
     minStrongScore,
     isPasswordRepeat,
     repeatPassword,
@@ -80,7 +81,8 @@ export const PasswordInput: StatelessFunctionalComponent<PasswordInputProps> = (
   let passwordFeedback = null;
   const password = props.value;
   const score = calculatePasswordScore(password, entropyFactor);
-  const isValidPassword = password.length >= minLength;
+  const isValidPassword =
+    password.length >= minLength && password.length <= maxLength;
   const isNotEmpty = password.length > 0;
 
   if (error) {

--- a/source/components/PasswordInput.js
+++ b/source/components/PasswordInput.js
@@ -140,6 +140,7 @@ PasswordInput.defaultProps = {
   isShowingTooltipOnFocus: true,
   isShowingTooltipOnHover: true,
   minLength: 10,
+  maxLength: 255,
   minStrongScore: 0.75,
   readOnly: false,
   theme: null,

--- a/source/skins/simple/AutocompleteSkin.js
+++ b/source/skins/simple/AutocompleteSkin.js
@@ -56,7 +56,8 @@ export const AutocompleteSkin = (props: Props) => {
     if (props.selectedOptions && props.renderSelections) {
       // call custom renderSelections function
       return props.renderSelections(props.getSelectionProps);
-    } else if (props.selectedOptions && !props.renderSelections) {
+    }
+    if (props.selectedOptions && !props.renderSelections) {
       // render default skin
       return props.selectedOptions.map((selectedOption, index) => (
         <span className={theme.selectedWordBox} key={index}>
@@ -90,6 +91,14 @@ export const AutocompleteSkin = (props: Props) => {
       ref={props.rootRef}
       role="presentation"
     >
+      {props.requiredSelections > 0 && props.requiredSelectionsInfo != null && (
+        <div className={theme.requiredWordsInfo}>
+          {props.requiredSelectionsInfo(
+            props.requiredSelections,
+            selectedOptionsCount
+          )}
+        </div>
+      )}
       <FormField
         error={error}
         inputRef={props.inputRef}

--- a/source/skins/simple/AutocompleteSkin.js
+++ b/source/skins/simple/AutocompleteSkin.js
@@ -1,9 +1,9 @@
 // @flow
 import React from 'react';
-import type { ElementRef, Element } from 'react';
+import type { ElementRef } from 'react';
 
 // external libraries
-import _ from 'lodash';
+import { slice, some } from 'lodash';
 import classnames from 'classnames';
 import type { AutocompleteProps } from '../../components/Autocomplete';
 
@@ -38,7 +38,7 @@ type Props = AutocompleteProps & {
 export const AutocompleteSkin = (props: Props) => {
   const theme = props.theme[props.themeId];
 
-  const filteredAndLimitedOptions = _.slice(
+  const filteredAndLimitedOptions = slice(
     props.filteredOptions,
     0,
     props.maxVisibleOptions
@@ -79,8 +79,10 @@ export const AutocompleteSkin = (props: Props) => {
   };
 
   const selectedOptionsCount = props.selectedOptions.length;
-  const hasSelectedRequiredNumberOfOptions =
-    selectedOptionsCount >= props.requiredSelections;
+  const hasSelectedRequiredNumberOfOptions = some(
+    props.requiredSelections,
+    (requiredCount) => selectedOptionsCount === requiredCount
+  );
   const error = hasSelectedRequiredNumberOfOptions ? props.error : null;
 
   return (
@@ -91,14 +93,15 @@ export const AutocompleteSkin = (props: Props) => {
       ref={props.rootRef}
       role="presentation"
     >
-      {props.requiredSelections > 0 && props.requiredSelectionsInfo != null && (
-        <div className={theme.requiredWordsInfo}>
-          {props.requiredSelectionsInfo(
-            props.requiredSelections,
-            selectedOptionsCount
-          )}
-        </div>
-      )}
+      {props.requiredSelections.length > 0 &&
+        props.requiredSelectionsInfo != null && (
+          <div className={theme.requiredWordsInfo}>
+            {props.requiredSelectionsInfo(
+              props.requiredSelections,
+              selectedOptionsCount
+            )}
+          </div>
+        )}
       <FormField
         error={error}
         inputRef={props.inputRef}

--- a/source/themes/API/autocomplete.js
+++ b/source/themes/API/autocomplete.js
@@ -8,5 +8,6 @@ export const AUTOCOMPLETE_THEME_API = {
   selectedWordRemoveButton: '',
   hasSelectedWords: '',
   opened: '',
-  errored: ''
+  errored: '',
+  requiredWordsInfo: '',
 };

--- a/source/themes/simple/SimpleAutocomplete.scss
+++ b/source/themes/simple/SimpleAutocomplete.scss
@@ -11,6 +11,9 @@ $autocomplete-border-color-errored: var(--rp-autocomplete-border-color-errored, 
 $autocomplete-min-height: var(--rp-autocomplete-min-height, 90px) !default;
 $autocomplete-padding: var(--rp-autocomplete-padding, 5px 20px) !default;
 $autocomplete-width: var(--rp-autocomplete-width, 100%) !default;
+$autocomplete-required-words-font-family: var(--rp-autocomplete-required-words-font-family, $theme-font-regular, sans-serif) !default;
+$autocomplete-required-words-font-size: var(--rp-autocomplete-required-words-color, 14px) !default;
+$autocomplete-required-words-color: var(--rp-autocomplete-required-words-color, rgba(94, 96, 102, 0.5)) !default;
 
 // input
 $autocomplete-input-bg-color: var(--rp-autocomplete-input-bg-color, transparent) !default;
@@ -49,6 +52,7 @@ $autocomplete-selected-words-font-family: var(
 $autocomplete-selected-words-min-height: var(--rp-autocomplete-selected-words-min-height, 28px) !default;
 
 .autocompleteWrapper {
+  position: relative;
 }
 
 .autocompleteContent {
@@ -115,6 +119,15 @@ $autocomplete-selected-words-min-height: var(--rp-autocomplete-selected-words-mi
   cursor: pointer;
   margin-left: 8px;
   color: inherit;
+}
+
+.requiredWordsInfo {
+  position: absolute;
+  right: 0;
+  top: 9px;
+  font-family: $autocomplete-required-words-font-family;
+  font-size: $autocomplete-required-words-font-size;
+  color: $autocomplete-required-words-color;
 }
 
 // BEGIN SPECIAL STATES ---------- //

--- a/source/themes/simple/SimpleAutocomplete.scss
+++ b/source/themes/simple/SimpleAutocomplete.scss
@@ -14,6 +14,7 @@ $autocomplete-width: var(--rp-autocomplete-width, 100%) !default;
 $autocomplete-required-words-font-family: var(--rp-autocomplete-required-words-font-family, $theme-font-regular, sans-serif) !default;
 $autocomplete-required-words-font-size: var(--rp-autocomplete-required-words-font-size, 14px) !default;
 $autocomplete-required-words-color: var(--rp-autocomplete-required-words-color, rgba(94, 96, 102, 0.5)) !default;
+$autocomplete-required-words-offset-top: var(--rp-autocomplete-required-words-offset-top, 9px) !default;
 
 // input
 $autocomplete-input-bg-color: var(--rp-autocomplete-input-bg-color, transparent) !default;
@@ -124,7 +125,7 @@ $autocomplete-selected-words-min-height: var(--rp-autocomplete-selected-words-mi
 .requiredWordsInfo {
   position: absolute;
   right: 0;
-  top: 9px;
+  top: $autocomplete-required-words-offset-top;
   font-family: $autocomplete-required-words-font-family;
   font-size: $autocomplete-required-words-font-size;
   color: $autocomplete-required-words-color;

--- a/source/themes/simple/SimpleAutocomplete.scss
+++ b/source/themes/simple/SimpleAutocomplete.scss
@@ -12,7 +12,7 @@ $autocomplete-min-height: var(--rp-autocomplete-min-height, 90px) !default;
 $autocomplete-padding: var(--rp-autocomplete-padding, 5px 20px) !default;
 $autocomplete-width: var(--rp-autocomplete-width, 100%) !default;
 $autocomplete-required-words-font-family: var(--rp-autocomplete-required-words-font-family, $theme-font-regular, sans-serif) !default;
-$autocomplete-required-words-font-size: var(--rp-autocomplete-required-words-color, 14px) !default;
+$autocomplete-required-words-font-size: var(--rp-autocomplete-required-words-font-size, 14px) !default;
 $autocomplete-required-words-color: var(--rp-autocomplete-required-words-color, rgba(94, 96, 102, 0.5)) !default;
 
 // input

--- a/stories/Autocomplete.stories.js
+++ b/stories/Autocomplete.stories.js
@@ -1,4 +1,5 @@
 // @flow
+import { some } from 'lodash';
 import React from 'react';
 import createRef from 'create-react-ref/lib/createRef';
 import classnames from 'classnames';
@@ -195,13 +196,13 @@ storiesOf('Autocomplete', module)
   })
 
   .add(
-    'requiredSelections',
+    'requiredSelections [3]',
     withState({ error: null }, (store) => (
       <Autocomplete
         label="Required Selections"
         options={OPTIONS}
         placeholder="Enter mnemonic..."
-        requiredSelections={3}
+        requiredSelections={[3]}
         requiredSelectionsInfo={(required, actual) =>
           `${Math.min(actual, required)} of ${required} words selected`
         }
@@ -209,6 +210,31 @@ storiesOf('Autocomplete', module)
         error={store.state.error}
         onChange={(options) =>
           store.set({ error: options.length === 3 ? 'invalid mnemonic' : null })
+        }
+      />
+    ))
+  )
+
+  .add(
+    'requiredSelections [3, 5, 7]',
+    withState({ error: null }, (store) => (
+      <Autocomplete
+        label="Required Selections"
+        options={OPTIONS}
+        placeholder="Enter mnemonic..."
+        requiredSelections={[3, 5, 7]}
+        requiredSelectionsInfo={(required, actual) => `${actual} words entered`}
+        maxSelections={7}
+        error={store.state.error}
+        onChange={(options) =>
+          store.set({
+            error: some(
+              [3, 5, 7],
+              (requiredCount) => options.length === requiredCount
+            )
+              ? 'invalid mnemonic'
+              : null,
+          })
         }
       />
     ))

--- a/stories/Autocomplete.stories.js
+++ b/stories/Autocomplete.stories.js
@@ -35,28 +35,22 @@ const OPTIONS = [
   'join',
   'paper',
   'box',
-  'tab'
+  'tab',
 ];
 
 storiesOf('Autocomplete', module)
-
   .addDecorator(decorateWithSimpleTheme)
 
   // ====== Stories ======
 
-  .add('Enter mnemonics - plain', () => (
-    <Autocomplete />
-  ))
+  .add('Enter mnemonics - plain', () => <Autocomplete />)
 
   .add('Enter mnemonics - label', () => (
     <Autocomplete label="Recovery phrase" />
   ))
 
   .add('Enter mnemonics - placeholder', () => (
-    <Autocomplete
-      label="Recovery phrase"
-      placeholder="Enter recovery phrase"
-    />
+    <Autocomplete label="Recovery phrase" placeholder="Enter recovery phrase" />
   ))
 
   .add('Enter mnemonics - error', () => (
@@ -67,8 +61,9 @@ storiesOf('Autocomplete', module)
     />
   ))
 
-  .add('(9-word mnemonic) - not sorted',
-    withState({ selectedOpts: [] }, store => (
+  .add(
+    '(9-word mnemonic) - not sorted',
+    withState({ selectedOpts: [] }, (store) => (
       <Autocomplete
         label="Recovery phrase"
         options={OPTIONS}
@@ -76,38 +71,41 @@ storiesOf('Autocomplete', module)
         sortAlphabetically={false}
         multipleSameSelections={false}
         maxSelections={9}
-        onChange={selectedOpts => store.set({ selectedOpts })}
+        onChange={(selectedOpts) => store.set({ selectedOpts })}
       />
     ))
   )
 
-  .add('(9-word mnemonic) - sorted with multiple same selections',
-    withState({ selectedOpts: [] }, store => (
+  .add(
+    '(9-word mnemonic) - sorted with multiple same selections',
+    withState({ selectedOpts: [] }, (store) => (
       <Autocomplete
         label="Recovery phrase"
         options={OPTIONS}
         placeholder="Enter mnemonic..."
         maxSelections={9}
-        onChange={selectedOpts => store.set({ selectedOpts })}
+        onChange={(selectedOpts) => store.set({ selectedOpts })}
       />
     ))
   )
 
-  .add('(12-word mnemonic) 5 suggestions',
-    withState({ selectedOpts: [] }, store => (
+  .add(
+    '(12-word mnemonic) 5 suggestions',
+    withState({ selectedOpts: [] }, (store) => (
       <Autocomplete
         label="Recovery phrase"
         options={OPTIONS}
         placeholder="Enter mnemonic..."
         maxSelections={12}
         maxVisibleOptions={5}
-        onChange={selectedOpts => store.set({ selectedOpts })}
+        onChange={(selectedOpts) => store.set({ selectedOpts })}
       />
     ))
   )
 
-  .add('(12-word mnemonic) 5 suggestions - isOpeningUpward',
-    withState({ selectedOpts: [] }, store => (
+  .add(
+    '(12-word mnemonic) 5 suggestions - isOpeningUpward',
+    withState({ selectedOpts: [] }, (store) => (
       <Autocomplete
         className={styles.customMargin}
         isOpeningUpward
@@ -116,13 +114,14 @@ storiesOf('Autocomplete', module)
         placeholder="Enter mnemonic..."
         maxSelections={12}
         maxVisibleOptions={5}
-        onChange={selectedOpts => store.set({ selectedOpts })}
+        onChange={(selectedOpts) => store.set({ selectedOpts })}
       />
     ))
   )
 
-  .add('(12-word mnemonic) 5 suggestions and regex that allows only letters',
-    withState({ selectedOpts: [] }, store => (
+  .add(
+    '(12-word mnemonic) 5 suggestions and regex that allows only letters',
+    withState({ selectedOpts: [] }, (store) => (
       <Autocomplete
         label="Recovery phrase"
         options={OPTIONS}
@@ -130,54 +129,53 @@ storiesOf('Autocomplete', module)
         maxSelections={12}
         maxVisibleOptions={5}
         invalidCharsRegex={/[^a-zA-Z]/g}
-        onChange={selectedOpts => store.set({ selectedOpts })}
+        onChange={(selectedOpts) => store.set({ selectedOpts })}
       />
     ))
   )
 
-  .add('Enter mnemonics in Modal',
-    withState({ isOpen: true, selectedOpts: [] }, store => (
-      store.state.isOpen
-        ? (
-          <Modal
-            isOpen={store.state.isOpen}
-            triggerCloseOnOverlayClick={false}
-            onClose={() => store.set({ isOpen: false })}
-          >
-            <div className={styles.dialogWrapper}>
-              <div className={styles.title}>
-                <h1>Autocomplete in Modal</h1>
-              </div>
-              <div className={styles.content}>
-                <Autocomplete
-                  label="Recovery phrase"
-                  placeholder="Enter recovery phrase"
-                  options={OPTIONS}
-                  maxSelections={12}
-                  maxVisibleOptions={5}
-                  invalidCharsRegex={/[^a-zA-Z]/g}
-                  onChange={selectedOpts => store.set({ selectedOpts })}
-                />
-              </div>
-              <div className={styles.actions}>
-                <Button
-                  onClick={() => store.set({ isOpen: false })}
-                  className="primary"
-                  label="Submit"
-                />
-              </div>
+  .add(
+    'Enter mnemonics in Modal',
+    withState({ isOpen: true, selectedOpts: [] }, (store) =>
+      store.state.isOpen ? (
+        <Modal
+          isOpen={store.state.isOpen}
+          triggerCloseOnOverlayClick={false}
+          onClose={() => store.set({ isOpen: false })}
+        >
+          <div className={styles.dialogWrapper}>
+            <div className={styles.title}>
+              <h1>Autocomplete in Modal</h1>
             </div>
-          </Modal>
-        )
-        : (
-          <button
-            className={styles.reopenModal}
-            onClick={() => store.set({ isOpen: !store.state.isOpen })}
-          >
-            Reopen modal
-          </button>
-        )
-    ))
+            <div className={styles.content}>
+              <Autocomplete
+                label="Recovery phrase"
+                placeholder="Enter recovery phrase"
+                options={OPTIONS}
+                maxSelections={12}
+                maxVisibleOptions={5}
+                invalidCharsRegex={/[^a-zA-Z]/g}
+                onChange={(selectedOpts) => store.set({ selectedOpts })}
+              />
+            </div>
+            <div className={styles.actions}>
+              <Button
+                onClick={() => store.set({ isOpen: false })}
+                className="primary"
+                label="Submit"
+              />
+            </div>
+          </div>
+        </Modal>
+      ) : (
+        <button
+          className={styles.reopenModal}
+          onClick={() => store.set({ isOpen: !store.state.isOpen })}
+        >
+          Reopen modal
+        </button>
+      )
+    )
   )
 
   .add('Clear value on click', () => {
@@ -195,9 +193,31 @@ storiesOf('Autocomplete', module)
       </div>
     );
   })
+
+  .add(
+    'requiredSelections',
+    withState({ error: null }, (store) => (
+      <Autocomplete
+        label="Required Selections"
+        options={OPTIONS}
+        placeholder="Enter mnemonic..."
+        requiredSelections={3}
+        requiredSelectionsInfo={(required, actual) =>
+          `${Math.min(actual, required)} of ${required} words selected`
+        }
+        maxSelections={3}
+        error={store.state.error}
+        onChange={(options) =>
+          store.set({ error: options.length === 3 ? 'invalid mnemonic' : null })
+        }
+      />
+    ))
+  )
+
   /*eslint-disable */
-  .add('render prop - renderSelections',
-    withState({ selectedOpts: [] }, store => (
+  .add(
+    'render prop - renderSelections',
+    withState({ selectedOpts: [] }, (store) => (
       <Autocomplete
         label="Recovery phrase"
         options={OPTIONS}
@@ -206,17 +226,17 @@ storiesOf('Autocomplete', module)
         multipleSameSelections={false}
         maxSelections={7}
         maxVisibleOptions={7}
-        onChange={selectedOpts => store.set({ selectedOpts })}
-        renderSelections={getSelectionProps => {
+        onChange={(selectedOpts) => store.set({ selectedOpts })}
+        renderSelections={(getSelectionProps) => {
           const {
             inputValue,
             isOpen,
             selectedOptions,
             theme,
-            removeSelection
+            removeSelection,
           } = getSelectionProps({
-            removeSelection: index =>
-              console.log(`You removed: ${selectedOptions[index]}`)
+            removeSelection: (index) =>
+              console.log(`You removed: ${selectedOptions[index]}`),
           });
 
           return selectedOptions.map((option, index) => (
@@ -240,8 +260,9 @@ storiesOf('Autocomplete', module)
     ))
   )
 
-  .add('Render prop - renderOptions',
-    withState({ selectedOpts: [] }, store => (
+  .add(
+    'Render prop - renderOptions',
+    withState({ selectedOpts: [] }, (store) => (
       <Autocomplete
         label="Select an Option Multiple Times"
         options={OPTIONS}
@@ -250,8 +271,8 @@ storiesOf('Autocomplete', module)
         multipleSameSelections
         maxSelections={10}
         maxVisibleOptions={7}
-        onChange={selectedOpts => store.set({ selectedOpts })}
-        renderOptions={getOptionProps => {
+        onChange={(selectedOpts) => store.set({ selectedOpts })}
+        renderOptions={(getOptionProps) => {
           const {
             options,
             selectedOptions,
@@ -260,18 +281,18 @@ storiesOf('Autocomplete', module)
             isDisabledOption,
             theme,
             onClick,
-            onMouseEnter
+            onMouseEnter,
           } = getOptionProps({
             onClick: (option, event) => console.log(`You clicked "${option}"`),
             onMouseEnter: (index, event) =>
-              console.log(`Mouse is on "${options[index]}"`)
+              console.log(`Mouse is on "${options[index]}"`),
           });
 
           return options.map((option, index) => {
             // calculates number of times the option
             // has been selected already
             const timesSelected = selectedOptions.filter(
-              selectedOpt => selectedOpt === option
+              (selectedOpt) => selectedOpt === option
             ).length;
 
             return (
@@ -284,7 +305,7 @@ storiesOf('Autocomplete', module)
                   isHighlightedOption(index)
                     ? themeOverrides.customHighlight
                     : null,
-                  option.isDisabled ? theme.disabledOption : null
+                  option.isDisabled ? theme.disabledOption : null,
                 ])}
                 onMouseEnter={onMouseEnter.bind(null, index)}
                 onClick={onClick.bind(null, option)}
@@ -295,7 +316,7 @@ storiesOf('Autocomplete', module)
                     style={{
                       fontStyle: 'italic',
                       fontSize: '12px',
-                      marginLeft: '1rem'
+                      marginLeft: '1rem',
                     }}
                   >
                     {`times selected: ${timesSelected}`}
@@ -309,8 +330,9 @@ storiesOf('Autocomplete', module)
     ))
   )
   /*eslint-disable */
-  .add('theme overrides',
-    withState({ selectedOpts: [] }, store => (
+  .add(
+    'theme overrides',
+    withState({ selectedOpts: [] }, (store) => (
       <Autocomplete
         themeOverrides={themeOverrides}
         label="Recovery phrase"
@@ -319,13 +341,14 @@ storiesOf('Autocomplete', module)
         maxSelections={12}
         maxVisibleOptions={5}
         invalidCharsRegex={/[^a-zA-Z]/g}
-        onChange={selectedOpts => store.set({ selectedOpts })}
+        onChange={(selectedOpts) => store.set({ selectedOpts })}
       />
     ))
   )
 
-  .add('custom theme',
-    withState({ selectedOpts: [] }, store => (
+  .add(
+    'custom theme',
+    withState({ selectedOpts: [] }, (store) => (
       <Autocomplete
         theme={CustomAutocompleteTheme}
         label="Custom Autocomplete theme"
@@ -334,7 +357,7 @@ storiesOf('Autocomplete', module)
         maxSelections={12}
         maxVisibleOptions={5}
         invalidCharsRegex={/[^a-zA-Z]/g}
-        onChange={selectedOpts => store.set({ selectedOpts })}
+        onChange={(selectedOpts) => store.set({ selectedOpts })}
       />
     ))
   );


### PR DESCRIPTION
This PR improves the Autocomplete `requiredSelections` prop UX with an optional `requiredSelectionsInfo` prop - a function that gets the required and actual selections as inputs and returns any string which is displayed above the autocomplete:

**Note:** The "x of x words selected" string is not generated by react-polymorph but by a callback function which can return any string for the given params like this: `(required, actual) => `${actual} words entered`

## Explanation:

The feature consists of the combination of multiple props:

```js
maxSelections={7}
requiredSelections={[3, 5, 7]}
requiredSelectionsInfo={(required, actual) => `${actual} words entered`}
```

- `requiredSelections` contains any number of possible "target counts" of selections
- `requiredSelectionsInfo` is a callback function `(required, actual) => `${actual} words entered` that returns any string which is rendered on the top right above the Autocomplete (which can be used to show the user useful feedback about the words entered etc.)
- `maxSelections` restricts the maximum number of selections (should always be higher than the biggest `requiredSelection`)

## Screenshots:

### `requiredSelections={[3]}` (only a single count -> "x of x words …")
![CleanShot 2020-12-14 at 17 54 29](https://user-images.githubusercontent.com/172414/102110712-c9841f00-3e35-11eb-81d9-87ada6e2182b.gif)

### `requiredSelections={[3, 5, 7]}` (multiple counts -> "x words entered …"
![CleanShot 2020-12-14 at 17 58 44](https://user-images.githubusercontent.com/172414/102110984-2253b780-3e36-11eb-967a-65503de3f2b6.gif)


## Todos:

- [x] Handle the case where we expected one of the specified phrase lengths: 18, 24 or 27