### PR TITLE
[DDW-602] - Improve PIN entry component UX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ vNext
 
 ### Features
 
+- Improved PIN entry component UX ([PR 166](https://github.com/input-output-hk/react-polymorph/pull/166))
 - Enabled pasting of multiple words into Autocomplete ([PR 163](https://github.com/input-output-hk/react-polymorph/pull/163))
 
 ### Fixes

--- a/source/components/NumericInput.js
+++ b/source/components/NumericInput.js
@@ -22,6 +22,7 @@ type NumericInputValue = null | number | string | BigNumber.Instance;
 
 export type NumericInputProps = InputProps & {
   allowSigns?: boolean,
+  pinCodeSigns?: boolean,
   bigNumberFormat?: BigNumber.Format,
   decimalPlaces?: number,
   roundingMode?: BigNumber.RoundingMode,
@@ -42,6 +43,7 @@ class NumericInputBase extends Component<NumericInputProps, State> {
 
   static defaultProps = {
     allowSigns: true,
+    pinCodeSigns: true,
     readOnly: false,
     roundingMode: BigNumber.ROUND_FLOOR,
     value: null,
@@ -113,7 +115,7 @@ class NumericInputBase extends Component<NumericInputProps, State> {
     caretPosition: number,
     fallbackInputValue?: ?string,
   } {
-    const { allowSigns, decimalPlaces, value } = this.props;
+    const { allowSigns, pinCodeSigns, decimalPlaces, value } = this.props;
     const { inputType, target } = event;
     const { decimalSeparator, groupSeparator } = this.getBigNumberFormat();
     const changedCaretPosition = target.selectionStart;
@@ -130,9 +132,15 @@ class NumericInputBase extends Component<NumericInputProps, State> {
     const validInputNoSignsRegExp = new RegExp(
       `^([0-9${decimalSeparator}${groupSeparator}]+)?$`
     );
-    const validInputRegex = allowSigns
+    const validPinInputNoSignsRegExp = new RegExp(
+      `^([0-9]+)?$`
+    );
+    let validInputRegex = allowSigns
       ? validInputSignsRegExp
       : validInputNoSignsRegExp;
+    validInputRegex = pinCodeSigns
+        ? validInputRegex
+        : validPinInputNoSignsRegExp;
     const valueHasLeadingZero = /^0[1-9]/.test(valueToProcess);
 
     /**

--- a/source/components/NumericInput.js
+++ b/source/components/NumericInput.js
@@ -334,14 +334,16 @@ class NumericInputBase extends Component<NumericInputProps, State> {
   }
 
   valueToFormattedString(number: NumericInputValue) {
-    const { bigNumberFormat, decimalPlaces, roundingMode } = this.props;
+    const { bigNumberFormat, decimalPlaces, roundingMode, allowOnlyIntegers } = this.props;
     const debugSetting = BigNumber.DEBUG;
     if (BigNumber.isBigNumber(number) && number.isNaN()) return '';
     try {
       BigNumber.DEBUG = true;
-      return new BigNumber(number).toFormat(decimalPlaces, roundingMode, {
+      return allowOnlyIntegers ?
+        new BigNumber(number).toString()
+        : new BigNumber(number).toFormat(decimalPlaces, roundingMode, {
         ...BigNumber.config().FORMAT, // defaults
-        ...bigNumberFormat, // custom overrides
+        ...bigNumberFormat, // custom overrides;
       });
     } catch (e) {
       return '';

--- a/source/components/NumericInput.js
+++ b/source/components/NumericInput.js
@@ -133,7 +133,7 @@ class NumericInputBase extends Component<NumericInputProps, State> {
       `^([0-9${decimalSeparator}${groupSeparator}]+)?$`
     );
     const validInputOnlyIntegersRegExp = new RegExp(
-      `^([-])?([0-9]+)?$`
+      `^([0-9]+)?$`
     );
     let validInputRegex = allowSigns
       ? validInputSignsRegExp

--- a/source/components/NumericInput.js
+++ b/source/components/NumericInput.js
@@ -133,7 +133,7 @@ class NumericInputBase extends Component<NumericInputProps, State> {
       `^([0-9${decimalSeparator}${groupSeparator}]+)?$`
     );
     const validInputOnlyIntegersRegExp = new RegExp(
-      `^[0-9]*$`
+      `^([-])?([0-9]+)?$`
     );
     let validInputRegex = allowSigns
       ? validInputSignsRegExp

--- a/source/components/NumericInput.js
+++ b/source/components/NumericInput.js
@@ -22,7 +22,7 @@ type NumericInputValue = null | number | string | BigNumber.Instance;
 
 export type NumericInputProps = InputProps & {
   allowSigns?: boolean,
-  pinCodeSigns?: boolean,
+  allowOnlyIntegers?: boolean,
   bigNumberFormat?: BigNumber.Format,
   decimalPlaces?: number,
   roundingMode?: BigNumber.RoundingMode,
@@ -43,7 +43,7 @@ class NumericInputBase extends Component<NumericInputProps, State> {
 
   static defaultProps = {
     allowSigns: true,
-    pinCodeSigns: true,
+    allowOnlyIntegers: false,
     readOnly: false,
     roundingMode: BigNumber.ROUND_FLOOR,
     value: null,
@@ -115,7 +115,7 @@ class NumericInputBase extends Component<NumericInputProps, State> {
     caretPosition: number,
     fallbackInputValue?: ?string,
   } {
-    const { allowSigns, pinCodeSigns, decimalPlaces, value } = this.props;
+    const { allowSigns, allowOnlyIntegers, decimalPlaces, value } = this.props;
     const { inputType, target } = event;
     const { decimalSeparator, groupSeparator } = this.getBigNumberFormat();
     const changedCaretPosition = target.selectionStart;
@@ -132,15 +132,15 @@ class NumericInputBase extends Component<NumericInputProps, State> {
     const validInputNoSignsRegExp = new RegExp(
       `^([0-9${decimalSeparator}${groupSeparator}]+)?$`
     );
-    const validPinInputNoSignsRegExp = new RegExp(
-      `^([0-9]+)?$`
+    const validInputOnlyIntegersRegExp = new RegExp(
+      `^[0-9]*$`
     );
     let validInputRegex = allowSigns
       ? validInputSignsRegExp
       : validInputNoSignsRegExp;
-    validInputRegex = pinCodeSigns
-        ? validInputRegex
-        : validPinInputNoSignsRegExp;
+    validInputRegex = allowOnlyIntegers
+        ? validInputOnlyIntegersRegExp
+        : validInputRegex;
     const valueHasLeadingZero = /^0[1-9]/.test(valueToProcess);
 
     /**

--- a/stories/NumericInput.stories.js
+++ b/stories/NumericInput.stories.js
@@ -142,6 +142,17 @@ storiesOf('NumericInput', module)
     ))
   )
   .add(
+    'allowSigns = false | PinCode',
+    withState({ value: null }, (store) => (
+      <NumericInput
+        value={store.state.value}
+        onChange={(value) => store.set({ value })}
+        allowSigns={false}
+        pinCodeSigns={false}
+      />
+    ))
+  )
+  .add(
     'onFocus / onBlur',
     withState({ value: null, focused: false, blurred: false }, (store) => (
       <NumericInput

--- a/stories/NumericInput.stories.js
+++ b/stories/NumericInput.stories.js
@@ -132,7 +132,7 @@ storiesOf('NumericInput', module)
     ))
   )
   .add(
-    'allowSigns = false',
+    'allowSigns = false | allowOnlyIntegers = false',
     withState({ value: null }, (store) => (
       <NumericInput
         value={store.state.value}
@@ -142,7 +142,17 @@ storiesOf('NumericInput', module)
     ))
   )
   .add(
-    'allowOnlyIntegers',
+    'allowSigns = true | allowOnlyIntegers = false',
+    withState({ value: null }, (store) => (
+      <NumericInput
+        value={store.state.value}
+        onChange={(value) => store.set({ value })}
+        allowOnlyIntegers={false}
+      />
+    ))
+  )
+  .add(
+    'allowSigns = false | allowOnlyIntegers = true',
     withState({ value: null }, (store) => (
       <NumericInput
         value={store.state.value}

--- a/stories/NumericInput.stories.js
+++ b/stories/NumericInput.stories.js
@@ -142,13 +142,13 @@ storiesOf('NumericInput', module)
     ))
   )
   .add(
-    'allowSigns = false | PinCode',
+    'allowOnlyIntegers',
     withState({ value: null }, (store) => (
       <NumericInput
         value={store.state.value}
         onChange={(value) => store.set({ value })}
         allowSigns={false}
-        pinCodeSigns={false}
+        allowOnlyIntegers
       />
     ))
   )


### PR DESCRIPTION
This PR changes the `NumericInput` component to improve the Daedalus PIN entry component UX and logic handling for PIN input fields focus, add/remove & disallowing entry of special characters. 

## Screenshots

<img width="1680" alt="Screen Shot 2021-03-22 at 4 22 26 AM" src="https://user-images.githubusercontent.com/15862062/111975975-c6e53580-8ac6-11eb-9507-917c8fe95829.png">

<img width="1679" alt="Screen Shot 2021-03-22 at 4 22 36 AM" src="https://user-images.githubusercontent.com/15862062/111976005-cb115300-8ac6-11eb-881e-1e54c44ceccc.png">

<img width="1680" alt="Screen Shot 2021-03-22 at 4 22 51 AM" src="https://user-images.githubusercontent.com/15862062/111976014-cc428000-8ac6-11eb-956a-df570262981e.png">
<img width="1680" alt="Screen Shot 2021-03-22 at 4 23 47 AM" src="https://user-images.githubusercontent.com/15862062/111976083-db293280-8ac6-11eb-9b0a-d0b42befac26.png">

<img width="1680" alt="Screen Shot 2021-03-22 at 4 23 00 AM" src="https://user-images.githubusercontent.com/15862062/111976021-ccdb1680-8ac6-11eb-99e5-91215fd46903.png">

<img width="1679" alt="Screen Shot 2021-03-22 at 4 23 22 AM" src="https://user-images.githubusercontent.com/15862062/111976026-ce0c4380-8ac6-11eb-855a-bb1a89774d02.png">

<img width="1680" alt="Screen Shot 2021-03-22 at 4 23 35 AM" src="https://user-images.githubusercontent.com/15862062/111976070-d82e4200-8ac6-11eb-8147-e2839e84de05.png">


---

## Testing Checklist

- [Slack QA thread](https://input-output-rnd.slack.com/archives/GGKFXSKC6/p1616408886056400)

---

## Test Scenarios

**Scenario 1 - Replace a digit to unmatch the PINs**
```gherkin
Given that I am on the fourth step of the "Register for Fund3 voting" dialog
And the PIN was repeated on both fields
And the "Continue" button is enabled
When I replace one of the digits on any pin with a different value
Then I can see the "Continue" button is disabled as the values don't match
And the "Repeat" input displays an alert
```
**Scenario 2 - Insert non-numeric characters as PIN**
```gherkin
Given that I am on the fourth step of the "Register for Fund3 voting" dialog
When I insert one of these characters: "-", ",", "."
Then they are not inserted on the fields
```
---

## Review Checklist

### Basics

- [ ] PR has been assigned and has appropriate labels (`feature`/`bug`/`chore`, `release-x.x.x`)
- [ ] PR is updated to the most recent version of the target branch (and there are no conflicts)
- [ ] PR has a good description that summarizes all changes
- [ ] PR has default-sized Daedalus window screenshots or animated GIFs of important UI changes:
  - [ ] In English
  - [ ] In Japanese
- [ ] CHANGELOG entry has been added to the top of the appropriate section (*Features*, *Fixes*, *Chores*) and is linked to the correct PR on GitHub
- [ ] Automated tests: All acceptance and unit tests are passing (`yarn test`)
- [ ] Manual tests (minimum tests should cover newly added feature/fix): App works correctly in *development* build (`yarn dev`)
- [ ] Manual tests (minimum tests should cover newly added feature/fix): App works correctly in *production* build (`yarn package` / CI builds)
- [ ] There are no *flow* errors or warnings (`yarn flow:test`)
- [ ] There are no *lint* errors or warnings (`yarn lint`)
- [ ] There are no *prettier* errors or warnings (`yarn prettier:check`)
- [ ] There are no missing translations (running `yarn manage:translations` produces no changes)
- [ ] Text changes are proofread and approved (Jane Wild / Amy Reeve)
- [ ] Japanese text changes are proofread and approved (Junko Oda)
- [ ] UI changes look good in all themes (Alexander Rukin)
- [ ] Storybook works and no stories are broken (`yarn storybook`)
- [ ] In case of dependency changes `yarn.lock` file is updated

### Code Quality
- [ ] Important parts of the code are properly commented and documented
- [ ] Code is properly typed with flow
- [ ] React components are split-up enough to avoid unnecessary re-renderings
- [ ] Any code that only works in main process is neatly separated from components

### Testing
- [ ] New feature/change is covered by acceptance tests
- [ ] New feature/change is manually tested and approved by QA team
- [ ] All existing acceptance tests are still up-to-date
- [ ] New feature/change is covered by Daedalus Testing scenario
- [ ] All existing Daedalus Testing scenarios are still up-to-date

### After Review
- [ ] Merge the PR
- [ ] Delete the source branch
- [ ] Move the ticket to `done` column on the YouTrack board
- [ ] Update Slack QA thread by marking it with a green checkmark
