### PR TITLE
[DDW-543] Refactor Numeric Input to use bignumber.js

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -35,6 +35,7 @@
       },
       "allowChildren": true
     }],
+    "lines-between-class-members": "off",
     "react/destructuring-assignment": "off",
     "react/no-did-mount-set-state": "off",
     "react/jsx-no-bind": "off",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ vNext
 
 ### Features
 
-- Imporve `NumericInput` component to support big numbers ([PR 152](https://github.com/input-output-hk/react-polymorph/pull/152))
+- Improve `NumericInput` component to support big numbers ([PR 152](https://github.com/input-output-hk/react-polymorph/pull/152))
 - Improve `FormField` UX by using pop overs to show errors ([PR 151](https://github.com/input-output-hk/react-polymorph/pull/151)
 
 0.9.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ vNext
 
 ### Features
 
+- Imporve `NumericInput` component to support big numbers ([PR 152](https://github.com/input-output-hk/react-polymorph/pull/152))
 - Improve `FormField` UX by using pop overs to show errors ([PR 151](https://github.com/input-output-hk/react-polymorph/pull/151)
 
 0.9.6

--- a/README.md
+++ b/README.md
@@ -166,51 +166,39 @@ import { NumericInput } from "react-polymorph/lib/components";
 import { InputSkin } from "react-polymorph/lib/skins/simple";
 
 const MyNumericInput = () => (
-  <NumericInput // notice the different logic component!
-    skin={InputSkin} // but the same skin!
+  <NumericInput
     label="Amount"
     placeholder="0.000000"
-    numberLocaleOptions={{ maximumFractionDigits: 6 }}
+    decimalPlaces={6}
+    bigNumberFormat={{ decimalSeparator: '.', groupSeparator: ',' }}
   />
 );
 ```
 
-
-_Side Note: this shows how you can make/use specialized versions of basic components by composition 
-(reusing the `InputSkin` with a specialized logic component) - a core idea of react-polymorph!_
-
-##### Expected Behavior & Limitations:
+##### Expected Behavior:
 
 Since there is no web standard on how to build numeric input components, here is the specification we
 came up with that serves our purposes in the best way: 
 
-- Only numeric inputs that are representable by Javascript numbers are valid. This is guarded by `Number.MIN_SAFE_INTEGER` 
-  (-9007199254740991) and `Number.MAX_SAFE_INTEGER` (9007199254740991) but since also fractions need to 
-  represented, the calculation for the maximum integer part goes like this:
-  `Number.MAX_SAFE_INTEGER / 10 ** (maximumFractionDigits + 1)` (which basically means that one integer digit is lost for
-  each supported fraction digit). For `maximumFractionDigits == 3` this results in 
-  `9007199254740991 / 10 ** 4 == 900719925474.099` being the biggest number that can be entered.
-- Only numeric digits `[0-9]` and dots `.` can be entered.
+- Only numeric digits `[0-9]` and decimal separators (configurable via `bigNumberFormat` prop) can be entered.
 - When invalid characters are pasted as input, nothing happens
-- When a second dot is entered it replaces the existing one and updates the fraction part accordingly
-- Commas cannot be deleted but the cursor should jump over them when DEL or BACKSPACE keys are used
-- The fraction dot can only be deleted if `minimumFractionDigits` is not defined or
-  if the resulting number does not exceed the numeric limits!
-- It's possible to replace the whole number or parts of it (even the dot) by inserting another number.
-- If the fraction dot is deleted but the resulting number is too big the cursor jumps over the dot without deletion
-- If you insert a digit but the resulting number would exceed the numeric limit, nothing happens
+- When a second decimal separators is entered it replaces the existing one and updates the fraction part accordingly
+- Group separators cannot be deleted but the cursor should jump over them when DEL or BACKSPACE keys are used
+- It's possible to replace the whole number or parts of it (even the decimal separator) by inserting another number.
 
 ##### Props:
 
+The `NumericInput` is based on the `Input` component and extends it's functionality:
+
 ```js
 type NumericInputProps = {
+  // Input props:
   autoFocus?: boolean,
   className?: string,
   context: ThemeContextProp,
   disabled?: boolean,
   error?: string,
   label?: string | Element<any>,
-  numberLocaleOptions?: Number$LocaleOptions,
   onBlur?: Function,
   onChange?: Function,
   onFocus?: Function,
@@ -220,26 +208,36 @@ type NumericInputProps = {
   theme: ?Object,
   themeId: string,
   themeOverrides: Object,
-  useDynamicDigitCalculation: boolean,
-  value: ?number,
+  // Numeric input specific props:
+  allowSigns?: boolean,
+  bigNumberFormat?: BigNumber.Format,
+  decimalPlaces?: number,
+  roundingMode?: BigNumber.RoundingMode,
+  value: ?BigNumber.Instance,
 };
 ```
 
-###### `numberLocaleOptions`
+###### `value`
 
-`Number.toLocaleString()` is used internally to localize the given number value. This method takes options
-explained in greater detail in the 
-[MDN web docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toLocaleString) 
+Must be an instance of [BigNumber](https://mikemcl.github.io/bignumber.js)
+`onChange` also returns an instance of `BigNumber` after any user changes.
 
-The most important parts are `maximumFractionDigits` (defaults to 3 as per web standard) and `minimumFractionDigits`
-which dictate the handling of fraction digits. 
+###### `allowSigns`
 
-###### `useDynamicDigitCalculation`
+Is `true` by default, if `false` the user cannot enter negative numbers.
 
-This is an optional mode that "sacrifices" simple, clear UX in favor of being able to enter bigger numbers.
-Basically it works the same way but it dynamically calculates how large the integer part of the number can
-be based on the actual fraction digits entered. The less fraction digits, the more integer digits are possible
-and vice versa.
+###### `decimalPlaces`
+
+No restriction by default (any number of decimal places allowed).
+Can be set to fix the decimal places to a specific amount.
+
+###### `bigNumberFormat`
+
+You can configure the number format by passing in any valid [bignumber.js FORMAT option](https://mikemcl.github.io/bignumber.js/#format)
+
+###### `roundingMode`
+
+You can configure the rounding mode by passing in any valid [bignumber.js ROUNDING_MODE option](https://mikemcl.github.io/bignumber.js/#rounding-mode)
 
 ---
 

--- a/__tests__/FormField.test.js
+++ b/__tests__/FormField.test.js
@@ -6,42 +6,34 @@ import { renderInSimpleTheme } from './helpers/theming';
 const renderFormField = () => <div className="render-prop" />;
 
 test('FormField renders correctly', () => {
-  expect(renderInSimpleTheme(
-    <FormField render={renderFormField} />
-  )).toMatchSnapshot();
+  expect(
+    renderInSimpleTheme(<FormField render={renderFormField} />)
+  ).toMatchSnapshot();
 });
 
 test('FormField renders with label', () => {
-  expect(renderInSimpleTheme(
-    <FormField
-      label="Add a Label"
-      render={renderFormField}
-    />
-  )).toMatchSnapshot();
-});
-
-test('FormField renders with an error', () => {
-  expect(renderInSimpleTheme(
-    <FormField
-      error="Add an Error"
-      render={renderFormField}
-    />
-  )).toMatchSnapshot();
+  expect(
+    renderInSimpleTheme(
+      <FormField label="Add a Label" render={renderFormField} />
+    )
+  ).toMatchSnapshot();
 });
 
 test('FormField is disabled', () => {
-  expect(renderInSimpleTheme(
-    <FormField
-      disabled
-      render={({ disabled }) => <span>{disabled.toString()}</span>}
-    />
-  )).toMatchSnapshot();
+  expect(
+    renderInSimpleTheme(
+      <FormField
+        disabled
+        render={({ disabled }) => <span>{disabled.toString()}</span>}
+      />
+    )
+  ).toMatchSnapshot();
 });
 
 test('FormField renders an input element', () => {
-  expect(renderInSimpleTheme(
-    <FormField
-      render={() => <input className="render-prop" />}
-    />
-  )).toMatchSnapshot();
+  expect(
+    renderInSimpleTheme(
+      <FormField render={() => <input className="render-prop" />} />
+    )
+  ).toMatchSnapshot();
 });

--- a/__tests__/NumericInput.behavior.test.js
+++ b/__tests__/NumericInput.behavior.test.js
@@ -1,13 +1,15 @@
+import BigNumber from 'bignumber.js';
 import React from 'react';
 
 import { NumericInput } from '../source/components/NumericInput';
 import { mountInSimpleTheme } from './helpers/theming';
 
 describe('NumericInput onChange simulations', () => {
-
   const mountNumericInputWithProps = (props) => {
     const onChangeMock = jest.fn();
-    const wrapper = mountInSimpleTheme(<NumericInput {...props} onChange={onChangeMock} />);
+    const wrapper = mountInSimpleTheme(
+      <NumericInput {...props} onChange={onChangeMock} />
+    );
     const input = wrapper.find('input');
     return {
       input,
@@ -20,7 +22,9 @@ describe('NumericInput onChange simulations', () => {
     test('valid input triggers onChange listener', () => {
       const { input, onChangeMock } = mountNumericInputWithProps();
       input.simulate('change', { nativeEvent: { target: { value: '19.00' } } });
-      expect(onChangeMock.mock.calls[0][0]).toBe(19.00);
+      const onChangeValue = onChangeMock.mock.calls[0][0];
+      expect(BigNumber.isBigNumber(onChangeValue)).toBe(true);
+      expect(onChangeValue.toNumber()).toBe(19);
     });
     test('invalid input does not trigger onChange listener', () => {
       const { input, onChangeMock } = mountNumericInputWithProps();
@@ -30,47 +34,37 @@ describe('NumericInput onChange simulations', () => {
   });
 
   describe('configurable number formats', () => {
-    test('handles commas as thousand separators by default', () => {
+    test('handles commas as group separators by default', () => {
       const { input, onChangeMock } = mountNumericInputWithProps();
-      input.simulate('change', { nativeEvent: { target: { value: '9,999,999.00' } } });
-      expect(onChangeMock.mock.calls[0][0]).toBe(9999999.00);
+      input.simulate('change', {
+        nativeEvent: { target: { value: '9,999,999.00' } },
+      });
+      const onChangeValue = onChangeMock.mock.calls[0][0];
+      expect(onChangeValue.toNumber()).toBe(9999999.0);
     });
     test('can be configured to handle dots as thousand separators', () => {
       const { input, onChangeMock } = mountNumericInputWithProps({
-        numberFormat: {
+        bigNumberFormat: {
           groupSeparator: '.',
           decimalSeparator: ',',
-        }
+        },
       });
-      input.simulate('change', { nativeEvent: { target: { value: '9.999.999,00' } } });
-      expect(onChangeMock.mock.calls[0][0]).toBe(9999999.00);
+      input.simulate('change', {
+        nativeEvent: { target: { value: '9.999.999,00' } },
+      });
+      expect(onChangeMock.mock.calls[0][0].toNumber()).toBe(9999999);
     });
     test('can be configured to handle spaces as thousand separators', () => {
       const { input, onChangeMock } = mountNumericInputWithProps({
-        numberFormat: {
+        bigNumberFormat: {
           groupSeparator: ' ',
           decimalSeparator: '.',
-        }
+        },
       });
-      input.simulate('change', { nativeEvent: { target: { value: '9 999 999.00' } } });
-      expect(onChangeMock.mock.calls[0][0]).toBe(9999999.00);
+      input.simulate('change', {
+        nativeEvent: { target: { value: '9 999 999.00' } },
+      });
+      expect(onChangeMock.mock.calls[0][0].toNumber()).toBe(9999999);
     });
   });
-
-  test('enforces given minimumFractionDigits', () => {
-    const { input } = mountNumericInputWithProps({
-      numberLocaleOptions: { minimumFractionDigits: 6 },
-      value: 0,
-    });
-    expect(input.getDOMNode().value).toBe('0.000000');
-  });
-
-  test('enforces given maximumFractionDigits', () => {
-    const { input } = mountNumericInputWithProps({
-      numberLocaleOptions: { maximumFractionDigits: 2 },
-      value: 0.123,
-    });
-    expect(input.getDOMNode().value).toBe('0.12');
-  });
-
 });

--- a/__tests__/NumericInput.test.js
+++ b/__tests__/NumericInput.test.js
@@ -1,40 +1,35 @@
+import BigNumber from 'bignumber.js';
 import React from 'react';
 
 import { NumericInput } from '../source/components/NumericInput';
 import { renderInSimpleTheme } from './helpers/theming';
 
 test('NumericInput renders correctly', () => {
-  expect(renderInSimpleTheme(
-    <NumericInput />
-  )).toMatchSnapshot();
+  expect(renderInSimpleTheme(<NumericInput />)).toMatchSnapshot();
 });
 
 test('NumericInput renders with placeholder', () => {
-  expect(renderInSimpleTheme(
-    <NumericInput placeholder="0.0000" />
-  )).toMatchSnapshot();
+  expect(
+    renderInSimpleTheme(<NumericInput placeholder="0.0000" />)
+  ).toMatchSnapshot();
 });
 
 test('NumericInput is disabled', () => {
-  expect(renderInSimpleTheme(
-    <NumericInput disabled />
-  )).toMatchSnapshot();
+  expect(renderInSimpleTheme(<NumericInput disabled />)).toMatchSnapshot();
 });
 
 test('NumericInput is readOnly', () => {
-  expect(renderInSimpleTheme(
-    <NumericInput readOnly />
-  )).toMatchSnapshot();
+  expect(renderInSimpleTheme(<NumericInput readOnly />)).toMatchSnapshot();
 });
 
 test('NumericInput renders with an error', () => {
-  expect(renderInSimpleTheme(
-    <NumericInput error="Invalid Amount" />
-  )).toMatchSnapshot();
+  expect(
+    renderInSimpleTheme(<NumericInput error="Invalid Amount" />)
+  ).toMatchSnapshot();
 });
 
 test('NumericInput renders with a value', () => {
-  expect(renderInSimpleTheme(
-    <NumericInput value="555.333" />
-  )).toMatchSnapshot();
+  expect(
+    renderInSimpleTheme(<NumericInput value={new BigNumber(555.333)} />)
+  ).toMatchSnapshot();
 });

--- a/__tests__/TextArea.test.js
+++ b/__tests__/TextArea.test.js
@@ -4,31 +4,21 @@ import { TextArea } from '../source/components/TextArea';
 import { renderInSimpleTheme } from './helpers/theming';
 
 test('TextArea renders correctly', () => {
-  expect(renderInSimpleTheme(
-    <TextArea />
-  )).toMatchSnapshot();
+  expect(renderInSimpleTheme(<TextArea />)).toMatchSnapshot();
 });
 
 test('TextArea renders with placeholder', () => {
-  expect(renderInSimpleTheme(
-    <TextArea placeholder="0.0000" />
-  )).toMatchSnapshot();
-});
-
-test('TextArea renders with an error', () => {
-  expect(renderInSimpleTheme(
-    <TextArea error="Please enter valid input" />
-  )).toMatchSnapshot();
+  expect(
+    renderInSimpleTheme(<TextArea placeholder="0.0000" />)
+  ).toMatchSnapshot();
 });
 
 test('TextArea renders with a value', () => {
-  expect(renderInSimpleTheme(
-    <TextArea value="this one has a value" />
-  )).toMatchSnapshot();
+  expect(
+    renderInSimpleTheme(<TextArea value="this one has a value" />)
+  ).toMatchSnapshot();
 });
 
 test('TextArea renders with 5 rows', () => {
-  expect(renderInSimpleTheme(
-    <TextArea rows={5} />
-  )).toMatchSnapshot();
+  expect(renderInSimpleTheme(<TextArea rows={5} />)).toMatchSnapshot();
 });

--- a/__tests__/__snapshots__/Autocomplete.test.js.snap
+++ b/__tests__/__snapshots__/Autocomplete.test.js.snap
@@ -9,21 +9,23 @@ exports[`Autocomplete renders correctly 1`] = `
   <div
     class="root"
   >
-    <div
-      class="inputWrapper"
-    >
+    <span>
       <div
-        class="autocompleteContent"
+        class="inputWrapper"
       >
         <div
-          class="selectedWords"
+          class="autocompleteContent"
         >
-          <input
-            value=""
-          />
+          <div
+            class="selectedWords"
+          >
+            <input
+              value=""
+            />
+          </div>
         </div>
       </div>
-    </div>
+    </span>
   </div>
   <div
     class="options firstOptionHighlighted root isFloating isHidden"
@@ -125,22 +127,24 @@ exports[`Autocomplete renders with a placeholder 1`] = `
   <div
     class="root"
   >
-    <div
-      class="inputWrapper"
-    >
+    <span>
       <div
-        class="autocompleteContent"
+        class="inputWrapper"
       >
         <div
-          class="selectedWords"
+          class="autocompleteContent"
         >
-          <input
-            placeholder="Enter recovery phrase"
-            value=""
-          />
+          <div
+            class="selectedWords"
+          >
+            <input
+              placeholder="Enter recovery phrase"
+              value=""
+            />
+          </div>
         </div>
       </div>
-    </div>
+    </span>
   </div>
   <div
     class="options firstOptionHighlighted root isFloating isHidden"
@@ -242,26 +246,23 @@ exports[`Autocomplete renders with an error 1`] = `
   <div
     class="root errored"
   >
-    <div
-      class="error"
-    >
-      Your mnemonic phrase is incorrect
-    </div>
-    <div
-      class="inputWrapper"
-    >
+    <span>
       <div
-        class="autocompleteContent errored"
+        class="inputWrapper"
       >
         <div
-          class="selectedWords"
+          class="autocompleteContent errored"
         >
-          <input
-            value=""
-          />
+          <div
+            class="selectedWords"
+          >
+            <input
+              value=""
+            />
+          </div>
         </div>
       </div>
-    </div>
+    </span>
   </div>
   <div
     class="options firstOptionHighlighted root isFloating isHidden"
@@ -370,21 +371,23 @@ exports[`Autocomplete renders with label 1`] = `
     >
       Enter your recovery phrase below
     </label>
-    <div
-      class="inputWrapper"
-    >
+    <span>
       <div
-        class="autocompleteContent"
+        class="inputWrapper"
       >
         <div
-          class="selectedWords"
+          class="autocompleteContent"
         >
-          <input
-            value=""
-          />
+          <div
+            class="selectedWords"
+          >
+            <input
+              value=""
+            />
+          </div>
         </div>
       </div>
-    </div>
+    </span>
   </div>
   <div
     class="options firstOptionHighlighted root isFloating isHidden"
@@ -486,21 +489,23 @@ exports[`Autocomplete uses render prop - renderOptions 1`] = `
   <div
     class="root"
   >
-    <div
-      class="inputWrapper"
-    >
+    <span>
       <div
-        class="autocompleteContent"
+        class="inputWrapper"
       >
         <div
-          class="selectedWords"
+          class="autocompleteContent"
         >
-          <input
-            value=""
-          />
+          <div
+            class="selectedWords"
+          >
+            <input
+              value=""
+            />
+          </div>
         </div>
       </div>
-    </div>
+    </span>
   </div>
   <div
     class="options firstOptionHighlighted root isFloating isHidden"
@@ -594,21 +599,23 @@ exports[`Autocomplete uses render prop - renderSelections 1`] = `
   <div
     class="root"
   >
-    <div
-      class="inputWrapper"
-    >
+    <span>
       <div
-        class="autocompleteContent"
+        class="inputWrapper"
       >
         <div
-          class="selectedWords"
+          class="autocompleteContent"
         >
-          <input
-            value=""
-          />
+          <div
+            class="selectedWords"
+          >
+            <input
+              value=""
+            />
+          </div>
         </div>
       </div>
-    </div>
+    </span>
   </div>
   <div
     class="options firstOptionHighlighted root isFloating isHidden"

--- a/__tests__/__snapshots__/FormField.test.js.snap
+++ b/__tests__/__snapshots__/FormField.test.js.snap
@@ -4,13 +4,15 @@ exports[`FormField is disabled 1`] = `
 <div
   class="root disabled"
 >
-  <div
-    class="inputWrapper"
-  >
-    <span>
-      true
-    </span>
-  </div>
+  <span>
+    <div
+      class="inputWrapper"
+    >
+      <span>
+        true
+      </span>
+    </div>
+  </span>
 </div>
 `;
 
@@ -18,13 +20,15 @@ exports[`FormField renders an input element 1`] = `
 <div
   class="root"
 >
-  <div
-    class="inputWrapper"
-  >
-    <input
-      class="render-prop"
-    />
-  </div>
+  <span>
+    <div
+      class="inputWrapper"
+    >
+      <input
+        class="render-prop"
+      />
+    </div>
+  </span>
 </div>
 `;
 
@@ -32,13 +36,15 @@ exports[`FormField renders correctly 1`] = `
 <div
   class="root"
 >
-  <div
-    class="inputWrapper"
-  >
+  <span>
     <div
-      class="render-prop"
-    />
-  </div>
+      class="inputWrapper"
+    >
+      <div
+        class="render-prop"
+      />
+    </div>
+  </span>
 </div>
 `;
 
@@ -46,18 +52,15 @@ exports[`FormField renders with an error 1`] = `
 <div
   class="root errored"
 >
-  <div
-    class="error"
-  >
-    Add an Error
-  </div>
-  <div
-    class="inputWrapper"
-  >
+  <span>
     <div
-      class="render-prop"
-    />
-  </div>
+      class="inputWrapper"
+    >
+      <div
+        class="render-prop"
+      />
+    </div>
+  </span>
 </div>
 `;
 
@@ -72,12 +75,14 @@ exports[`FormField renders with label 1`] = `
   >
     Add a Label
   </label>
-  <div
-    class="inputWrapper"
-  >
+  <span>
     <div
-      class="render-prop"
-    />
-  </div>
+      class="inputWrapper"
+    >
+      <div
+        class="render-prop"
+      />
+    </div>
+  </span>
 </div>
 `;

--- a/__tests__/__snapshots__/Input.test.js.snap
+++ b/__tests__/__snapshots__/Input.test.js.snap
@@ -4,15 +4,17 @@ exports[`Input is readOnly 1`] = `
 <div
   class="root"
 >
-  <div
-    class="inputWrapper"
-  >
-    <input
-      class="input"
-      readonly=""
-      value=""
-    />
-  </div>
+  <span>
+    <div
+      class="inputWrapper"
+    >
+      <input
+        class="input"
+        readonly=""
+        value=""
+      />
+    </div>
+  </span>
 </div>
 `;
 
@@ -20,14 +22,16 @@ exports[`Input renders correctly 1`] = `
 <div
   class="root"
 >
-  <div
-    class="inputWrapper"
-  >
-    <input
-      class="input"
-      value=""
-    />
-  </div>
+  <span>
+    <div
+      class="inputWrapper"
+    >
+      <input
+        class="input"
+        value=""
+      />
+    </div>
+  </span>
 </div>
 `;
 
@@ -35,14 +39,16 @@ exports[`Input renders with a value 1`] = `
 <div
   class="root"
 >
-  <div
-    class="inputWrapper"
-  >
-    <input
-      class="input"
-      value="there is value"
-    />
-  </div>
+  <span>
+    <div
+      class="inputWrapper"
+    >
+      <input
+        class="input"
+        value="there is value"
+      />
+    </div>
+  </span>
 </div>
 `;
 
@@ -50,14 +56,16 @@ exports[`Input renders with placeholder 1`] = `
 <div
   class="root"
 >
-  <div
-    class="inputWrapper"
-  >
-    <input
-      class="input"
-      placeholder="0.0000"
-      value=""
-    />
-  </div>
+  <span>
+    <div
+      class="inputWrapper"
+    >
+      <input
+        class="input"
+        placeholder="0.0000"
+        value=""
+      />
+    </div>
+  </span>
 </div>
 `;

--- a/__tests__/__snapshots__/NumericInput.test.js.snap
+++ b/__tests__/__snapshots__/NumericInput.test.js.snap
@@ -4,15 +4,17 @@ exports[`NumericInput is disabled 1`] = `
 <div
   class="root disabled"
 >
-  <div
-    class="inputWrapper"
-  >
-    <input
-      class="input disabled"
-      disabled=""
-      value=""
-    />
-  </div>
+  <span>
+    <div
+      class="inputWrapper"
+    >
+      <input
+        class="input disabled"
+        disabled=""
+        value=""
+      />
+    </div>
+  </span>
 </div>
 `;
 
@@ -20,15 +22,17 @@ exports[`NumericInput is readOnly 1`] = `
 <div
   class="root"
 >
-  <div
-    class="inputWrapper"
-  >
-    <input
-      class="input"
-      readonly=""
-      value=""
-    />
-  </div>
+  <span>
+    <div
+      class="inputWrapper"
+    >
+      <input
+        class="input"
+        readonly=""
+        value=""
+      />
+    </div>
+  </span>
 </div>
 `;
 
@@ -36,14 +40,16 @@ exports[`NumericInput renders correctly 1`] = `
 <div
   class="root"
 >
-  <div
-    class="inputWrapper"
-  >
-    <input
-      class="input"
-      value=""
-    />
-  </div>
+  <span>
+    <div
+      class="inputWrapper"
+    >
+      <input
+        class="input"
+        value=""
+      />
+    </div>
+  </span>
 </div>
 `;
 
@@ -51,14 +57,16 @@ exports[`NumericInput renders with a value 1`] = `
 <div
   class="root"
 >
-  <div
-    class="inputWrapper"
-  >
-    <input
-      class="input"
-      value="555.333"
-    />
-  </div>
+  <span>
+    <div
+      class="inputWrapper"
+    >
+      <input
+        class="input"
+        value="555.333"
+      />
+    </div>
+  </span>
 </div>
 `;
 
@@ -66,19 +74,16 @@ exports[`NumericInput renders with an error 1`] = `
 <div
   class="root errored"
 >
-  <div
-    class="error"
-  >
-    Invalid Amount
-  </div>
-  <div
-    class="inputWrapper"
-  >
-    <input
-      class="input errored"
-      value=""
-    />
-  </div>
+  <span>
+    <div
+      class="inputWrapper"
+    >
+      <input
+        class="input errored"
+        value=""
+      />
+    </div>
+  </span>
 </div>
 `;
 
@@ -86,14 +91,16 @@ exports[`NumericInput renders with placeholder 1`] = `
 <div
   class="root"
 >
-  <div
-    class="inputWrapper"
-  >
-    <input
-      class="input"
-      placeholder="0.0000"
-      value=""
-    />
-  </div>
+  <span>
+    <div
+      class="inputWrapper"
+    >
+      <input
+        class="input"
+        placeholder="0.0000"
+        value=""
+      />
+    </div>
+  </span>
 </div>
 `;

--- a/__tests__/__snapshots__/Select.test.js.snap
+++ b/__tests__/__snapshots__/Select.test.js.snap
@@ -10,15 +10,17 @@ exports[`Select isOpen={true} 1`] = `
     <div
       class="root"
     >
-      <div
-        class="inputWrapper"
-      >
-        <input
-          class="input"
-          readonly=""
-          value=""
-        />
-      </div>
+      <span>
+        <div
+          class="inputWrapper"
+        >
+          <input
+            class="input"
+            readonly=""
+            value=""
+          />
+        </div>
+      </span>
     </div>
   </div>
   <div
@@ -149,15 +151,17 @@ exports[`Select isOpeningUpward={true} 1`] = `
     <div
       class="root"
     >
-      <div
-        class="inputWrapper"
-      >
-        <input
-          class="input"
-          readonly=""
-          value=""
-        />
-      </div>
+      <span>
+        <div
+          class="inputWrapper"
+        >
+          <input
+            class="input"
+            readonly=""
+            value=""
+          />
+        </div>
+      </span>
     </div>
   </div>
   <div
@@ -288,15 +292,17 @@ exports[`Select renders correctly 1`] = `
     <div
       class="root"
     >
-      <div
-        class="inputWrapper"
-      >
-        <input
-          class="input"
-          readonly=""
-          value=""
-        />
-      </div>
+      <span>
+        <div
+          class="inputWrapper"
+        >
+          <input
+            class="input"
+            readonly=""
+            value=""
+          />
+        </div>
+      </span>
     </div>
   </div>
   <div
@@ -427,20 +433,17 @@ exports[`Select renders with an error 1`] = `
     <div
       class="root errored"
     >
-      <div
-        class="error"
-      >
-        Please select a different option
-      </div>
-      <div
-        class="inputWrapper"
-      >
-        <input
-          class="input errored"
-          readonly=""
-          value=""
-        />
-      </div>
+      <span>
+        <div
+          class="inputWrapper"
+        >
+          <input
+            class="input errored"
+            readonly=""
+            value=""
+          />
+        </div>
+      </span>
     </div>
   </div>
   <div
@@ -571,15 +574,17 @@ exports[`Select renders with disabled options 1`] = `
     <div
       class="root"
     >
-      <div
-        class="inputWrapper"
-      >
-        <input
-          class="input"
-          readonly=""
-          value=""
-        />
-      </div>
+      <span>
+        <div
+          class="inputWrapper"
+        >
+          <input
+            class="input"
+            readonly=""
+            value=""
+          />
+        </div>
+      </span>
     </div>
   </div>
   <div
@@ -699,16 +704,18 @@ exports[`Select renders with placeholder 1`] = `
     <div
       class="root"
     >
-      <div
-        class="inputWrapper"
-      >
-        <input
-          class="input"
-          placeholder="Select your country …"
-          readonly=""
-          value=""
-        />
-      </div>
+      <span>
+        <div
+          class="inputWrapper"
+        >
+          <input
+            class="input"
+            placeholder="Select your country …"
+            readonly=""
+            value=""
+          />
+        </div>
+      </span>
     </div>
   </div>
   <div
@@ -839,15 +846,17 @@ exports[`Select uses render prop - optionRenderer 1`] = `
     <div
       class="root"
     >
-      <div
-        class="inputWrapper"
-      >
-        <input
-          class="input"
-          readonly=""
-          value=""
-        />
-      </div>
+      <span>
+        <div
+          class="inputWrapper"
+        >
+          <input
+            class="input"
+            readonly=""
+            value=""
+          />
+        </div>
+      </span>
     </div>
   </div>
   <div
@@ -993,22 +1002,24 @@ exports[`Select uses render prop - valueRenderer 1`] = `
     <div
       class="root"
     >
-      <div
-        class="inputWrapper"
-      >
+      <span>
         <div
-          class="customValueWrapper"
+          class="inputWrapper"
         >
-          <input
-            class="input"
-            readonly=""
-            value=""
-          />
           <div
-            class="customValueBlock"
-          />
+            class="customValueWrapper"
+          >
+            <input
+              class="input"
+              readonly=""
+              value=""
+            />
+            <div
+              class="customValueBlock"
+            />
+          </div>
         </div>
-      </div>
+      </span>
     </div>
   </div>
   <div

--- a/__tests__/__snapshots__/TextArea.test.js.snap
+++ b/__tests__/__snapshots__/TextArea.test.js.snap
@@ -4,13 +4,15 @@ exports[`TextArea renders correctly 1`] = `
 <div
   class="root"
 >
-  <div
-    class="inputWrapper"
-  >
-    <textarea
-      class="textarea"
-    />
-  </div>
+  <span>
+    <div
+      class="inputWrapper"
+    >
+      <textarea
+        class="textarea"
+      />
+    </div>
+  </span>
 </div>
 `;
 
@@ -18,14 +20,16 @@ exports[`TextArea renders with 5 rows 1`] = `
 <div
   class="root"
 >
-  <div
-    class="inputWrapper"
-  >
-    <textarea
-      class="textarea"
-      rows="5"
-    />
-  </div>
+  <span>
+    <div
+      class="inputWrapper"
+    >
+      <textarea
+        class="textarea"
+        rows="5"
+      />
+    </div>
+  </span>
 </div>
 `;
 
@@ -33,15 +37,17 @@ exports[`TextArea renders with a value 1`] = `
 <div
   class="root"
 >
-  <div
-    class="inputWrapper"
-  >
-    <textarea
-      class="textarea"
+  <span>
+    <div
+      class="inputWrapper"
     >
-      this one has a value
-    </textarea>
-  </div>
+      <textarea
+        class="textarea"
+      >
+        this one has a value
+      </textarea>
+    </div>
+  </span>
 </div>
 `;
 
@@ -49,18 +55,15 @@ exports[`TextArea renders with an error 1`] = `
 <div
   class="root errored"
 >
-  <div
-    class="error"
-  >
-    Please enter valid input
-  </div>
-  <div
-    class="inputWrapper"
-  >
-    <textarea
-      class="textarea errored"
-    />
-  </div>
+  <span>
+    <div
+      class="inputWrapper"
+    >
+      <textarea
+        class="textarea errored"
+      />
+    </div>
+  </span>
 </div>
 `;
 
@@ -68,13 +71,15 @@ exports[`TextArea renders with placeholder 1`] = `
 <div
   class="root"
 >
-  <div
-    class="inputWrapper"
-  >
-    <textarea
-      class="textarea"
-      placeholder="0.0000"
-    />
-  </div>
+  <span>
+    <div
+      class="inputWrapper"
+    >
+      <textarea
+        class="textarea"
+        placeholder="0.0000"
+      />
+    </div>
+  </span>
 </div>
 `;

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -2,4 +2,10 @@ import 'raf/polyfill';
 import { configure } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 
+// Suppress react warning about using useLayoutEffect hook on server
+jest.mock('react', () => ({
+  ...jest.requireActual('react'),
+  useLayoutEffect: jest.requireActual('react').useEffect,
+}));
+
 configure({ adapter: new Adapter() });

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-polymorph",
   "description": "React components with highly customizable logic, markup and styles.",
-  "version": "0.9.7-rc.15",
+  "version": "0.9.7-rc.16",
   "scripts": {
     "build": "cross-env yarn clean && yarn sass && yarn js",
     "build:watch": "concurrently 'yarn js:watch' 'yarn sass:watch'",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-polymorph",
   "description": "React components with highly customizable logic, markup and styles.",
-  "version": "0.9.7-rc.14",
+  "version": "0.9.7-rc.15",
   "scripts": {
     "build": "cross-env yarn clean && yarn sass && yarn js",
     "build:watch": "concurrently 'yarn js:watch' 'yarn sass:watch'",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-polymorph",
   "description": "React components with highly customizable logic, markup and styles.",
-  "version": "0.9.7-rc.12",
+  "version": "0.9.7-rc.13",
   "scripts": {
     "build": "cross-env yarn clean && yarn sass && yarn js",
     "build:watch": "concurrently 'yarn js:watch' 'yarn sass:watch'",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-polymorph",
   "description": "React components with highly customizable logic, markup and styles.",
-  "version": "0.9.7-rc.11",
+  "version": "0.9.7-rc.12",
   "scripts": {
     "build": "cross-env yarn clean && yarn sass && yarn js",
     "build:watch": "concurrently 'yarn js:watch' 'yarn sass:watch'",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "babel-jest": "24.9.0",
     "babel-loader": "8.0.6",
     "babel-plugin-lodash": "3.3.4",
+    "bignumber.js": "9.0.1",
     "classnames": "2.2.5",
     "concurrently": "5.2.0",
     "cpy": "8.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-polymorph",
   "description": "React components with highly customizable logic, markup and styles.",
-  "version": "0.9.7-rc.13",
+  "version": "0.9.7-rc.14",
   "scripts": {
     "build": "cross-env yarn clean && yarn sass && yarn js",
     "build:watch": "concurrently 'yarn js:watch' 'yarn sass:watch'",

--- a/source/components/FormField.js
+++ b/source/components/FormField.js
@@ -16,6 +16,7 @@ export type FormFieldProps = {
   disabled?: boolean,
   error?: string | Element<any>,
   isErrorHidden?: boolean,
+  isErrorShown?: boolean,
   inputRef?: ElementRef<*>,
   label?: string | Element<any>,
   onChange: Function,

--- a/source/components/FormField.js
+++ b/source/components/FormField.js
@@ -17,10 +17,9 @@ export type FormFieldProps = {
   error?: string | Element<any>,
   isErrorHidden?: boolean,
   isErrorShown?: boolean,
-  inputRef?: ElementRef<*>,
   label?: string | Element<any>,
   onChange: Function,
-  render: Function,
+  render: (setFormFieldRef: (ElementRef<*>) => void) => React$Node,
   skin?: ComponentType<any>,
   theme: ?Object, // will take precedence over theme in context if passed
   themeId: string,
@@ -42,6 +41,8 @@ class FormFieldBase extends Component<FormFieldProps, State> {
     themeId: IDENTIFIERS.FORM_FIELD,
     themeOverrides: {},
   };
+
+  formFieldRef: ElementRef<*> = React.createRef;
 
   constructor(props: FormFieldProps) {
     super(props);
@@ -67,10 +68,10 @@ class FormFieldBase extends Component<FormFieldProps, State> {
   setError = (error: string) => this.setState({ error });
 
   focusChild = () => {
-    const { inputRef } = this.props;
-    if (inputRef && inputRef.current) {
-      if (typeof inputRef.current.focus === 'function') {
-        inputRef.current.focus();
+    const { formFieldRef } = this;
+    if (formFieldRef && formFieldRef.current) {
+      if (typeof formFieldRef.current.focus === 'function') {
+        formFieldRef.current.focus();
       }
     }
   };
@@ -86,6 +87,7 @@ class FormFieldBase extends Component<FormFieldProps, State> {
         error={error || this.state.error}
         setError={this.setError}
         theme={this.state.composedTheme}
+        formFieldRef={this.formFieldRef}
         focusChild={this.focusChild}
         {...rest}
       />

--- a/source/components/Input.js
+++ b/source/components/Input.js
@@ -89,9 +89,8 @@ class InputBase extends Component<InputProps, State> {
   }
 
   onChange = (event: SyntheticInputEvent<Element<'input'>>) => {
-    const { onChange, disabled } = this.props;
-    if (disabled) return;
-
+    const { onChange, disabled, readOnly } = this.props;
+    if (disabled || readOnly) return;
     if (onChange) onChange(this._processValue(event.target.value), event);
   };
 

--- a/source/components/NumericInput.js
+++ b/source/components/NumericInput.js
@@ -10,11 +10,9 @@ import type { SyntheticInputEvent, Element, ElementRef } from 'react';
 import createRef from 'create-react-ref/lib/createRef';
 
 // internal utility functions
-import { createEmptyContext, withTheme } from './HOC/withTheme';
-import { composeTheme, addThemeId, didThemePropsChange } from '../utils/themes';
+import { withTheme } from './HOC/withTheme';
 
 // import constants
-import { IDENTIFIERS } from '.';
 import { removeCharAtPosition } from '../utils/strings';
 import type { InputEvent } from '../utils/types';
 import { Input } from './Input';
@@ -42,25 +40,15 @@ class NumericInputBase extends Component<NumericInputProps, State> {
 
   static defaultProps = {
     allowSigns: true,
-    context: createEmptyContext(),
     readOnly: false,
     roundingMode: BigNumber.ROUND_FLOOR,
-    theme: null,
-    themeId: IDENTIFIERS.INPUT,
-    themeOverrides: {},
     value: null,
   };
 
   constructor(props: NumericInputProps) {
     super(props);
-    const { context, themeId, theme, themeOverrides } = props;
     this.inputElement = createRef();
     this.state = {
-      composedTheme: composeTheme(
-        addThemeId(theme || context.theme, themeId),
-        addThemeId(themeOverrides, themeId),
-        context.ROOT_THEME_API
-      ),
       inputCaretPosition: 0,
       fallbackInputValue: null,
     };
@@ -93,9 +81,6 @@ class NumericInputBase extends Component<NumericInputProps, State> {
       this.setInputCaretPosition(inputCaretPosition);
     }
     this._hasInputBeenChanged = false;
-    if (prevProps !== this.props) {
-      didThemePropsChange(prevProps, this.props, this.setState.bind(this));
-    }
   }
 
   onChange = (newValue, event: SyntheticInputEvent<Element<'input'>>) => {
@@ -363,15 +348,7 @@ class NumericInputBase extends Component<NumericInputProps, State> {
 
   render() {
     // destructuring props ensures only the "...rest" get passed down
-    const {
-      context,
-      onChange,
-      skin,
-      theme,
-      themeOverrides,
-      value,
-      ...rest
-    } = this.props;
+    const { onChange, value, ...rest } = this.props;
 
     const inputValue = this.state.fallbackInputValue
       ? this.state.fallbackInputValue
@@ -381,9 +358,8 @@ class NumericInputBase extends Component<NumericInputProps, State> {
       <Input
         inputRef={this.inputElement}
         onChange={this.onChange}
-        theme={this.state.composedTheme}
-        value={inputValue}
         onBlur={this.onBlur}
+        value={inputValue}
         {...rest}
       />
     );

--- a/source/components/NumericInput.js
+++ b/source/components/NumericInput.js
@@ -153,7 +153,7 @@ class NumericInputBase extends Component<NumericInputProps, State> {
     const { decimalSeparator, groupSeparator } = this.getBigNumberFormat();
     const changedCaretPosition = target.selectionStart;
     const valueToProcess = target.value;
-    const fallbackInputValue = this.state.fallbackInputValue || '';
+    const fallbackInputValue = this.state.fallbackInputValue;
     const isBackwardDelete = inputType === 'deleteContentBackward';
     const isForwardDelete = inputType === 'deleteContentForward';
     const isDeletion = isForwardDelete || isBackwardDelete;
@@ -209,9 +209,7 @@ class NumericInputBase extends Component<NumericInputProps, State> {
 
     const currentNumber = value;
     const currentValue =
-      currentNumber != null
-        ? this.bigNumberToFormattedString(currentNumber)
-        : fallbackInputValue;
+      fallbackInputValue ?? this.bigNumberToFormattedString(currentNumber);
 
     const currentNumberOfDecimalSeparators = this.getNumberOfDecimalSeparators(
       currentValue
@@ -261,6 +259,7 @@ class NumericInputBase extends Component<NumericInputProps, State> {
       return {
         value: newNumber,
         caretPosition: newCaretPos,
+        fallbackInputValue: null,
       };
     }
 
@@ -363,21 +362,19 @@ class NumericInputBase extends Component<NumericInputProps, State> {
     const { decimalSeparator, groupSeparator } = this.getBigNumberFormat();
     return new BigNumber(
       value
-        .replace(new RegExp(escapeRegExp(groupSeparator), 'g'), '')
-        .replace(new RegExp(escapeRegExp(decimalSeparator), 'g'), '.')
+        .replace(escapedGlobalRegExp(groupSeparator), '')
+        .replace(escapedGlobalRegExp(decimalSeparator), '.')
     );
   }
 
   getNumberOfGroupSeparators(value: string): number {
     const { groupSeparator } = this.getBigNumberFormat();
-    return (value.match(new RegExp(escapeRegExp(groupSeparator), 'g')) || [])
-      .length;
+    return (value.match(escapedGlobalRegExp(groupSeparator)) || []).length;
   }
 
   getNumberOfDecimalSeparators(value: string): number {
     const { decimalSeparator } = this.getBigNumberFormat();
-    return (value.match(new RegExp(escapeRegExp(decimalSeparator), 'g')) || [])
-      .length;
+    return (value.match(escapedGlobalRegExp(decimalSeparator)) || []).length;
   }
 
   isDifferentValue(first: ?BigNumber.Instance, second: ?BigNumber.Instance) {
@@ -425,3 +422,7 @@ class NumericInputBase extends Component<NumericInputProps, State> {
 }
 
 export const NumericInput = withTheme(NumericInputBase);
+
+function escapedGlobalRegExp(regex) {
+  return new RegExp(escapeRegExp(regex), 'g');
+}

--- a/source/components/NumericInput.js
+++ b/source/components/NumericInput.js
@@ -4,12 +4,7 @@ import React, { Component } from 'react';
 import BigNumber from 'bignumber.js';
 
 // $FlowFixMe
-import type {
-  ComponentType,
-  SyntheticInputEvent,
-  Element,
-  ElementRef,
-} from 'react';
+import type { SyntheticInputEvent, Element, ElementRef } from 'react';
 
 // external libraries
 import createRef from 'create-react-ref/lib/createRef';
@@ -20,30 +15,16 @@ import { composeTheme, addThemeId, didThemePropsChange } from '../utils/themes';
 
 // import constants
 import { IDENTIFIERS } from '.';
-import type { ThemeContextProp } from './HOC/withTheme';
 import { removeCharAtPosition } from '../utils/strings';
 import type { InputEvent } from '../utils/types';
+import { Input } from './Input';
+import type { InputProps } from './Input';
 
-export type NumericInputProps = {
+export type NumericInputProps = InputProps & {
   allowSigns?: boolean,
-  autoFocus?: boolean,
   bigNumberFormat?: BigNumber.Format,
   decimalPlaces?: number,
   roundingMode?: BigNumber.RoundingMode,
-  className?: string,
-  context: ThemeContextProp,
-  disabled?: boolean,
-  error?: string,
-  label?: string | Element<any>,
-  onBlur?: Function,
-  onChange?: Function,
-  onFocus?: Function,
-  placeholder?: string,
-  readOnly?: boolean,
-  skin?: ComponentType<any>,
-  theme: ?Object,
-  themeId: string,
-  themeOverrides: Object,
   value: ?BigNumber.Instance,
 };
 
@@ -116,12 +97,8 @@ class NumericInputBase extends Component<NumericInputProps, State> {
     }
   }
 
-  onChange = (event: SyntheticInputEvent<Element<'input'>>) => {
-    event.preventDefault();
-    const { value, onChange, disabled } = this.props;
-    if (disabled) {
-      return;
-    }
+  onChange = (newValue, event: SyntheticInputEvent<Element<'input'>>) => {
+    const { value, onChange } = this.props;
     const result = this.processValueChange(event.nativeEvent);
     if (result) {
       this._hasInputBeenChanged = true;
@@ -338,10 +315,11 @@ class NumericInputBase extends Component<NumericInputProps, State> {
     inputElement.current.focus();
   };
 
-  onBlur = () => {
+  onBlur = (event) => {
     this.setState({
       fallbackInputValue: null,
     });
+    this.props.onBlur?.(event);
   };
 
   getBigNumberFormat(): BigNumber.Config {
@@ -387,8 +365,6 @@ class NumericInputBase extends Component<NumericInputProps, State> {
     // destructuring props ensures only the "...rest" get passed down
     const {
       context,
-      error,
-      numberLocaleOptions,
       onChange,
       skin,
       theme,
@@ -401,15 +377,12 @@ class NumericInputBase extends Component<NumericInputProps, State> {
       throw new Error('Prop "value" must be of type BigNumber or null.');
     }
 
-    const InputSkin = skin || context.skins[IDENTIFIERS.INPUT];
-
     const inputValue = this.state.fallbackInputValue
       ? this.state.fallbackInputValue
       : this.bigNumberToFormattedString(value);
 
     return (
-      <InputSkin
-        error={error}
+      <Input
         inputRef={this.inputElement}
         onChange={this.onChange}
         theme={this.state.composedTheme}

--- a/source/components/NumericInput.js
+++ b/source/components/NumericInput.js
@@ -1,11 +1,14 @@
 // @flow
+import { escapeRegExp } from 'lodash/string';
 import React, { Component } from 'react';
+import BigNumber from 'bignumber.js';
+
 // $FlowFixMe
 import type {
   ComponentType,
   SyntheticInputEvent,
   Element,
-  ElementRef
+  ElementRef,
 } from 'react';
 
 // external libraries
@@ -21,26 +24,17 @@ import type { ThemeContextProp } from './HOC/withTheme';
 import { removeCharAtPosition } from '../utils/strings';
 import type { InputEvent } from '../utils/types';
 
-type NumberFormatOptions = {
-  groupSeparator: string,
-  decimalSeparator: string
-};
-
-const DEFAULT_NUMBER_FORMAT = {
-  groupSeparator: ',',
-  decimalSeparator: '.'
-};
-
 export type NumericInputProps = {
   allowSigns?: boolean,
   autoFocus?: boolean,
+  bigNumberFormat?: BigNumber.Format,
+  decimalPlaces?: number,
+  roundingMode?: BigNumber.RoundingMode,
   className?: string,
   context: ThemeContextProp,
   disabled?: boolean,
   error?: string,
   label?: string | Element<any>,
-  numberFormat: NumberFormatOptions,
-  numberLocaleOptions?: Number$LocaleOptions,
   onBlur?: Function,
   onChange?: Function,
   onFocus?: Function,
@@ -50,18 +44,14 @@ export type NumericInputProps = {
   theme: ?Object,
   themeId: string,
   themeOverrides: Object,
-  value: ?number
+  value: ?BigNumber.Instance,
 };
 
 type State = {
   composedTheme: Object,
-  minimumFractionDigits: number,
   inputCaretPosition: number,
-  fallbackInputValue: ?string
+  fallbackInputValue: ?string,
 };
-
-// Always use known number format and transform it where necessary
-const LOCALE = 'en-US';
 
 class NumericInputBase extends Component<NumericInputProps, State> {
   inputElement: { current: null | ElementRef<'input'> };
@@ -72,36 +62,25 @@ class NumericInputBase extends Component<NumericInputProps, State> {
   static defaultProps = {
     allowSigns: true,
     context: createEmptyContext(),
-    numberFormat: DEFAULT_NUMBER_FORMAT,
     readOnly: false,
     theme: null,
     themeId: IDENTIFIERS.INPUT,
     themeOverrides: {},
-    value: null
+    value: null,
   };
 
   constructor(props: NumericInputProps) {
     super(props);
-    const {
-      context,
-      numberLocaleOptions,
-      themeId,
-      theme,
-      themeOverrides
-    } = props;
+    const { context, themeId, theme, themeOverrides } = props;
     this.inputElement = createRef();
-    const minimumFractionDigits = numberLocaleOptions
-      ? numberLocaleOptions.minimumFractionDigits
-      : 0;
     this.state = {
       composedTheme: composeTheme(
         addThemeId(theme || context.theme, themeId),
         addThemeId(themeOverrides, themeId),
         context.ROOT_THEME_API
       ),
-      minimumFractionDigits: minimumFractionDigits || 0,
       inputCaretPosition: 0,
-      fallbackInputValue: null
+      fallbackInputValue: null,
     };
   }
 
@@ -112,7 +91,7 @@ class NumericInputBase extends Component<NumericInputProps, State> {
       this.focus();
       if (inputElement && inputElement.current) {
         this.setState({
-          inputCaretPosition: inputElement.current.selectionStart
+          inputCaretPosition: inputElement.current.selectionStart,
         });
       }
     }
@@ -152,8 +131,7 @@ class NumericInputBase extends Component<NumericInputProps, State> {
       }
       this.setState({
         inputCaretPosition: result.caretPosition,
-        minimumFractionDigits: result.minimumFractionDigits,
-        fallbackInputValue: result.fallbackInputValue
+        fallbackInputValue: result.fallbackInputValue,
       });
     }
   };
@@ -166,27 +144,27 @@ class NumericInputBase extends Component<NumericInputProps, State> {
   processValueChange(
     event: InputEvent
   ): ?{
-    value: ?number,
+    value: ?BigNumber.Instance,
     caretPosition: number,
     fallbackInputValue?: ?string,
-    minimumFractionDigits: number
   } {
-    const { numberFormat, value, allowSigns } = this.props;
-    const changedCaretPosition = event.target.selectionStart;
-    const valueToProcess = transformNumberFormat(
-      event.target.value,
-      numberFormat,
-      DEFAULT_NUMBER_FORMAT
-    );
-    const { inputType } = event;
+    const { allowSigns, decimalPlaces, value } = this.props;
+    const { inputType, target } = event;
+    const { decimalSeparator, groupSeparator } = this.getBigNumberFormat();
+    const changedCaretPosition = target.selectionStart;
+    const valueToProcess = target.value;
     const fallbackInputValue = this.state.fallbackInputValue || '';
     const isBackwardDelete = inputType === 'deleteContentBackward';
     const isForwardDelete = inputType === 'deleteContentForward';
     const isDeletion = isForwardDelete || isBackwardDelete;
     const isInsert = inputType === 'insertText';
     const deleteCaretCorrection = isBackwardDelete ? 0 : 1;
-    const validInputSignsRegExp = new RegExp(`^([-])?([0-9,.]+)?$`); // eslint-disable-line
-    const validInputNoSignsRegExp = new RegExp(`^([0-9,.]+)?$`); // eslint-disable-line
+    const validInputSignsRegExp = new RegExp(
+      `^([-])?([0-9${decimalSeparator}${groupSeparator}]+)?$`
+    );
+    const validInputNoSignsRegExp = new RegExp(
+      `^([0-9${decimalSeparator}${groupSeparator}]+)?$`
+    );
     const validInputRegex = allowSigns
       ? validInputSignsRegExp
       : validInputNoSignsRegExp;
@@ -200,8 +178,7 @@ class NumericInputBase extends Component<NumericInputProps, State> {
       return {
         caretPosition: changedCaretPosition - 1,
         fallbackInputValue,
-        minimumFractionDigits: this.state.minimumFractionDigits,
-        value
+        value,
       };
     }
 
@@ -211,7 +188,6 @@ class NumericInputBase extends Component<NumericInputProps, State> {
         value: null,
         caretPosition: 0,
         fallbackInputValue: null,
-        minimumFractionDigits: 0
       };
     }
 
@@ -224,7 +200,6 @@ class NumericInputBase extends Component<NumericInputProps, State> {
         value: null,
         caretPosition: 1,
         fallbackInputValue: '-',
-        minimumFractionDigits: 0
       };
     }
 
@@ -232,68 +207,60 @@ class NumericInputBase extends Component<NumericInputProps, State> {
      * ========= CLEAN THE INPUT =============
      */
 
-    // Options
-    const propsMinimumFractionDigits = this.getMinimumFractionDigits();
-    const maximumFractionDigits = this.getMaximumFractionDigits();
-    const numberLocaleOptions = this.getDynamicLocaleOptions();
-
-    // Current value
     const currentNumber = value;
     const currentValue =
-      value != null
-        ? value.toLocaleString(LOCALE, numberLocaleOptions)
+      currentNumber != null
+        ? this.bigNumberToFormattedString(currentNumber)
         : fallbackInputValue;
-    const currentNumberOfDots = getNumberOfDots(currentValue);
-    const hadDotBefore = currentNumberOfDots > 0;
+
+    const currentNumberOfDecimalSeparators = this.getNumberOfDecimalSeparators(
+      currentValue
+    );
+    const hadDecimalSeparatorBefore = currentNumberOfDecimalSeparators > 0;
 
     // New Value
     let newValue = valueToProcess;
     let newCaretPosition = changedCaretPosition;
-    const newNumberOfDots = getNumberOfDots(newValue);
+    const newNumberOfDecimalSeparators = this.getNumberOfDecimalSeparators(
+      newValue
+    );
 
-    // Case: A second decimal point was added somewhere
-    if (hadDotBefore && newNumberOfDots === 2) {
-      const oldFirstDotIndex = currentValue.indexOf('.');
-      const newFirstDotIndex = newValue.indexOf('.');
-      const wasDotAddedBeforeOldOne = newFirstDotIndex < oldFirstDotIndex;
+    // Case: A second decimal separator was added somewhere
+    if (hadDecimalSeparatorBefore && newNumberOfDecimalSeparators === 2) {
+      const oldFirstIndex = currentValue.indexOf(decimalSeparator);
+      const newFirstIndex = newValue.indexOf(decimalSeparator);
+      const wasSeparatorAddedBeforeOldOne = newFirstIndex < oldFirstIndex;
       // Remove the second decimal point and set caret position
       newValue = removeCharAtPosition(
         newValue,
-        wasDotAddedBeforeOldOne ? newValue.lastIndexOf('.') : oldFirstDotIndex
+        wasSeparatorAddedBeforeOldOne
+          ? newValue.lastIndexOf(decimalSeparator)
+          : oldFirstIndex
       );
-      newCaretPosition = newValue.indexOf('.') + 1;
+      newCaretPosition = newValue.indexOf(decimalSeparator) + 1;
     }
-
-    newValue = truncateToPrecision(newValue, maximumFractionDigits);
 
     /**
      * ========= PROCESS CLEANED INPUT =============
      */
-    const numberOfFractionDigits = getFractionDigits(newValue).length;
-    const dynamicMinimumFractionDigits = Math.min(
-      Math.max(propsMinimumFractionDigits, numberOfFractionDigits),
-      maximumFractionDigits
-    );
-    const newNumber = getValueAsNumber(newValue, maximumFractionDigits);
+    const newNumber =
+      newValue === '' ? null : this.formattedValueToBigNumber(newValue);
 
-    // Case: Just a dot was entered
-    if (valueToProcess === '.') {
-      const hasMinFractions = dynamicMinimumFractionDigits > 0;
+    // Case: Just a decimal separator was entered
+    if (valueToProcess === decimalSeparator) {
       return {
-        value: 0,
+        value: new BigNumber(0),
         caretPosition: 2,
-        fallbackInputValue: hasMinFractions ? null : '0.',
-        minimumFractionDigits: dynamicMinimumFractionDigits
+        fallbackInputValue: decimalPlaces > 0 ? null : `0${decimalSeparator}`,
       };
     }
 
-    // Case: Dot was added at the beginning of number
-    if (newValue.charAt(0) === '.') {
+    // Case: Decimal separator was added at the beginning of number
+    if (newValue.charAt(0) === decimalSeparator) {
       const newCaretPos = isInsert ? 2 : 1;
       return {
         value: newNumber,
         caretPosition: newCaretPos,
-        minimumFractionDigits: dynamicMinimumFractionDigits
       };
     }
 
@@ -306,97 +273,56 @@ class NumericInputBase extends Component<NumericInputProps, State> {
           changedCaretPosition +
           (isDeletion ? deleteAdjustment : insertAdjustment),
         fallbackInputValue,
-        minimumFractionDigits: dynamicMinimumFractionDigits,
-        value: currentNumber
+        value: currentNumber,
       };
     }
 
-    const localizedNewNumber = newNumber.toLocaleString(LOCALE, {
-      minimumFractionDigits: dynamicMinimumFractionDigits
-    });
+    const formattedNewNumber = this.bigNumberToFormattedString(newNumber);
 
     // Case: Dot was added at the end of number
-    if (!isDeletion && newValue.charAt(newValue.length - 1) === '.') {
+    if (
+      !isDeletion &&
+      newValue.charAt(newValue.length - 1) === decimalSeparator
+    ) {
       return {
         value: newNumber,
         caretPosition: changedCaretPosition,
         fallbackInputValue:
-          propsMinimumFractionDigits > 0 ? null : localizedNewNumber + '.',
-        minimumFractionDigits: 0
+          decimalPlaces > 0 ? null : formattedNewNumber + decimalSeparator,
+        minimumFractionDigits: 0,
       };
     }
 
     // Case: Dot was deleted with minimum fraction digits constrain defined
-    const hasFractions = this.getMinimumFractionDigitsProp() != null;
-    const wasDotRemoved = hadDotBefore && !newNumberOfDots;
-    if (wasDotRemoved && hasFractions && !isInsert) {
+    const hasDecimalPlaces = decimalPlaces != null;
+    const wasDecimalSeparatorRemoved =
+      hadDecimalSeparatorBefore && !newNumberOfDecimalSeparators;
+    if (wasDecimalSeparatorRemoved && hasDecimalPlaces && !isInsert) {
       return {
         caretPosition: newCaretPosition + deleteCaretCorrection,
         fallbackInputValue: null,
-        minimumFractionDigits: dynamicMinimumFractionDigits,
-        value: currentNumber
+        value: currentNumber,
       };
     }
 
     // Case: Valid change has been made
-    const hasNumberChanged = value !== newNumber;
-    const commasDiff =
-      getNumberOfCommas(localizedNewNumber) - getNumberOfCommas(newValue);
-    const haveCommasChanged = commasDiff > 0;
-    const onlyCommasChanged = !hasNumberChanged && haveCommasChanged;
+    const hasNumberChanged = this.isDifferentValue(currentNumber, newNumber);
+    const groupSeparatorsDiff =
+      this.getNumberOfGroupSeparators(formattedNewNumber) -
+      this.getNumberOfGroupSeparators(newValue);
+    const hasNumberOfGroupSeparatorsChanged = groupSeparatorsDiff > 0;
+    const onlyNumberOfGroupSeparatorsChanged =
+      !hasNumberChanged && hasNumberOfGroupSeparatorsChanged;
     const leadingZeroCorrection = valueHasLeadingZero ? -1 : 0;
     const caretCorrection =
-      (onlyCommasChanged ? deleteCaretCorrection : commasDiff) +
-      leadingZeroCorrection;
+      (onlyNumberOfGroupSeparatorsChanged
+        ? deleteCaretCorrection
+        : groupSeparatorsDiff) + leadingZeroCorrection;
     return {
       caretPosition: Math.max(newCaretPosition + caretCorrection, 0),
       fallbackInputValue: null,
-      minimumFractionDigits: dynamicMinimumFractionDigits,
-      value: newNumber
+      value: newNumber,
     };
-  }
-
-  getMinimumFractionDigitsProp(): number | null {
-    const { numberLocaleOptions } = this.props;
-    if (!numberLocaleOptions) return null;
-    const { minimumFractionDigits } = numberLocaleOptions;
-    return minimumFractionDigits || null;
-  }
-
-  getMinimumFractionDigits(): number {
-    return this.getMinimumFractionDigitsProp() || 0;
-  }
-
-  getDynamicMinimumFractionDigits(): number {
-    const minimumFractionDigitsProp = this.getMinimumFractionDigits();
-    return Math.max(
-      this.state.minimumFractionDigits,
-      minimumFractionDigitsProp || 0
-    );
-  }
-
-  getMaximumFractionDigits(): number {
-    const { numberLocaleOptions } = this.props;
-    const minimumFractionDigits = this.getDynamicMinimumFractionDigits();
-    const maximumFractionDigits =
-      numberLocaleOptions && numberLocaleOptions.maximumFractionDigits != null
-        ? numberLocaleOptions.maximumFractionDigits
-        : 3;
-    return Math.max(minimumFractionDigits, maximumFractionDigits);
-  }
-
-  getDynamicLocaleOptions(): Number$LocaleOptions {
-    return Object.assign({}, this.props.numberLocaleOptions, {
-      minimumFractionDigits: this.getDynamicMinimumFractionDigits()
-    });
-  }
-
-  getLocalizedNumber(value: ?number) {
-    return convertNumberToLocalizedString(
-      value,
-      LOCALE,
-      this.getDynamicLocaleOptions()
-    );
   }
 
   setInputCaretPosition = (position: number) => {
@@ -415,9 +341,50 @@ class NumericInputBase extends Component<NumericInputProps, State> {
 
   onBlur = () => {
     this.setState({
-      fallbackInputValue: null
+      fallbackInputValue: null,
     });
   };
+
+  getBigNumberFormat(): BigNumber.Config {
+    return this.props.bigNumberFormat ?? BigNumber.config().FORMAT;
+  }
+
+  bigNumberToFormattedString(number: ?BigNumber.Instance) {
+    const { bigNumberFormat, decimalPlaces, roundingMode } = this.props;
+    return number === null
+      ? ''
+      : number.toFormat(decimalPlaces, roundingMode, {
+          ...BigNumber.config().FORMAT, // defaults
+          ...bigNumberFormat, // custom overrides
+        });
+  }
+
+  formattedValueToBigNumber(value: string) {
+    const { decimalSeparator, groupSeparator } = this.getBigNumberFormat();
+    return new BigNumber(
+      value
+        .replace(new RegExp(escapeRegExp(groupSeparator), 'g'), '')
+        .replace(new RegExp(escapeRegExp(decimalSeparator), 'g'), '.')
+    );
+  }
+
+  getNumberOfGroupSeparators(value: string): number {
+    const { groupSeparator } = this.getBigNumberFormat();
+    return (value.match(new RegExp(escapeRegExp(groupSeparator), 'g')) || [])
+      .length;
+  }
+
+  getNumberOfDecimalSeparators(value: string): number {
+    const { decimalSeparator } = this.getBigNumberFormat();
+    return (value.match(new RegExp(escapeRegExp(decimalSeparator), 'g')) || [])
+      .length;
+  }
+
+  isDifferentValue(first: ?BigNumber.Instance, second: ?BigNumber.Instance) {
+    return BigNumber.isBigNumber(first)
+      ? first.isEqualTo(second)
+      : first === second;
+  }
 
   render() {
     // destructuring props ensures only the "...rest" get passed down
@@ -433,12 +400,15 @@ class NumericInputBase extends Component<NumericInputProps, State> {
       ...rest
     } = this.props;
 
+    if (value != null && !BigNumber.isBigNumber(value)) {
+      throw new Error('Prop "value" must be of type BigNumber or null.');
+    }
+
     const InputSkin = skin || context.skins[IDENTIFIERS.INPUT];
 
-    const localizedInput = value != null ? this.getLocalizedNumber(value) : '';
     const inputValue = this.state.fallbackInputValue
       ? this.state.fallbackInputValue
-      : localizedInput;
+      : this.bigNumberToFormattedString(value);
 
     return (
       <InputSkin
@@ -446,11 +416,7 @@ class NumericInputBase extends Component<NumericInputProps, State> {
         inputRef={this.inputElement}
         onChange={this.onChange}
         theme={this.state.composedTheme}
-        value={transformNumberFormat(
-          inputValue,
-          DEFAULT_NUMBER_FORMAT,
-          this.props.numberFormat
-        )}
+        value={inputValue}
         onBlur={this.onBlur}
         {...rest}
       />
@@ -459,97 +425,3 @@ class NumericInputBase extends Component<NumericInputProps, State> {
 }
 
 export const NumericInput = withTheme(NumericInputBase);
-
-// ========= HELPERS ==========
-
-const NUMERIC_INPUT_REGEX = /^([-])?([0-9,]+)?(\.([0-9]+)?)?$/;
-
-const isValidNumericInput = (value: string): boolean =>
-  NUMERIC_INPUT_REGEX.test(value);
-
-const isParsableNumberString = (
-  value: string,
-  requiredPrecision: number
-): boolean =>
-  // The number of digits is limited in Javascript - so the required precision influence
-  // the possible number of integer digits (only 15 digits can be safely represented in total)
-  parseFloat(value) >=
-    Number.MIN_SAFE_INTEGER / 10 ** (requiredPrecision + 1) &&
-  parseFloat(value) <=
-    Number.MAX_SAFE_INTEGER / 10 ** (requiredPrecision + 1) &&
-  !isNaN(parseFloat(value)) &&
-  isFinite(value);
-
-const removeCommas = (value: string): string => value.replace(/,/g, '');
-
-function parseStringToNumber(
-  value: string,
-  requiredPrecision: number
-): ?number {
-  const cleanedValue = removeCommas(value);
-  if (!isValidNumericInput(cleanedValue)) return null;
-  if (!isParsableNumberString(cleanedValue, requiredPrecision)) return null;
-  return parseFloat(cleanedValue);
-}
-
-function convertNumberToLocalizedString(
-  num: ?number,
-  locale: string,
-  options?: Number$LocaleOptions
-): string {
-  return num != null ? num.toLocaleString(locale, options) : '';
-}
-
-function getValueAsNumber(
-  value: string | number,
-  requiredPrecision: number
-): ?number {
-  return typeof value === 'string'
-    ? parseStringToNumber(value, requiredPrecision)
-    : value;
-}
-
-function getNumberOfCommas(value: string): number {
-  return (value.match(/,/g) || []).length;
-}
-
-function getNumberOfDots(value: string): number {
-  return (value.match(/\./g) || []).length;
-}
-
-function getIntegerDigits(
-  value: string,
-  decimalSeparator: string = '.'
-): string {
-  const fractionSeparatorIndex = value.indexOf(decimalSeparator);
-  if (fractionSeparatorIndex === -1) return value;
-  return value.substring(0, fractionSeparatorIndex);
-}
-
-function getFractionDigits(
-  value: string,
-  decimalSeparator: string = '.'
-): string {
-  const fractionSeparatorIndex = value.indexOf(decimalSeparator);
-  if (fractionSeparatorIndex === -1) return '';
-  return value.substring(fractionSeparatorIndex + 1);
-}
-
-function truncateToPrecision(value: string, precision: number): string {
-  const decimalPointIndex = value.indexOf('.');
-  if (decimalPointIndex === -1) return value;
-  const fractionDigits = removeCommas(getFractionDigits(value));
-  return getIntegerDigits(value) + '.' + fractionDigits.substring(0, precision);
-}
-
-function transformNumberFormat(
-  value: string,
-  inputFormat: NumberFormatOptions,
-  outputFormat: NumberFormatOptions
-) {
-  return value
-    .replace(new RegExp('\\' + inputFormat.groupSeparator, 'g'), '#')
-    .replace(new RegExp('\\' + inputFormat.decimalSeparator, 'g'), '@')
-    .replace(new RegExp('#', 'g'), outputFormat.groupSeparator)
-    .replace(new RegExp('@', 'g'), outputFormat.decimalSeparator);
-}

--- a/source/components/NumericInput.js
+++ b/source/components/NumericInput.js
@@ -44,6 +44,7 @@ class NumericInputBase extends Component<NumericInputProps, State> {
     allowSigns: true,
     context: createEmptyContext(),
     readOnly: false,
+    roundingMode: BigNumber.ROUND_FLOOR,
     theme: null,
     themeId: IDENTIFIERS.INPUT,
     themeOverrides: {},
@@ -326,13 +327,13 @@ class NumericInputBase extends Component<NumericInputProps, State> {
     return this.props.bigNumberFormat ?? BigNumber.config().FORMAT;
   }
 
-  bigNumberToFormattedString(number: BigNumber.Instance) {
+  bigNumberToFormattedString(number: ?BigNumber.Instance) {
     const { bigNumberFormat, decimalPlaces, roundingMode } = this.props;
-    const result = number.toFormat(decimalPlaces, roundingMode, {
+    const result = new BigNumber(number).toFormat(decimalPlaces, roundingMode, {
       ...BigNumber.config().FORMAT, // defaults
       ...bigNumberFormat, // custom overrides
     });
-    return result === 'NaN' ? null : result;
+    return result === 'NaN' ? '' : result;
   }
 
   formattedValueToBigNumber(value: string) {

--- a/source/components/NumericInput.js
+++ b/source/components/NumericInput.js
@@ -292,7 +292,7 @@ class NumericInputBase extends Component<NumericInputProps, State> {
       };
     }
 
-    // Case: Dot was deleted with minimum fraction digits constrain defined
+    // Case: Decimal separator was deleted while number of decimal places specified
     const hasDecimalPlaces = decimalPlaces != null;
     const wasDecimalSeparatorRemoved =
       hadDecimalSeparatorBefore && !newNumberOfDecimalSeparators;
@@ -305,7 +305,7 @@ class NumericInputBase extends Component<NumericInputProps, State> {
     }
 
     // Case: Valid change has been made
-    const hasNumberChanged = this.isDifferentValue(currentNumber, newNumber);
+    const hasNumberChanged = !this.isSameValue(currentNumber, newNumber);
     const groupSeparatorsDiff =
       this.getNumberOfGroupSeparators(formattedNewNumber) -
       this.getNumberOfGroupSeparators(newValue);
@@ -377,7 +377,7 @@ class NumericInputBase extends Component<NumericInputProps, State> {
     return (value.match(escapedGlobalRegExp(decimalSeparator)) || []).length;
   }
 
-  isDifferentValue(first: ?BigNumber.Instance, second: ?BigNumber.Instance) {
+  isSameValue(first: ?BigNumber.Instance, second: ?BigNumber.Instance) {
     return BigNumber.isBigNumber(first)
       ? first.isEqualTo(second)
       : first === second;

--- a/source/components/NumericInput.js
+++ b/source/components/NumericInput.js
@@ -326,14 +326,13 @@ class NumericInputBase extends Component<NumericInputProps, State> {
     return this.props.bigNumberFormat ?? BigNumber.config().FORMAT;
   }
 
-  bigNumberToFormattedString(number: ?BigNumber.Instance) {
+  bigNumberToFormattedString(number: BigNumber.Instance) {
     const { bigNumberFormat, decimalPlaces, roundingMode } = this.props;
-    return number === null
-      ? ''
-      : number.toFormat(decimalPlaces, roundingMode, {
-          ...BigNumber.config().FORMAT, // defaults
-          ...bigNumberFormat, // custom overrides
-        });
+    const result = number.toFormat(decimalPlaces, roundingMode, {
+      ...BigNumber.config().FORMAT, // defaults
+      ...bigNumberFormat, // custom overrides
+    });
+    return result === 'NaN' ? null : result;
   }
 
   formattedValueToBigNumber(value: string) {
@@ -373,13 +372,9 @@ class NumericInputBase extends Component<NumericInputProps, State> {
       ...rest
     } = this.props;
 
-    if (value != null && !BigNumber.isBigNumber(value)) {
-      throw new Error('Prop "value" must be of type BigNumber or null.');
-    }
-
     const inputValue = this.state.fallbackInputValue
       ? this.state.fallbackInputValue
-      : this.bigNumberToFormattedString(value);
+      : this.bigNumberToFormattedString(new BigNumber(value));
 
     return (
       <Input

--- a/source/skins/simple/AutocompleteSkin.js
+++ b/source/skins/simple/AutocompleteSkin.js
@@ -79,10 +79,12 @@ export const AutocompleteSkin = (props: Props) => {
   };
 
   const selectedOptionsCount = props.selectedOptions.length;
-  const hasSelectedRequiredNumberOfOptions = some(
-    props.requiredSelections,
-    (requiredCount) => selectedOptionsCount === requiredCount
-  );
+  const hasSelectedRequiredNumberOfOptions =
+    props.requiredSelections.length === 0 ||
+    some(
+      props.requiredSelections,
+      (requiredCount) => selectedOptionsCount === requiredCount
+    );
   const error = hasSelectedRequiredNumberOfOptions ? props.error : null;
 
   return (
@@ -107,7 +109,7 @@ export const AutocompleteSkin = (props: Props) => {
         inputRef={props.inputRef}
         label={props.label}
         isErrorHidden={props.isOpen}
-        render={() => (
+        render={(setFormFieldRef) => (
           <div
             className={classnames([
               theme.autocompleteContent,
@@ -120,7 +122,7 @@ export const AutocompleteSkin = (props: Props) => {
             <div className={theme.selectedWords}>
               {renderSelectedOptions()}
               <input
-                ref={props.inputRef}
+                ref={setFormFieldRef}
                 placeholder={placeholder}
                 value={props.inputValue}
                 onChange={props.handleInputChange}

--- a/source/skins/simple/FormFieldSkin.js
+++ b/source/skins/simple/FormFieldSkin.js
@@ -1,18 +1,24 @@
 // @flow
-import React from 'react';
+import type { ElementRef } from 'react';
+import React, { useState } from 'react';
 import classnames from 'classnames';
 import type { FormFieldProps } from '../../components/FormField';
 import { PopOver } from '../../components/PopOver';
 import { SimpleFormFieldVariables } from '../../themes/simple/SimpleFormField';
-import { isRefFocused } from '../../utils/hooks';
+import { handleRefFocusState } from '../../utils/hooks';
 
 type Props = FormFieldProps & {
+  formFieldRef: ElementRef<*>,
   focusChild: Function,
   setError: Function,
 };
 
 export function FormFieldSkin(props: Props) {
-  const isInputFocused = isRefFocused(props.inputRef);
+  const [isFormFieldFocused, setIsFormFieldFocused] = useState(false);
+  const setFormFieldRef = handleRefFocusState(
+    props.formFieldRef,
+    setIsFormFieldFocused
+  );
   const hasError = props.error != null;
   return (
     <div
@@ -37,7 +43,7 @@ export function FormFieldSkin(props: Props) {
         isShowingOnHover={hasError && !props.isErrorHidden}
         isVisible={
           props.isErrorShown ||
-          (hasError && isInputFocused && !props.isErrorHidden)
+          (hasError && isFormFieldFocused && !props.isErrorHidden)
         }
         content={props.error}
         themeVariables={{
@@ -48,7 +54,7 @@ export function FormFieldSkin(props: Props) {
         duration={[300, 0]}
       >
         <div className={props.theme[props.themeId].inputWrapper}>
-          {props.render(props)}
+          {props.render(setFormFieldRef)}
         </div>
       </PopOver>
     </div>

--- a/source/skins/simple/FormFieldSkin.js
+++ b/source/skins/simple/FormFieldSkin.js
@@ -35,7 +35,10 @@ export function FormFieldSkin(props: Props) {
       )}
       <PopOver
         isShowingOnHover={hasError && !props.isErrorHidden}
-        isVisible={hasError && isInputFocused && !props.isErrorHidden}
+        isVisible={
+          props.isErrorShown ||
+          (hasError && isInputFocused && !props.isErrorHidden)
+        }
         content={props.error}
         themeVariables={{
           '--rp-pop-over-bg-color': `var(${SimpleFormFieldVariables.errorColor}`,
@@ -45,7 +48,7 @@ export function FormFieldSkin(props: Props) {
         duration={[300, 0]}
       >
         <div className={props.theme[props.themeId].inputWrapper}>
-          {props.render()}
+          {props.render(props)}
         </div>
       </PopOver>
     </div>

--- a/source/skins/simple/InputSkin.js
+++ b/source/skins/simple/InputSkin.js
@@ -14,15 +14,14 @@ import type { InputProps } from '../../components/Input';
 import { pickDOMProps } from '../../utils/props';
 
 type Props = InputProps & {
-  inputRef: ElementRef<'input'>,
   theme: Object,
   themeId: string,
 };
 
 export const InputSkin = (props: Props) => {
-  const renderInput = () => (
+  const renderInput = (setFormFieldRef) => (
     <input
-      ref={props.inputRef}
+      ref={setFormFieldRef}
       {...pickDOMProps(props)}
       className={classnames([
         props.theme[props.themeId].input,
@@ -35,23 +34,23 @@ export const InputSkin = (props: Props) => {
     />
   );
 
-  const useSelectionRenderer = (option) => (
+  const useSelectionRenderer = (setFormFieldRef, option) => (
     <div className={props.theme[props.themeId].customValueWrapper}>
-      {renderInput()}
+      {renderInput(setFormFieldRef)}
       <div className={props.theme[props.themeId].customValueBlock}>
         {option && props.selectionRenderer && props.selectionRenderer(option)}
       </div>
     </div>
   );
 
-  const render = () => {
+  const render = (setFormFieldRef) => {
     // check if user has passed render prop "selectionRenderer"
     const hasSelectionRenderer =
       props.selectionRenderer && isFunction(props.selectionRenderer);
     if (hasSelectionRenderer) {
-      return useSelectionRenderer(props.selectedOption);
+      return useSelectionRenderer(setFormFieldRef, props.selectedOption);
     }
-    return renderInput();
+    return renderInput(setFormFieldRef);
   };
 
   return (

--- a/source/skins/simple/TextAreaSkin.js
+++ b/source/skins/simple/TextAreaSkin.js
@@ -1,5 +1,5 @@
 // @flow
-import React, { useState } from 'react';
+import React from 'react';
 import type { ElementRef, Element } from 'react';
 
 // external libraries
@@ -40,9 +40,9 @@ export const TextAreaSkin = (props: Props) => {
       error={props.error}
       inputRef={props.textareaRef}
       skin={FormFieldSkin}
-      render={() => (
+      render={(setFormFieldRef) => (
         <textarea
-          ref={props.textareaRef}
+          ref={setFormFieldRef}
           {...pickDOMProps(props)}
           className={classnames([
             theme[themeId].textarea,

--- a/source/utils/hooks.js
+++ b/source/utils/hooks.js
@@ -25,10 +25,10 @@ export function isRefFocused(ref: Ref<*>) {
   const [isFocused, setIsFocused] = useState(false);
 
   useEffect(() => {
-    const element = ref.current;
-    if (!element || !element.addEventListener) {
+    if (!ref || ref.current || !ref.current.addEventListener) {
       return;
     }
+    const element = ref.current;
     const focusListener = () => setIsFocused(true);
     const blurListener = () => setIsFocused(false);
     element.addEventListener('focus', focusListener);
@@ -37,7 +37,7 @@ export function isRefFocused(ref: Ref<*>) {
       element.removeEventListener('focus', focusListener);
       element.removeEventListener('blur', blurListener);
     };
-  }, [ref.current]);
+  }, [ref]);
 
   return isFocused;
 }

--- a/source/utils/hooks.js
+++ b/source/utils/hooks.js
@@ -1,5 +1,6 @@
 // @flow
-import { useEffect, useState, Ref } from 'react';
+import type { ElementRef } from 'react';
+import { useEffect, useState, Ref, useCallback } from 'react';
 
 export function useDebouncedValueChangedIndicator(value: any, delay: number) {
   const [isDirty, setIsDirty] = useState(false);
@@ -21,23 +22,24 @@ export function useDebouncedValueChangedIndicator(value: any, delay: number) {
   return isDirty;
 }
 
-export function isRefFocused(ref: Ref<*>) {
-  const [isFocused, setIsFocused] = useState(false);
+// Inspired by https://medium.com/@teh_builder/ref-objects-inside-useeffect-hooks-eb7c15198780
+export function handleRefFocusState(
+  ref: ElementRef<*>,
+  setIsFocused: React.SetStateAction
+) {
+  const focusListener = () => setIsFocused(true);
+  const blurListener = () => setIsFocused(false);
 
-  useEffect(() => {
-    if (!ref || ref.current || !ref.current.addEventListener) {
-      return;
+  return useCallback((node) => {
+    if (ref.current) {
+      const { current } = ref;
+      current.removeEventListener('focus', focusListener);
+      current.removeEventListener('blur', blurListener);
     }
-    const element = ref.current;
-    const focusListener = () => setIsFocused(true);
-    const blurListener = () => setIsFocused(false);
-    element.addEventListener('focus', focusListener);
-    element.addEventListener('blur', blurListener);
-    return () => {
-      element.removeEventListener('focus', focusListener);
-      element.removeEventListener('blur', blurListener);
-    };
-  }, [ref]);
-
-  return isFocused;
+    if (node) {
+      node.addEventListener('focus', focusListener);
+      node.addEventListener('blur', blurListener);
+    }
+    ref.current = node;
+  }, []);
 }

--- a/source/utils/strings.js
+++ b/source/utils/strings.js
@@ -1,4 +1,3 @@
 // @flow
-export const removeCharAtPosition = (str: string, pos: number) => (
-  str.substring(0, pos) + str.substring(pos + 1, str.length)
-);
+export const removeCharAtPosition = (str: string, pos: number) =>
+  str.substring(0, pos) + str.substring(pos + 1, str.length);

--- a/stories/FormField.stories.js
+++ b/stories/FormField.stories.js
@@ -4,6 +4,7 @@ import React from 'react';
 
 // storybook
 import { storiesOf } from '@storybook/react';
+import { FormField } from '../source/components/FormField';
 import { Input } from '../source/components/Input';
 
 // components
@@ -19,6 +20,15 @@ storiesOf('FormField', module)
 
   // ====== Stories ======
 
+  .add('error', () => (
+    <div style={{ width: '100px', border: '1px solid black', padding: '10px' }}>
+      <FormField
+        error="An error is shown"
+        render={() => <span>simple form field test</span>}
+        isErrorShown
+      />
+    </div>
+  ))
   .add(
     'input error',
     withState({ value: '' }, (store) => (

--- a/stories/NumericInput.stories.js
+++ b/stories/NumericInput.stories.js
@@ -1,5 +1,6 @@
 // @flow
 import React from 'react';
+import BigNumber from 'bignumber.js';
 
 // storybook
 import { storiesOf } from '@storybook/react';
@@ -18,149 +19,154 @@ import themeOverrides from './theme-overrides/customInput.scss';
 import { decorateWithSimpleTheme } from './helpers/theming';
 
 storiesOf('NumericInput', module)
-
   .addDecorator(decorateWithSimpleTheme)
 
   // ====== Stories ======
 
-  .add('plain',
-    withState({ value: null }, store => (
+  .add(
+    'plain',
+    withState({ value: null }, (store) => (
       <NumericInput
-        onChange={value => store.set({ value })}
+        onChange={(value) => store.set({ value })}
         value={store.state.value}
       />
     ))
   )
-  .add('value (9999.99)',
-    withState({ value: 9999.99 }, store => (
+  .add(
+    'value (9999.99)',
+    withState({ value: new BigNumber(9999.99) }, (store) => (
       <NumericInput
-        onChange={value => store.set({ value })}
+        onChange={(value) => store.set({ value })}
         value={store.state.value}
       />
     ))
   )
-  .add('minimumFractionDigits (6)',
-    withState({ value: 0 }, store => (
+  .add(
+    'decimalPlaces (6)',
+    withState({ value: new BigNumber(0) }, (store) => (
       <NumericInput
-        onChange={value => store.set({ value })}
-        numberLocaleOptions={{ minimumFractionDigits: 6 }}
+        onChange={(value) => store.set({ value })}
+        decimalPlaces={6}
         value={store.state.value}
       />
     ))
   )
-  .add('maximumFractionDigits (6)',
-    withState({ value: 0 }, store => (
+  .add(
+    'format: decimal (comma) group (dot)',
+    withState({ value: new BigNumber(0) }, (store) => (
       <NumericInput
-        onChange={value => store.set({ value })}
-        numberLocaleOptions={{ maximumFractionDigits: 6 }}
-        value={store.state.value}
-      />
-    ))
-  )
-  .add('format: group (dot) fraction (comma)',
-    withState({ value: 0 }, store => (
-      <NumericInput
-        onChange={value => store.set({ value })}
-        numberFormat={{
+        onChange={(value) => store.set({ value })}
+        bigNumberFormat={{
           decimalSeparator: ',',
           groupSeparator: '.',
         }}
+        decimalPlaces={2}
         value={store.state.value}
       />
     ))
   )
-  .add('format: group (space) fraction (dot)',
-    withState({ value: 0 }, store => (
+  .add(
+    'format: decimal (dot) group (space)',
+    withState({ value: new BigNumber(0) }, (store) => (
       <NumericInput
-        onChange={value => store.set({ value })}
-        numberFormat={{
+        onChange={(value) => store.set({ value })}
+        bigNumberFormat={{
           decimalSeparator: '.',
           groupSeparator: ' ',
         }}
+        decimalPlaces={2}
         value={store.state.value}
       />
     ))
   )
-  .add('autoFocus',
-    withState({ value: null }, store => (
+  .add(
+    'autoFocus',
+    withState({ value: null }, (store) => (
       <NumericInput
         autoFocus
-        onChange={value => store.set({ value })}
+        onChange={(value) => store.set({ value })}
         value={store.state.value}
       />
     ))
   )
-  .add('label',
-    withState({ value: null }, store => (
+  .add(
+    'label',
+    withState({ value: null }, (store) => (
       <NumericInput
         label="Amount"
-        onChange={value => store.set({ value })}
+        onChange={(value) => store.set({ value })}
         value={store.state.value}
       />
     ))
   )
-  .add('placeholder',
-    withState({ value: null }, store => (
+  .add(
+    'placeholder',
+    withState({ value: null }, (store) => (
       <NumericInput
         value={store.state.value}
-        onChange={value => store.set({ value })}
+        onChange={(value) => store.set({ value })}
         placeholder="18.000000"
       />
     ))
   )
-  .add('allowSigns = false',
-    withState({ value: null }, store => (
+  .add(
+    'allowSigns = false',
+    withState({ value: null }, (store) => (
       <NumericInput
         value={store.state.value}
-        onChange={value => store.set({ value })}
+        onChange={(value) => store.set({ value })}
         allowSigns={false}
       />
     ))
   )
-  .add('onFocus / onBlur',
-    withState({ value: null, focused: false, blurred: false }, store => (
+  .add(
+    'onFocus / onBlur',
+    withState({ value: null, focused: false, blurred: false }, (store) => (
       <NumericInput
         value={store.state.value}
         placeholder="onFocus / onBlur"
-        onChange={value => store.set({ value })}
+        onChange={(value) => store.set({ value })}
         onFocus={() => store.set({ focused: true, blurred: false })}
         onBlur={() => store.set({ blurred: true, focused: false })}
       />
     ))
   )
 
-  .add('with error',
-    withState({ value: null }, store => (
+  .add(
+    'with error',
+    withState({ value: null }, (store) => (
       <NumericInput
         label="Amount"
         error="Please enter a valid amount"
         value={store.state.value}
         placeholder="0.000000"
-        onChange={value => store.set({ value })}
+        onChange={(value) => store.set({ value })}
       />
     ))
   )
 
-  .add('theme overrides',
-    withState({ value: null }, store => (
+  .add(
+    'theme overrides',
+    withState({ value: null }, (store) => (
       <NumericInput
         label="Composed Theme"
         themeOverrides={themeOverrides}
         value={store.state.value}
         placeholder="0.000000"
-        onChange={value => store.set({ value })}
+        onChange={(value) => store.set({ value })}
       />
     ))
   )
 
-  .add('Custom Theme',
-    withState({ value: null }, store => (
+  .add(
+    'Custom Theme',
+    withState({ value: null }, (store) => (
       <NumericInput
         label="Amount"
         theme={CustomInputTheme}
         value={store.state.value}
         placeholder="0.000000"
-        onChange={value => store.set({ value })}
+        onChange={(value) => store.set({ value })}
       />
     ))
   );

--- a/stories/NumericInput.stories.js
+++ b/stories/NumericInput.stories.js
@@ -62,6 +62,7 @@ storiesOf('NumericInput', module)
         }}
         decimalPlaces={2}
         value={store.state.value}
+        label="Numeric Input (2 decimal places, ',' as decimal separator, '.' as group separator)"
       />
     ))
   )
@@ -76,6 +77,7 @@ storiesOf('NumericInput', module)
         }}
         decimalPlaces={2}
         value={store.state.value}
+        label="Numeric Input (2 decimal places, '.' as decimal separator, space as group separator)"
       />
     ))
   )

--- a/stories/NumericInput.stories.js
+++ b/stories/NumericInput.stories.js
@@ -143,7 +143,17 @@ storiesOf('NumericInput', module)
       />
     ))
   )
-
+  .add(
+    'invalid value',
+    withState({ value: '' }, (store) => (
+      <NumericInput
+        value={store.state.value}
+        onChange={(value) => store.set({ value })}
+        placeholder="placeholder …"
+        label="Invalid values are ignored"
+      />
+    ))
+  )
   .add(
     'with error',
     withState({ value: null }, (store) => (

--- a/stories/NumericInput.stories.js
+++ b/stories/NumericInput.stories.js
@@ -112,6 +112,16 @@ storiesOf('NumericInput', module)
     ))
   )
   .add(
+    'readOnly',
+    withState({ value: new BigNumber(2) }, (store) => (
+      <NumericInput
+        value={store.state.value}
+        onChange={(value) => store.set({ value })}
+        readOnly
+      />
+    ))
+  )
+  .add(
     'allowSigns = false',
     withState({ value: null }, (store) => (
       <NumericInput

--- a/yarn.lock
+++ b/yarn.lock
@@ -4344,6 +4344,11 @@ big.js@^5.2.2:
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328"
   integrity sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==
 
+bignumber.js@9.0.1:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-9.0.1.tgz#8d7ba124c882bfd8e43260c67475518d0689e4e5"
+  integrity sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA==
+
 binary-extensions@^1.0.0:
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.11.0.tgz#46aa1751fb6a2f93ee5e689bb1087d4b14c6c205"


### PR DESCRIPTION
This PR improves the `NumericInput` component to support big numbers (bignumber.js) with "arbitrary" precision by refactoring the logic to be based on bignumber.js.

![grafik](https://user-images.githubusercontent.com/172414/105494384-fcce8f00-5cba-11eb-8cbe-0a453f58ebc7.png)

### Todos:
- [x] Fix broken tests
- [x] Fix edge case: inserting decimal separator twice at the same caret position results in a `NaN` error

### API changes:
The `NumericInput` component uses the defaults/config of `BigNumber` by default which can be selectively overwritten with the following props:

```js
bigNumberFormat?: BigNumber.Format, // Will be merged with the BigNumber defaults
decimalPlaces?: number, // Only a specific number or any number of decimal places are supported (no min/max)
roundingMode?: BigNumber.RoundingMode,
value: ?BigNumber.Instance,
```

The value provided to the `NumericInput` as well as given back `onChange` are `BigNumber` instances now.

### How to Test
Open Storybook with the `NumericInput` component and it should work exactly like before but support any floating point number / big integers you throw at it.