### PR TITLE
[DDW-588] Refuse inserts over decimal separator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ vNext
 
 ### Fixes
 
+- Fixed an issue related to Numeric Input when entering numbers after having selected the decimal separator ([PR 167](https://github.com/input-output-hk/react-polymorph/pull/167))
 - Fixed issues related to controlled/uncontrolled Tippy state ([PR 160](https://github.com/input-output-hk/react-polymorph/pull/160))
 - Fixed `NumericInput` to support DEBUG mode ([PR 159](https://github.com/input-output-hk/react-polymorph/pull/159))
 

--- a/source/components/NumericInput.js
+++ b/source/components/NumericInput.js
@@ -213,6 +213,19 @@ class NumericInputBase extends Component<NumericInputProps, State> {
       newCaretPosition = newValue.indexOf(decimalSeparator) + 1;
     }
 
+    // Case: Decimal separator was replaced with a number
+    if (
+      hadDecimalSeparatorBefore &&
+      newNumberOfDecimalSeparators === 0 &&
+      isInsert
+    ) {
+      return {
+        caretPosition: changedCaretPosition - 1,
+        fallbackInputValue,
+        value,
+      };
+    }
+
     /**
      * ========= PROCESS CLEANED INPUT =============
      */

--- a/source/components/NumericInput.js
+++ b/source/components/NumericInput.js
@@ -215,6 +215,7 @@ class NumericInputBase extends Component<NumericInputProps, State> {
 
     // Case: Decimal separator was replaced with a number
     if (
+      value != null &&
       hadDecimalSeparatorBefore &&
       newNumberOfDecimalSeparators === 0 &&
       isInsert


### PR DESCRIPTION
This PR fixes an issue with `NumericInput` when entering numbers after having selected the decimal separator in a numeric input configured to always show a specific precision. This resulted in weird numbers being produced because the decimal separator was deleted This is now simply refused, so the number is not changed at all:

https://user-images.githubusercontent.com/172414/113428477-269ce400-93d7-11eb-9d0a-8f86888cb67b.mp4

How to test:

- [ ] Go to the storybook "numeric input > decimals places (6)" and try to insert (type) new numbers while having a selection that includes the decimal separator. This should be refused in all cases (it should never be possible to "delete" the decimal separator with the setting of having a fixed required number of decimal places)

### Test Scenarios

**Scenario 1 -  Select separator and insert a number**
```gherkin
Given that I am on the "NumericInput" Screen
And a value is inserted in the field
When I select the decimal separator on the number
And I insert a number to replace the selection
Then the decimal separator is not replaced with the value
And the cursor moves to the right of the selection
```

**Scenario 2 -  Select separator and at least a digit and insert a number**
```gherkin
Given that I am on the "NumericInput" Screen
And a value is inserted in the field
When I select the decimal separator and at least one digit before or after it
And I insert a number to replace the selection
Then the decimal separator is not replaced with the value
And the cursor moves to the right of the selection
```
