### PR TITLE
Fix NumericInput on BigNumber.DEBUG

### DIFF
--- a/source/components/NumericInput.js
+++ b/source/components/NumericInput.js
@@ -172,7 +172,7 @@ class NumericInputBase extends Component<NumericInputProps, State> {
      * ========= CLEAN THE INPUT =============
      */
 
-    const currentNumber = new BigNumber(value);
+    const currentNumber = value == null ? new BigNumber('0') : new BigNumber(value);
     const currentValue =
       fallbackInputValue ?? this.bigNumberToFormattedString(currentNumber);
 
@@ -316,6 +316,7 @@ class NumericInputBase extends Component<NumericInputProps, State> {
 
   bigNumberToFormattedString(number: ?BigNumber.Instance) {
     const { bigNumberFormat, decimalPlaces, roundingMode } = this.props;
+    if (number == null) return '';
     const result = new BigNumber(number).toFormat(decimalPlaces, roundingMode, {
       ...BigNumber.config().FORMAT, // defaults
       ...bigNumberFormat, // custom overrides
@@ -359,7 +360,10 @@ class NumericInputBase extends Component<NumericInputProps, State> {
 
     const inputValue = this.state.fallbackInputValue
       ? this.state.fallbackInputValue
-      : this.bigNumberToFormattedString(new BigNumber(value));
+      : this.bigNumberToFormattedString(value == null
+        ? null
+        : new BigNumber(value)
+      );
 
     return (
       <Input

--- a/stories/NumericInput.stories.js
+++ b/stories/NumericInput.stories.js
@@ -18,6 +18,8 @@ import themeOverrides from './theme-overrides/customInput.scss';
 // helpers
 import { decorateWithSimpleTheme } from './helpers/theming';
 
+BigNumber.DEBUG = true;
+
 storiesOf('NumericInput', module)
   .addDecorator(decorateWithSimpleTheme)
 


### PR DESCRIPTION
# Background

Here is the definition of BigNumber.DEBUG from the documentation

```javascript
/**
     * To aid in debugging, if a `BigNumber.DEBUG` property is `true` then an error will be thrown
     * if the BigNumber constructor receives an invalid `BigNumber.Value`, or if `BigNumber.isBigNumber`
     * receives a BigNumber instance that is malformed.
     *
     * ```ts
     * // No error, and BigNumber NaN is returned.
     * new BigNumber('blurgh')    // 'NaN'
     * new BigNumber(9, 2)        // 'NaN'
     * BigNumber.DEBUG = true
     * new BigNumber('blurgh')    // '[BigNumber Error] Not a number'
     * new BigNumber(9, 2)        // '[BigNumber Error] Not a base 2 number'
     * ```
     *
     * An error will also be thrown if a `BigNumber.Value` is of type number with more than 15
     * significant digits, as calling `toString` or `valueOf` on such numbers may not result
     * in the intended value.
     *
     * ```ts
     * console.log(823456789123456.3)       //  823456789123456.2
     * // No error, and the returned BigNumber does not have the same value as the number literal.
     * new BigNumber(823456789123456.3)     // '823456789123456.2'
     * BigNumber.DEBUG = true
     * new BigNumber(823456789123456.3)
     * // '[BigNumber Error] Number primitive has more than 15 significant digits'
     * ```
     *
     * Check that a BigNumber instance is well-formed:
     *
     * ```ts
     * x = new BigNumber(10)
     *
     * BigNumber.DEBUG = false
     * // Change x.c to an illegitimate value.
     * x.c = NaN
     * // No error, as BigNumber.DEBUG is false.
     * BigNumber.isBigNumber(x)    // true
     *
     * BigNumber.DEBUG = true
     * BigNumber.isBigNumber(x)    // '[BigNumber Error] Invalid BigNumber'
     * ```
     */
```

# Problem

`new BigNumber(null)` throws an error when `BigNumber.DEBUG` is set to true, and yet react-polymorph currently depends on this behavior inside the `NumericInput` component.

Impact is that programs that have `BigNumber.DEBUG` set to true can't use react-polymorph's NumericInput.

# Solution

To fix this, I handle all the null/undefined cases explicitly

I also added `BigNumber.DEBUG=true` to the test file to make sure this error gets caught in the future

![image](https://user-images.githubusercontent.com/2608559/107963056-06fa5980-6feb-11eb-810c-13597f5cdb72.png)


