### PR TITLE
[DDW-595] Improve input popover handling

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,11 @@
+name: test
+on: [push]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: install modules
+        run: yarn
+      - name: run tests
+        run: yarn test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,23 @@ The history of all changes to react-polymorph.
 vNext
 =====
 
-### Features
+### Breaking Changes :boom:
 
+- `Input` now shows errors on hover and focus by default which can be configured via two new props:
+
+```ts
+  isShowingErrorOnFocus: boolean,
+  isShowingErrorOnHover: boolean,
+```
+
+### Features :sparkles:
+
+- `Input` now accepts a new prop `themeVariables` which can be used to override css variables ([PR 173](https://github.com/input-output-hk/react-polymorph/pull/173))
 - Implemented the search functionality to the Options component ([PR 165](https://github.com/input-output-hk/daedalus/pull/165))
 - Improved PIN entry component UX ([PR 166](https://github.com/input-output-hk/react-polymorph/pull/166))
 - Enabled pasting of multiple words into Autocomplete ([PR 163](https://github.com/input-output-hk/react-polymorph/pull/163))
 
-### Fixes
+### Fixes :muscle:
 
 - Fixed Select Search styles and minor code issues ([PR 175](https://github.com/input-output-hk/react-polymorph/pull/175))
 - Fixed a wrong variable name for the select search highlight color ([PR 170](https://github.com/input-output-hk/react-polymorph/pull/170))

--- a/README.md
+++ b/README.md
@@ -122,10 +122,10 @@ Temporary releases are useful for testing specific changes in your project PRs w
 releases that might confuse others and are not following semver.
 
 1. Create a dedicated branch for your bug/feature/chore
-2. Run `npm:view:next` to see the latest release version the `next` npm dist-tag is currently pointing to
+2. Run `npm view react-polymorph dist-tags.next` to see the latest release version the `next` npm dist-tag is currently pointing to
    (this will look something like this: `1.0.0-next.1`)
 3. Increase the `next.X` number by one (e.g: `npm version 1.0.0-next.2`) to create a new git tag via.
-4. Publish the release candidate with `npm:publish:next` (this automatically assigns the `next` dist-tag)
+4. Publish the release candidate with `npm publish --tag next` (to assign the `next` dist-tag instead of `latest`)
 5. Reference your release candidate version in your project PR
 
 ### How to publish a stable release

--- a/__tests__/FormField.test.js
+++ b/__tests__/FormField.test.js
@@ -19,17 +19,6 @@ test('FormField renders with label', () => {
   ).toMatchSnapshot();
 });
 
-test('FormField is disabled', () => {
-  expect(
-    renderInSimpleTheme(
-      <FormField
-        disabled
-        render={({ disabled }) => <span>{disabled.toString()}</span>}
-      />
-    )
-  ).toMatchSnapshot();
-});
-
 test('FormField renders an input element', () => {
   expect(
     renderInSimpleTheme(

--- a/__tests__/NumericInput.behavior.test.js
+++ b/__tests__/NumericInput.behavior.test.js
@@ -23,8 +23,7 @@ describe('NumericInput onChange simulations', () => {
       const { input, onChangeMock } = mountNumericInputWithProps();
       input.simulate('change', { nativeEvent: { target: { value: '19.00' } } });
       const onChangeValue = onChangeMock.mock.calls[0][0];
-      expect(BigNumber.isBigNumber(onChangeValue)).toBe(true);
-      expect(onChangeValue.toNumber()).toBe(19);
+      expect(onChangeValue).toEqual('19');
     });
     test('invalid input does not trigger onChange listener', () => {
       const { input, onChangeMock } = mountNumericInputWithProps();
@@ -40,7 +39,7 @@ describe('NumericInput onChange simulations', () => {
         nativeEvent: { target: { value: '9,999,999.00' } },
       });
       const onChangeValue = onChangeMock.mock.calls[0][0];
-      expect(onChangeValue.toNumber()).toBe(9999999.0);
+      expect(onChangeValue).toBe('9999999');
     });
     test('can be configured to handle dots as thousand separators', () => {
       const { input, onChangeMock } = mountNumericInputWithProps({
@@ -52,7 +51,7 @@ describe('NumericInput onChange simulations', () => {
       input.simulate('change', {
         nativeEvent: { target: { value: '9.999.999,00' } },
       });
-      expect(onChangeMock.mock.calls[0][0].toNumber()).toBe(9999999);
+      expect(onChangeMock.mock.calls[0][0]).toBe('9999999');
     });
     test('can be configured to handle spaces as thousand separators', () => {
       const { input, onChangeMock } = mountNumericInputWithProps({
@@ -64,7 +63,7 @@ describe('NumericInput onChange simulations', () => {
       input.simulate('change', {
         nativeEvent: { target: { value: '9 999 999.00' } },
       });
-      expect(onChangeMock.mock.calls[0][0].toNumber()).toBe(9999999);
+      expect(onChangeMock.mock.calls[0][0]).toBe('9999999');
     });
   });
 });

--- a/__tests__/__snapshots__/FormField.test.js.snap
+++ b/__tests__/__snapshots__/FormField.test.js.snap
@@ -1,21 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`FormField is disabled 1`] = `
-<div
-  class="root disabled"
->
-  <span>
-    <div
-      class="inputWrapper"
-    >
-      <span>
-        true
-      </span>
-    </div>
-  </span>
-</div>
-`;
-
 exports[`FormField renders an input element 1`] = `
 <div
   class="root"
@@ -35,22 +19,6 @@ exports[`FormField renders an input element 1`] = `
 exports[`FormField renders correctly 1`] = `
 <div
   class="root"
->
-  <span>
-    <div
-      class="inputWrapper"
-    >
-      <div
-        class="render-prop"
-      />
-    </div>
-  </span>
-</div>
-`;
-
-exports[`FormField renders with an error 1`] = `
-<div
-  class="root errored"
 >
   <span>
     <div

--- a/__tests__/__snapshots__/TextArea.test.js.snap
+++ b/__tests__/__snapshots__/TextArea.test.js.snap
@@ -51,22 +51,6 @@ exports[`TextArea renders with a value 1`] = `
 </div>
 `;
 
-exports[`TextArea renders with an error 1`] = `
-<div
-  class="root errored"
->
-  <span>
-    <div
-      class="inputWrapper"
-    >
-      <textarea
-        class="textarea errored"
-      />
-    </div>
-  </span>
-</div>
-`;
-
 exports[`TextArea renders with placeholder 1`] = `
 <div
   class="root"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-polymorph",
   "description": "React components with highly customizable logic, markup and styles.",
-  "version": "0.9.8-rc.18",
+  "version": "0.9.8-rc.19",
   "scripts": {
     "build": "cross-env yarn clean && yarn sass && yarn js",
     "build:watch": "concurrently 'yarn js:watch' 'yarn sass:watch'",

--- a/package.json
+++ b/package.json
@@ -17,9 +17,7 @@
     "storybook:build": "build-storybook -c storybook -o dist/storybook",
     "test": "cross-env NODE_ENV=test jest",
     "test:update": "yarn test -u",
-    "test:watch": "yarn test --watchAll",
-    "npm:view:next": "npm view react-polymorph dist-tags.next",
-    "npm:publish:next": "npm publish --tag next"
+    "test:watch": "yarn test --watchAll"
   },
   "dependencies": {
     "@tippyjs/react": "4.2.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-polymorph",
   "description": "React components with highly customizable logic, markup and styles.",
-  "version": "0.9.8-rc.19",
+  "version": "0.9.7-next.1",
   "scripts": {
     "build": "cross-env yarn clean && yarn sass && yarn js",
     "build:watch": "concurrently 'yarn js:watch' 'yarn sass:watch'",

--- a/source/components/FormField.js
+++ b/source/components/FormField.js
@@ -18,6 +18,8 @@ export type FormFieldProps = {
   formFieldRef: ElementRef<*>,
   isErrorHidden?: boolean,
   isErrorShown?: boolean,
+  isShowingErrorOnFocus: boolean,
+  isShowingErrorOnHover: boolean,
   label?: string | Element<any>,
   onChange: Function,
   render: (setFormFieldRef: (ElementRef<*>) => void) => React$Node,
@@ -25,6 +27,7 @@ export type FormFieldProps = {
   theme: ?Object, // will take precedence over theme in context if passed
   themeId: string,
   themeOverrides: Object,
+  themeVariables?: Object,
 };
 
 type State = {
@@ -38,6 +41,8 @@ class FormFieldBase extends Component<FormFieldProps, State> {
 
   static defaultProps = {
     context: createEmptyContext(),
+    isShowingErrorOnFocus: true,
+    isShowingErrorOnHover: true,
     theme: null,
     themeId: IDENTIFIERS.FORM_FIELD,
     themeOverrides: {},

--- a/source/components/Input.js
+++ b/source/components/Input.js
@@ -22,6 +22,9 @@ export type InputProps = {
   error?: string | Element<any>,
   inputRef?: RefObject,
   showErrorState?: boolean,
+  hideErrorState?: boolean,
+  isShowingErrorOnFocus: boolean,
+  isShowingErrorOnHover: boolean,
   label?: string | Element<any>,
   maxLength?: number,
   minLength?: number,
@@ -35,6 +38,7 @@ export type InputProps = {
   theme: ?Object, // will take precedence over theme in context if passed
   themeId: string,
   themeOverrides: Object,
+  themeVariables?: Object,
   value: string,
 };
 
@@ -52,6 +56,8 @@ class InputBase extends Component<InputProps, State> {
     autoFocus: false,
     context: createEmptyContext(),
     error: '',
+    isShowingErrorOnFocus: true,
+    isShowingErrorOnHover: true,
     readOnly: false,
     theme: null,
     themeId: IDENTIFIERS.INPUT,

--- a/source/skins/simple/InputSkin.js
+++ b/source/skins/simple/InputSkin.js
@@ -1,6 +1,5 @@
 // @flow
-import React, { useState } from 'react';
-import type { ElementRef } from 'react';
+import React from 'react';
 
 // external libraries
 import classnames from 'classnames';
@@ -26,7 +25,7 @@ export const InputSkin = (props: Props) => {
       className={classnames([
         props.theme[props.themeId].input,
         props.disabled ? props.theme[props.themeId].disabled : null,
-        props.error || props.showErrorState
+        !props.hideErrorState && (props.error || props.showErrorState)
           ? props.theme[props.themeId].errored
           : null,
       ])}
@@ -58,9 +57,12 @@ export const InputSkin = (props: Props) => {
       disabled={props.disabled}
       label={props.label}
       error={props.error}
+      isShowingErrorOnHover={props.isShowingErrorOnHover}
+      isShowingErrorOnFocus={props.isShowingErrorOnFocus}
       formFieldRef={props.inputRef}
       theme={props.theme}
       render={render}
+      themeVariables={props.themeVariables}
     />
   );
 };

--- a/source/skins/simple/OptionsSkin.js
+++ b/source/skins/simple/OptionsSkin.js
@@ -89,11 +89,15 @@ export const OptionsSkin = (props: Props) => {
     if (!noResults && render) {
       // call user's custom render function
       return render(getOptionProps);
-    } if (!noResults && !render) {
+    }
+    if (!noResults && !render) {
       // render default simple skin
       return sortedOptions.map((option, index) => {
         // set reference of event handlers in memory to prevent excess re-renders
-        const boundSetHighlightedOptionIndex = setHighlightedOptionIndex.bind(null, index);
+        const boundSetHighlightedOptionIndex = setHighlightedOptionIndex.bind(
+          null,
+          index
+        );
         const boundHandleClickOnOption = handleClickOnOption.bind(null, option);
 
         return (
@@ -104,10 +108,14 @@ export const OptionsSkin = (props: Props) => {
             className={classnames([
               option.className ? option.className : null,
               theme[themeId].option,
-              isHighlightedOption(index) ? theme[themeId].highlightedOption : null,
+              isHighlightedOption(index)
+                ? theme[themeId].highlightedOption
+                : null,
               isSelectedOption(index) ? theme[themeId].selectedOption : null,
               option.isDisabled ? theme[themeId].disabledOption : null,
-              noSelectedOptionCheckmark ? theme[themeId].hasNoSelectedOptionCheckmark : null,
+              noSelectedOptionCheckmark
+                ? theme[themeId].hasNoSelectedOptionCheckmark
+                : null,
             ])}
             onClick={boundHandleClickOnOption}
             onMouseEnter={boundSetHighlightedOptionIndex}
@@ -121,20 +129,24 @@ export const OptionsSkin = (props: Props) => {
     return <li className={theme[themeId].option}>{noResultsMessage}</li>;
   };
 
-  const renderOption = option => {
+  const renderOption = (option) => {
     const escapedSearchValue = escapeRegExp(searchValue) || '';
     // check if user has passed render prop "optionRenderer"
     if (optionRenderer && isFunction(optionRenderer)) {
       // call user's custom rendering logic
       return optionRenderer(option);
-    } if (isObject(option)) {
+    }
+    if (isObject(option)) {
       let { label } = option;
       // in case `highlightSearch` then `searchValue` is wrapped in an `em` tag
-      if (highlightSearch !== false) {
-        const splitter = new RegExp(`(${escapedSearchValue})`,'i');
+      if (highlightSearch !== false && escapedSearchValue !== '') {
+        const splitter = new RegExp(`(${escapedSearchValue})`, 'i');
         const parts = typeof label === 'string' ? label.split(splitter) : label;
         for (let i = 1; i < parts.length; i += 2) {
-          if (escapeRegExp(parts[i].toLowerCase()) === `${escapedSearchValue}`.toLowerCase())
+          if (
+            escapeRegExp(parts[i].toLowerCase()) ===
+            `${escapedSearchValue}`.toLowerCase()
+          )
             parts[i] = <em key={i}>{parts[i]}</em>;
           label = parts;
         }
@@ -161,8 +173,8 @@ export const OptionsSkin = (props: Props) => {
           />
         )}
       </div>
-    )
-  }
+    );
+  };
 
   const getScrollBarHeight = (): number => {
     if (!options.length) return optionHeight;
@@ -173,9 +185,12 @@ export const OptionsSkin = (props: Props) => {
   };
 
   // Enforce max height of options dropdown if necessary
-  const optionsStyle = optionsMaxHeight == null ? null : {
-    maxHeight: `${optionsMaxHeight}px`
-  };
+  const optionsStyle =
+    optionsMaxHeight == null
+      ? null
+      : {
+          maxHeight: `${optionsMaxHeight}px`,
+        };
 
   return (
     <Bubble
@@ -201,8 +216,12 @@ export const OptionsSkin = (props: Props) => {
         style={optionsStyle}
         ref={optionsRef}
         className={theme[themeId].ul}
-        onMouseEnter={() => setMouseIsOverOptions && setMouseIsOverOptions(true)}
-        onMouseLeave={() => setMouseIsOverOptions && setMouseIsOverOptions(false)}
+        onMouseEnter={() =>
+          setMouseIsOverOptions && setMouseIsOverOptions(true)
+        }
+        onMouseLeave={() =>
+          setMouseIsOverOptions && setMouseIsOverOptions(false)
+        }
       >
         <ScrollBar style={{ height: `${getScrollBarHeight()}px` }}>
           {renderOptions()}

--- a/source/skins/simple/PasswordInputSkin.js
+++ b/source/skins/simple/PasswordInputSkin.js
@@ -1,10 +1,9 @@
 // @flow
 import classnames from 'classnames';
-import React, { useState } from 'react';
+import React from 'react';
 
 import { Input } from '../../components/Input';
 import { PasswordInput } from '../../components/PasswordInput';
-import { PopOver } from '../../components/PopOver';
 import type { PasswordInputProps } from '../../components/PasswordInput';
 import { SimplePasswordInputVariables } from '../../themes/simple/SimplePasswordInput';
 import { useDebouncedValueChangedIndicator } from '../../utils/hooks';
@@ -30,8 +29,6 @@ function getPopOverBgColorForState(state: PasswordInput.STATE): string {
 }
 
 export const PasswordInputSkin = (props: Props) => {
-  const [hasInputFocus, setHasInputFocus] = useState(false);
-  const [isInputHovered, setIsInputHovered] = useState(false);
   const {
     className,
     error,
@@ -52,6 +49,8 @@ export const PasswordInputSkin = (props: Props) => {
     ? useDebouncedValueChangedIndicator(value, debounceDelay)
     : true;
   const hasTooltip = hasInitialValueChanged && tooltip != null;
+  const stateColor = getPopOverBgColorForState(state);
+  const isErrorState = state === PasswordInput.STATE.ERROR;
   return (
     <div
       className={classnames([
@@ -60,34 +59,17 @@ export const PasswordInputSkin = (props: Props) => {
         className,
       ])}
     >
-      <PopOver
-        visible={
-          hasTooltip &&
-          (isTooltipOpen ||
-            (isShowingTooltipOnHover && isInputHovered) ||
-            (isShowingTooltipOnFocus && hasInputFocus))
-        }
-        content={tooltip}
+      <Input
+        {...inputProps}
+        error={hasTooltip ? tooltip : null}
+        showErrorState={hasTooltip && isErrorState}
+        hideErrorState={!isErrorState}
+        value={value}
+        type="password"
         themeVariables={{
-          '--rp-pop-over-bg-color': getPopOverBgColorForState(state),
+          '--rp-pop-over-bg-color': stateColor,
         }}
-        placement="bottom"
-        popperOptions={{ modifiers: [{ name: 'flip', enabled: false }] }}
-        duration={[300, 0]}
-      >
-        <Input
-          {...inputProps}
-          showErrorState={
-            hasInitialValueChanged && state === PasswordInput.STATE.ERROR
-          }
-          value={value}
-          type="password"
-          onBlur={() => setHasInputFocus(false)}
-          onFocus={() => setHasInputFocus(true)}
-          onMouseEnter={() => setIsInputHovered(true)}
-          onMouseOut={() => setIsInputHovered(false)}
-        />
-      </PopOver>
+      />
       <div className={theme[themeId].indicator}>
         <div
           className={theme[themeId].score}

--- a/source/themes/simple/SimplePasswordInput.scss
+++ b/source/themes/simple/SimplePasswordInput.scss
@@ -17,14 +17,6 @@
   transition: width 400ms ease;
 }
 
-.error {
-  :global {
-    .SimpleFormField_error {
-      display: none;
-    }
-  }
-}
-
 .insecure, .weak, .strong {
   :global {
     .SimpleInput_input {

--- a/source/utils/hooks.js
+++ b/source/utils/hooks.js
@@ -1,6 +1,6 @@
 // @flow
 import type { ElementRef } from 'react';
-import { useEffect, useState, Ref, useCallback } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 
 export function useDebouncedValueChangedIndicator(value: any, delay: number) {
   const [isDirty, setIsDirty] = useState(false);
@@ -22,24 +22,41 @@ export function useDebouncedValueChangedIndicator(value: any, delay: number) {
   return isDirty;
 }
 
-// Inspired by https://medium.com/@teh_builder/ref-objects-inside-useeffect-hooks-eb7c15198780
-export function handleRefFocusState(
-  ref: ElementRef<*>,
-  setIsFocused: React.SetStateAction
-) {
-  const focusListener = () => setIsFocused(true);
-  const blurListener = () => setIsFocused(false);
-
+/**
+ * Hook for setting a ref and re-rendering when the value changes
+ * Inspired by https://medium.com/@teh_builder/ref-objects-inside-useeffect-hooks-eb7c15198780
+ */
+export function manageRef(ref: ElementRef<*>) {
   return useCallback((node) => {
-    if (ref.current) {
-      const { current } = ref;
-      current.removeEventListener('focus', focusListener);
-      current.removeEventListener('blur', blurListener);
-    }
-    if (node) {
-      node.addEventListener('focus', focusListener);
-      node.addEventListener('blur', blurListener);
-    }
     ref.current = node;
   }, []);
+}
+
+/**
+ * Hook for handling the on/off state of events that
+ * are toggle-able like "hovered" or "focused"
+ */
+export function handleRefState(
+  ref: ElementRef<*>,
+  events: { on: string, off: string }
+) {
+  const [isOn, setIsOn] = useState(false);
+  const onListener = () => setIsOn(true);
+  const offListener = () => setIsOn(false);
+  useEffect(() => {
+    if (ref.current) {
+      const { current } = ref;
+      current.addEventListener(events.on, onListener);
+      current.addEventListener(events.off, offListener);
+    }
+    // Remove event listeners on component unmount
+    return () => {
+      if (ref.current) {
+        const { current } = ref;
+        current.removeEventListener(events.on, onListener);
+        current.removeEventListener(events.off, offListener);
+      }
+    };
+  });
+  return isOn;
 }

--- a/stories/Input.stories.js
+++ b/stories/Input.stories.js
@@ -19,153 +19,190 @@ import themeOverrides from './theme-overrides/customInput.scss';
 import { decorateWithSimpleTheme } from './helpers/theming';
 
 storiesOf('Input', module)
-
   .addDecorator(decorateWithSimpleTheme)
 
   // ====== Stories ======
 
-  .add('plain',
-    withState({ value: '' }, store => (
+  .add(
+    'plain',
+    withState({ value: '' }, (store) => (
       <Input
         value={store.state.value}
-        onChange={value => store.set({ value })}
+        onChange={(value) => store.set({ value })}
       />
     ))
   )
 
-  .add('label',
-    withState({ value: '' }, store => (
+  .add(
+    'label',
+    withState({ value: '' }, (store) => (
       <Input
         label="Click Me to Focus"
         value={store.state.value}
-        onChange={value => store.set({ value })}
+        onChange={(value) => store.set({ value })}
       />
     ))
   )
 
-  .add('placeholder',
-    withState({ value: '' }, store => (
+  .add(
+    'placeholder',
+    withState({ value: '' }, (store) => (
       <Input
         value={store.state.value}
         placeholder="user name"
-        onChange={value => store.set({ value })}
+        onChange={(value) => store.set({ value })}
       />
     ))
   )
 
-  .add('autoFocus',
-    withState({ value: '' }, store => (
+  .add(
+    'autoFocus',
+    withState({ value: '' }, (store) => (
       <Input
         autoFocus
         label="With autoFocus"
         value={store.state.value}
         placeholder="autoFocus"
-        onChange={value => store.set({ value })}
+        onChange={(value) => store.set({ value })}
       />
     ))
   )
 
   .add('disabled', () => (
-    <Input
-      disabled
-      label="Disabled Input"
-      placeholder="user name"
-    />
+    <Input disabled label="Disabled Input" placeholder="user name" />
   ))
 
-  .add('with error',
-    withState({ value: '' }, store => (
+  .add(
+    'error (on focus & hover)',
+    withState({ value: '' }, (store) => (
       <Input
-        label="With Error"
+        label="With Error on focus & hover"
         error="Something went wrong"
         value={store.state.value}
-        onChange={value => store.set({ value })}
+        onChange={(value) => store.set({ value })}
       />
     ))
   )
 
-  .add('minLength(8)',
-    withState({ value: '' }, store => (
+  .add(
+    'custom error (only on focus)',
+    withState({ value: '' }, (store) => (
+      <Input
+        label="Custom Error only on focus"
+        error="Something went wrong"
+        value={store.state.value}
+        onChange={(value) => store.set({ value })}
+        isShowingErrorOnHover={false}
+        themeVariables={{
+          '--rp-input-border-color-errored': 'orange',
+          '--rp-pop-over-bg-color': 'orange',
+        }}
+      />
+    ))
+  )
+
+  .add(
+    'error (only on hover)',
+    withState({ value: '' }, (store) => (
+      <Input
+        label="With Error only on focus"
+        error="Something went wrong"
+        value={store.state.value}
+        onChange={(value) => store.set({ value })}
+        isShowingErrorOnFocus={false}
+      />
+    ))
+  )
+
+  .add(
+    'minLength(8)',
+    withState({ value: '' }, (store) => (
       <Input
         label="Minimum 8 Characters"
         value={store.state.value}
         placeholder="min length"
         minLength={8}
-        onChange={value => store.set({ value })}
+        onChange={(value) => store.set({ value })}
       />
     ))
   )
 
-  .add('maxLength(5)',
-    withState({ value: '' }, store => (
+  .add(
+    'maxLength(5)',
+    withState({ value: '' }, (store) => (
       <Input
         label="Maximum 5 Characters"
         value={store.state.value}
         placeholder="max length"
         maxLength={5}
-        onChange={value => store.set({ value })}
+        onChange={(value) => store.set({ value })}
       />
     ))
   )
 
-  .add('type=password',
-    withState({ value: '' }, store => (
+  .add(
+    'type=password',
+    withState({ value: '' }, (store) => (
       <Input
         value={store.state.value}
         type="password"
         placeholder="password"
-        onChange={value => store.set({ value })}
+        onChange={(value) => store.set({ value })}
       />
     ))
   )
 
-  .add('onFocus / onBlur',
-    withState({ value: '', focused: false, blurred: false }, store => (
+  .add(
+    'onFocus / onBlur',
+    withState({ value: '', focused: false, blurred: false }, (store) => (
       <Input
         label="See the State Tab Below"
         value={store.state.value}
         placeholder="onFocus / onBlur"
-        onChange={value => store.set({ value })}
+        onChange={(value) => store.set({ value })}
         onFocus={() => store.set({ focused: true, blurred: false })}
         onBlur={() => store.set({ blurred: true, focused: false })}
       />
     ))
   )
 
-  .add('onKeyPress',
-    withState({ value: '' }, store => (
+  .add(
+    'onKeyPress',
+    withState({ value: '' }, (store) => (
       <Input
         label="Type to See Events Logged"
         value={store.state.value}
         placeholder="max 5 characters"
         maxLength={5}
         onKeyPress={action('onKeyPress')}
-        onChange={value => store.set({ value })}
+        onChange={(value) => store.set({ value })}
       />
     ))
   )
 
-  .add('theme overrides, minLength(8)',
-    withState({ value: '' }, store => (
+  .add(
+    'theme overrides, minLength(8)',
+    withState({ value: '' }, (store) => (
       <Input
         label="Composed Theme"
         minLength={8}
         themeOverrides={themeOverrides}
         value={store.state.value}
         placeholder="type here..."
-        onChange={value => store.set({ value })}
+        onChange={(value) => store.set({ value })}
       />
     ))
   )
 
-  .add('custom theme',
-    withState({ value: '' }, store => (
+  .add(
+    'custom theme',
+    withState({ value: '' }, (store) => (
       <Input
         label="Custom Theme"
         theme={CustomInputTheme}
         value={store.state.value}
         placeholder="type here..."
-        onChange={value => store.set({ value })}
+        onChange={(value) => store.set({ value })}
       />
     ))
   );


### PR DESCRIPTION
This PR improves the configurability of the `Input` and `FormField` components to support:

## New Features ✨ 

1. Showing form field error on hover
2. Showing form field error on focus
3. Styling the form field errors differently via injected css variables

which is required by https://github.com/input-output-hk/daedalus/pull/2506

![grafik](https://user-images.githubusercontent.com/172414/115067768-a6f03880-9ef1-11eb-85af-186b61d4d5ed.png)

## BREAKING CHANGE :boom:
❗**next release must increase major version**

- `FormField` now shows errors on hover and focus by default which can be configured via two new props:

```ts
  isShowingErrorOnFocus: boolean,
  isShowingErrorOnHover: boolean,
```

❗This means that we need to check all form elements (input, select, autocomplete, etc.)

## Chores 🤓 

- Added Github workflow for automated testing 🎉 