### PR TITLE
Release/1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,16 @@ The history of all changes to react-polymorph.
 vNext
 =====
 
+1.0.0
+=====
+
 ### Breaking Changes :boom:
 
 - `Input` now shows errors on hover and focus by default which can be configured via two new props:
 
 ```ts
-  isShowingErrorOnFocus: boolean,
-  isShowingErrorOnHover: boolean,
+  isShowingErrorOnFocus: boolean
+  isShowingErrorOnHover: boolean
 ```
 
 ### Features :sparkles:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-polymorph",
   "description": "React components with highly customizable logic, markup and styles.",
-  "version": "0.9.7-next.2",
+  "version": "1.0.0-rc.2",
   "scripts": {
     "build": "cross-env yarn clean && yarn sass && yarn js",
     "build:watch": "concurrently 'yarn js:watch' 'yarn sass:watch'",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-polymorph",
   "description": "React components with highly customizable logic, markup and styles.",
-  "version": "0.9.7-next.1",
+  "version": "0.9.7-next.2",
   "scripts": {
     "build": "cross-env yarn clean && yarn sass && yarn js",
     "build:watch": "concurrently 'yarn js:watch' 'yarn sass:watch'",


### PR DESCRIPTION
This PR prepares the 1.0 release and introduces a new release management process.

## 🤓 New Release Management

- Starting with `1.0.0` all future releases will follow semver semantics:
  - `patch` (eg: 1.0.x) for **API compatible bug fixes**
  - `minor` (eg.: 1.x.0) for **API compatible new features**
  - `major` (eg: 2.0.0) for **API breaking changes**
  
- For early integration of upcoming release changes we use the following conventions:
  
  - `[current version]-next.x` to tag changes for upcoming releases (as we cannot know the necessary 
    semver for the final release including all the changes). `x` in this case is simply a number that 
    is increased and can be thought of like "slots" for temporary releases
    
  - All temporary releases should be published with the `next` npm dist tag via: `npm publish --tag next` 
    so that they are not automatically tagged with the default `latest` npm tag.
    
- The `master` branch only includes commits of final releases
  
- `release/x.x.x` branches are created as soon as we cut a release and know the correct semver - they 
  are always targeting the `master` branch + should be well documented. They can include many release
  candidates which should be tagged like `[next releaes]-rc.X` where you increment X per release candidate
  until we are confident that the release is ready to be published under its normal version.

## Changes since version 0.9.7

### Breaking Changes :boom:

- `Input` now shows errors on hover and focus by default which can be configured via two new props ([PR 173](https://github.com/input-output-hk/react-polymorph/pull/173))

```ts
  isShowingErrorOnFocus: boolean,
  isShowingErrorOnHover: boolean,
```

### ✨ Features 

- Implemented the search functionality to the Options component ([PR 165](https://github.com/input-output-hk/daedalus/pull/165))
- Improved PIN entry component UX ([PR 166](https://github.com/input-output-hk/react-polymorph/pull/166))
- Enabled pasting of multiple words into Autocomplete ([PR 163](https://github.com/input-output-hk/react-polymorph/pull/163))

### 🐞 Fixes 

- Fixed Select search issues ([PR 179](https://github.com/input-output-hk/react-polymorph/pull/179))
- Fixed Select Search styles and minor code issues ([PR 175](https://github.com/input-output-hk/react-polymorph/pull/175))
- Fixed a wrong variable name for the select search highlight color ([PR 170](https://github.com/input-output-hk/react-polymorph/pull/170))
- Fixed an issue related to Numeric Input when entering numbers after having selected the decimal separator ([PR 167](https://github.com/input-output-hk/react-polymorph/pull/167))
- Fixed issues related to controlled/uncontrolled Tippy state ([PR 160](https://github.com/input-output-hk/react-polymorph/pull/160))
- Fixed `NumericInput` to support DEBUG mode ([PR 159](https://github.com/input-output-hk/react-polymorph/pull/159))