### PR TITLE
Fixes broken createRef without React.

### DIFF
--- a/source/components/Input.js
+++ b/source/components/Input.js
@@ -61,7 +61,7 @@ class InputBase extends Component<InputProps, State> {
 
   constructor(props: InputProps) {
     super(props);
-    this.inputElement = props.inputRef ?? createRef();
+    this.inputElement = props.inputRef ?? React.createRef();
     const { context, themeId, theme, themeOverrides } = props;
 
     this.state = {


### PR DESCRIPTION
This PR fixes #165, which left an empty `createRef` without `React.createRef`. This will break any <Input /> that uses the `inputRef` prop.