### PR TITLE
[DDW-974] Fix double triggering of checkbox onChange

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -84,6 +84,7 @@
     "react/no-array-index-key": 0,
     "object-curly-newline": 0,
     "jsx-a11y/alt-text": 0,
+    "jsx-a11y/label-has-associated-control": 0,
     "no-await-in-loop": 0,
     "no-restricted-syntax": 0,
     "no-return-assign": 0,

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ jspm_packages
 
 # Optional npm cache directory
 .npm
+.eslintcache
 
 # Optional REPL history
 .node_repl_history

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,11 @@
 
 The history of all changes to react-polymorph.
 
-# 1.0.4
+# vNext
 
+## Chores
+
+- Fix double triggering of checkbox onChange handler ([PR 206](https://github.com/input-output-hk/react-polymorph/pull/206))
 - Bumped the version of `create-react-context` ([PR 208](https://github.com/input-output-hk/react-polymorph/pull/208))
 
 # 1.0.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,12 @@ The history of all changes to react-polymorph.
 
 # vNext
 
+## Fixes
+
+- Fixed double triggering of checkbox onChange handler ([PR 206](https://github.com/input-output-hk/react-polymorph/pull/206))
+
 ## Chores
 
-- Fix double triggering of checkbox onChange handler ([PR 206](https://github.com/input-output-hk/react-polymorph/pull/206))
 - Bumped the version of `create-react-context` ([PR 208](https://github.com/input-output-hk/react-polymorph/pull/208))
 
 # 1.0.3

--- a/__tests__/Checkbox.behavior.test.js
+++ b/__tests__/Checkbox.behavior.test.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import { Checkbox } from '../source/components/Checkbox';
+import { mountInSimpleTheme } from './helpers/theming';
+
+describe('Checkbox behavior', () => {
+  test('onChange should fire exactly once', () => {
+    const onChange = jest.fn();
+    const component = mountInSimpleTheme(<Checkbox onChange={onChange} />);
+    component.simulate('click');
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({ type: 'click' })
+    );
+  });
+  test('onChange should not fire when disabled', () => {
+    const onChange = jest.fn();
+    const component = mountInSimpleTheme(
+      <Checkbox onChange={onChange} disabled />
+    );
+    const checkboxElement = component.find('input');
+    expect(checkboxElement.prop('disabled')).toBe(true);
+    component.simulate('click');
+    expect(onChange).toHaveBeenCalledTimes(0);
+  });
+});

--- a/__tests__/__snapshots__/Checkbox.test.js.snap
+++ b/__tests__/__snapshots__/Checkbox.test.js.snap
@@ -9,6 +9,7 @@ exports[`Checkbox is checked 1`] = `
   <input
     checked=""
     class="input"
+    readonly=""
     type="checkbox"
   />
   <div
@@ -26,6 +27,7 @@ exports[`Checkbox is disabled 1`] = `
   <input
     class="input"
     disabled=""
+    readonly=""
     type="checkbox"
   />
   <div
@@ -42,6 +44,7 @@ exports[`Checkbox renders correctly 1`] = `
 >
   <input
     class="input"
+    readonly=""
     type="checkbox"
   />
   <div
@@ -59,6 +62,7 @@ exports[`Checkbox renders with a label 1`] = `
   <input
     class="input"
     label="check here"
+    readonly=""
     type="checkbox"
   />
   <div

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-polymorph",
   "description": "React components with highly customizable logic, markup and styles.",
-  "version": "1.0.4",
+  "version": "1.0.3",
   "scripts": {
     "build": "cross-env yarn clean && yarn sass && yarn js",
     "build:watch": "concurrently 'yarn js:watch' 'yarn sass:watch'",

--- a/source/components/Checkbox.js
+++ b/source/components/Checkbox.js
@@ -11,9 +11,9 @@ import { IDENTIFIERS } from '.';
 import type { ThemeContextProp } from './HOC/withTheme';
 
 type Props = {
-  checked: boolean,
+  checked?: boolean,
   className?: string,
-  context: ThemeContextProp,
+  context?: ThemeContextProp,
   disabled?: boolean,
   label?: string | Element<any>,
   labelLeft?: string | Element<any>,
@@ -22,13 +22,13 @@ type Props = {
   onBlur?: Function,
   onFocus?: Function,
   skin?: ComponentType<any>,
-  theme: ?Object, // will take precedence over theme in context if passed
-  themeId: string,
-  themeOverrides: Object
+  theme?: ?Object, // will take precedence over theme in context if passed
+  themeId?: string,
+  themeOverrides?: Object,
 };
 
 type State = {
-  composedTheme: Object
+  composedTheme: Object,
 };
 
 class CheckboxBase extends Component<Props, State> {
@@ -39,7 +39,7 @@ class CheckboxBase extends Component<Props, State> {
     context: createEmptyContext(),
     theme: null,
     themeId: IDENTIFIERS.CHECKBOX,
-    themeOverrides: {}
+    themeOverrides: {},
   };
 
   constructor(props: Props) {
@@ -52,7 +52,7 @@ class CheckboxBase extends Component<Props, State> {
         addThemeId(theme || context.theme, themeId),
         addThemeId(themeOverrides, themeId),
         context.ROOT_THEME_API
-      )
+      ),
     };
   }
 

--- a/source/skins/simple/CheckboxSkin.js
+++ b/source/skins/simple/CheckboxSkin.js
@@ -1,4 +1,5 @@
 // @flow
+import { omit } from 'lodash';
 import React from 'react';
 import type { Element } from 'react';
 // external libraries
@@ -34,10 +35,10 @@ export const CheckboxSkin = (props: Props) => (
     }}
   >
     <input
-      {...pickDOMProps(props)}
-      onChange={() => {}}
+      {...pickDOMProps(omit(props, 'onChange'))}
       className={props.theme[props.themeId].input}
       type="checkbox"
+      readOnly
     />
     <div
       className={classnames([

--- a/source/skins/simple/CheckboxSkin.js
+++ b/source/skins/simple/CheckboxSkin.js
@@ -35,6 +35,7 @@ export const CheckboxSkin = (props: Props) => (
   >
     <input
       {...pickDOMProps(props)}
+      onChange={() => {}}
       className={props.theme[props.themeId].input}
       type="checkbox"
     />

--- a/stories/Checkbox.stories.js
+++ b/stories/Checkbox.stories.js
@@ -1,4 +1,5 @@
 // @flow
+import { action } from '@storybook/addon-actions';
 import React from 'react';
 
 // storybook
@@ -21,13 +22,13 @@ import themeOverrides from './theme-overrides/customCheckbox.scss';
 import { decorateWithSimpleTheme } from './helpers/theming';
 
 storiesOf('Checkbox', module)
-
   .addDecorator(decorateWithSimpleTheme)
 
   // ====== Stories ======
 
-  .add('plain',
-    withState({ checked: false }, store => (
+  .add(
+    'plain',
+    withState({ checked: false }, (store) => (
       <Checkbox
         checked={store.state.checked}
         onChange={() => store.set({ checked: !store.state.checked })}
@@ -38,8 +39,9 @@ storiesOf('Checkbox', module)
 
   .add('disabled', () => <Checkbox disabled skin={CheckboxSkin} />)
 
-  .add('short label',
-    withState({ checked: false }, store => (
+  .add(
+    'short label',
+    withState({ checked: false }, (store) => (
       <Checkbox
         label="My checkbox"
         checked={store.state.checked}
@@ -53,8 +55,9 @@ storiesOf('Checkbox', module)
     <Checkbox disabled label="My checkbox" skin={CheckboxSkin} />
   ))
 
-  .add('long label',
-    withState({ checked: false }, store => (
+  .add(
+    'long label',
+    withState({ checked: false }, (store) => (
       <Checkbox
         label="I understand that if this application is moved to another device
               or deleted, my money can be only recovered with the backup phrase
@@ -66,8 +69,9 @@ storiesOf('Checkbox', module)
     ))
   )
 
-  .add('html label',
-    withState({ checked: false }, store => (
+  .add(
+    'html label',
+    withState({ checked: false }, (store) => (
       <Checkbox
         label={
           <div>
@@ -81,8 +85,9 @@ storiesOf('Checkbox', module)
     ))
   )
 
-  .add('theme overrides',
-    withState({ checked: false }, store => (
+  .add(
+    'theme overrides',
+    withState({ checked: false }, (store) => (
       <Checkbox
         themeOverrides={themeOverrides}
         label="check here"
@@ -93,13 +98,24 @@ storiesOf('Checkbox', module)
     ))
   )
 
-  .add('custom theme',
-    withState({ checked: true }, store => (
+  .add(
+    'custom theme',
+    withState({ checked: true }, (store) => (
       <Checkbox
         theme={CustomCheckboxTheme}
         label="check here"
         checked={store.state.checked}
         onChange={() => store.set({ checked: !store.state.checked })}
+        skin={CheckboxSkin}
+      />
+    ))
+  )
+  .add(
+    'onChange action',
+    withState({ checked: false }, (store) => (
+      <Checkbox
+        defaultChecked={store.state.checked}
+        onChange={action('onChange')}
         skin={CheckboxSkin}
       />
     ))


### PR DESCRIPTION
This PR fixes Fix double triggering of checkbox onChange event handler.

The CheckboxSkin component was handling onChange by registering an onClick handler on the wrapper component AND passing the onChange to the underlying input (checkbox) component. That’s why the onChange handler to the Checkbox got called twice (once with the new boolean value + once with the event)

Todos:
- [x] Add regression test for the double triggering of events
- [x] Fix lint issues
- [x] Improve flow types of Checkbox component
- [x] Integrate this into Daedalus and make sure everything works as expected