### PR TITLE
[DDW-680] Allow NumericInput value to be overwritten from selection

### DIFF
--- a/__tests__/NumericInput.behavior.test.js
+++ b/__tests__/NumericInput.behavior.test.js
@@ -65,5 +65,35 @@ describe('NumericInput onChange simulations', () => {
       });
       expect(onChangeMock.mock.calls[0][0]).toBe('9999999');
     });
+    test('decimal places can be removed if the decimalPlaces prop is not passed to component', () => {
+      const { input, onChangeMock } = mountNumericInputWithProps({
+        bigNumberFormat: {
+          groupSeparator: ' ',
+          decimalSeparator: '.',
+        },
+        value: '11111.22222'
+      });
+      input.simulate('change', {
+        nativeEvent: { target: { value: '9999999' } },
+      });
+      expect(onChangeMock.mock.calls[0][0]).toBe('9999999');
+    });
+    test('decimaal places cannot be removed if the decimalPlaces prop is passed to component', () => {
+      const { input, onChangeMock,wrapper } = mountNumericInputWithProps({
+        bigNumberFormat: {
+          groupSeparator: ' ',
+          decimalSeparator: '.',
+        },
+        value: new BigNumber(111.222222),
+        decimalPlaces:6
+      });
+      input.simulate('change', {
+        nativeEvent: { target: { value: '9999999' } },
+      });
+      console.log(onChangeMock);
+      console.log(input.value);
+      console.log(wrapper);
+      expect(onChangeMock.mock.calls[0][0]).toBe('111.222222');
+    });
   });
 });

--- a/source/components/NumericInput.js
+++ b/source/components/NumericInput.js
@@ -222,6 +222,7 @@ class NumericInputBase extends Component<NumericInputProps, State> {
 
     // Case: Decimal separator was replaced with a number
     if (
+      !!decimalPlaces &&
       value != null &&
       hadDecimalSeparatorBefore &&
       newNumberOfDecimalSeparators === 0 &&


### PR DESCRIPTION
This PR fixes an issue where trying to overwrite the NumericInput value which includes decimals returns the original value

How to test:
- [ ] Ensure that the original test cases from https://github.com/input-output-hk/react-polymorph/pull/167 still pass
- [ ] Go to the storybook "numeric input > plain" and insert the value 111.222222, select the contents of the field and type "5", the value of the input should now read "5"