### PR TITLE
[DDW-756] Fix PopOver overlap

### DIFF
--- a/source/themes/simple/SimplePopOver.scss
+++ b/source/themes/simple/SimplePopOver.scss
@@ -1,4 +1,5 @@
-@import "theme";
+@use "sass:math";
+@import 'theme';
 
 // OVERRIDABLE CONFIGURATION VARIABLES
 
@@ -7,6 +8,7 @@ $pop-over-font-family: var(--rp-pop-over-font-family, $theme-font-regular), sans
 $pop-over-font-size: var(--rp-pop-over-font-size, 14px) !default;
 $pop-over-padding: var(--rp-pop-over-padding, 6px 12px) !default;
 $pop-over-arrow-size: var(--rp-pop-over-arrow-size, 16px) !default;
+$pop-over-arrow-nesting: calc(-1 * #{$pop-over-arrow-size} * #{math.sqrt(2)} / 2);
 $pop-over-bg-color: var(--rp-pop-over-bg-color, rgba(94, 96, 102, 0.9)) !default;
 $pop-over-text-color: var(--rp-pop-over-text-color, white) !default;
 $pop-over-line-height: var(--rp-pop-over-line-height, 19px) !default;
@@ -22,22 +24,22 @@ $pop-over-border-color: var(--rp-pop-over-border-color, transparent) !default;
   }
 
   [data-tippy-root] {
-    max-width: calc(100vw - 10px)
+    max-width: calc(100vw - 10px);
   }
 
   .tippy-box {
     position: relative;
-    transition-property: transform, visibility, opacity
+    transition-property: transform, visibility, opacity;
   }
 
   .tippy-box[data-inertia][data-state=visible] {
-    transition-timing-function: cubic-bezier(.54, 1.5, .38, 1.11)
+    transition-timing-function: cubic-bezier(.54, 1.5, .38, 1.11);
   }
 
   .tippy-content {
     position: relative;
     line-height: $pop-over-line-height;
-    z-index: 1
+    z-index: 1;
   }
 }
 
@@ -61,8 +63,8 @@ $pop-over-border-color: var(--rp-pop-over-border-color, transparent) !default;
       position: relative;
       overflow: hidden;
       display: flex;
-      width: calc(#{$pop-over-arrow-size} * 1.5);
-      height: calc(#{$pop-over-arrow-size} * 1.5);
+      width: $pop-over-arrow-size;
+      height: calc(#{$pop-over-arrow-size} * #{math.sqrt(2)} / 2);
       &:before {
         content: "";
         display: block;
@@ -81,7 +83,7 @@ $pop-over-border-color: var(--rp-pop-over-border-color, transparent) !default;
       justify-content: center;
       align-items: flex-start;
       &:before {
-        margin-top: calc(-1 * #{$pop-over-arrow-size} / 2 - #{$pop-over-border-width} * 2);
+        margin-top: $pop-over-arrow-nesting;
       }
     }
 
@@ -90,7 +92,7 @@ $pop-over-border-color: var(--rp-pop-over-border-color, transparent) !default;
       align-items: flex-end;
       bottom: 100%;
       &:before {
-        margin-bottom: calc(-1 * #{$pop-over-arrow-size} / 2 - #{$pop-over-border-width} * 2);
+        margin-bottom: $pop-over-arrow-nesting;
       }
     }
 
@@ -99,7 +101,7 @@ $pop-over-border-color: var(--rp-pop-over-border-color, transparent) !default;
       align-items: center;
       left: 100%;
       &:before {
-        margin-left: calc(-1 * #{$pop-over-arrow-size} / 2 - #{$pop-over-border-width} * 2);
+        margin-left: $pop-over-arrow-nesting;
       }
     }
 
@@ -108,7 +110,7 @@ $pop-over-border-color: var(--rp-pop-over-border-color, transparent) !default;
       align-items: center;
       right: 100%;
       &:before {
-        margin-right: calc(-1 * #{$pop-over-arrow-size} / 2 - #{$pop-over-border-width} * 2);
+        margin-right: $pop-over-arrow-nesting;
       }
     }
   }

--- a/source/themes/simple/SimplePopOver.scss
+++ b/source/themes/simple/SimplePopOver.scss
@@ -100,6 +100,8 @@ $pop-over-border-color: var(--rp-pop-over-border-color, transparent) !default;
       justify-content: flex-start;
       align-items: center;
       left: 100%;
+      width: calc(#{$pop-over-arrow-size} * #{math.sqrt(2)} / 2);
+      height: $pop-over-arrow-size;
       &:before {
         margin-left: $pop-over-arrow-nesting;
       }
@@ -109,6 +111,8 @@ $pop-over-border-color: var(--rp-pop-over-border-color, transparent) !default;
       justify-content: flex-end;
       align-items: center;
       right: 100%;
+      width: calc(#{$pop-over-arrow-size} * #{math.sqrt(2)} / 2);
+      height: $pop-over-arrow-size;
       &:before {
         margin-right: $pop-over-arrow-nesting;
       }

--- a/source/themes/simple/SimplePopOver.scss
+++ b/source/themes/simple/SimplePopOver.scss
@@ -7,8 +7,9 @@ $pop-over-box-shadow: var(--rp-pop-over-box-shadow, 0 1.5px 5px 0 rgba(0, 0, 0, 
 $pop-over-font-family: var(--rp-pop-over-font-family, $theme-font-regular), sans-serif !default;
 $pop-over-font-size: var(--rp-pop-over-font-size, 14px) !default;
 $pop-over-padding: var(--rp-pop-over-padding, 6px 12px) !default;
-$pop-over-arrow-size: var(--rp-pop-over-arrow-size, 16px) !default;
-$pop-over-arrow-nesting: calc(-1 * #{$pop-over-arrow-size} * #{math.sqrt(2)} / 2);
+$pop-over-arrow-width: var(--rp-pop-over-arrow-size, 16px) !default;
+$pop-over-arrow-height: calc(#{$pop-over-arrow-width} * #{math.sqrt(2)} / 2);
+$pop-over-arrow-nesting: calc(-1 * #{$pop-over-arrow-width} * #{math.sqrt(2)} / 2);
 $pop-over-bg-color: var(--rp-pop-over-bg-color, rgba(94, 96, 102, 0.9)) !default;
 $pop-over-text-color: var(--rp-pop-over-text-color, white) !default;
 $pop-over-line-height: var(--rp-pop-over-line-height, 19px) !default;
@@ -63,13 +64,13 @@ $pop-over-border-color: var(--rp-pop-over-border-color, transparent) !default;
       position: relative;
       overflow: hidden;
       display: flex;
-      width: $pop-over-arrow-size;
-      height: calc(#{$pop-over-arrow-size} * #{math.sqrt(2)} / 2);
+      width: $pop-over-arrow-width;
+      height: $pop-over-arrow-height;
       &:before {
         content: "";
         display: block;
-        width: $pop-over-arrow-size;
-        height: $pop-over-arrow-size;
+        width: $pop-over-arrow-width;
+        height: $pop-over-arrow-width;
         background-color: $pop-over-bg-color;
         border-width: $pop-over-border-width;
         border-color: $pop-over-border-color;
@@ -100,8 +101,8 @@ $pop-over-border-color: var(--rp-pop-over-border-color, transparent) !default;
       justify-content: flex-start;
       align-items: center;
       left: 100%;
-      width: calc(#{$pop-over-arrow-size} * #{math.sqrt(2)} / 2);
-      height: $pop-over-arrow-size;
+      width: $pop-over-arrow-height;
+      height: $pop-over-arrow-width;
       &:before {
         margin-left: $pop-over-arrow-nesting;
       }
@@ -111,8 +112,8 @@ $pop-over-border-color: var(--rp-pop-over-border-color, transparent) !default;
       justify-content: flex-end;
       align-items: center;
       right: 100%;
-      width: calc(#{$pop-over-arrow-size} * #{math.sqrt(2)} / 2);
-      height: $pop-over-arrow-size;
+      width: $pop-over-arrow-height;
+      height: $pop-over-arrow-width;
       &:before {
         margin-right: $pop-over-arrow-nesting;
       }


### PR DESCRIPTION
This PR fixes how PopOver component calculates the space for triangle pointer. This caused issues with outside clicks in Daedalus.

Before:
<img width="237" alt="image" src="https://user-images.githubusercontent.com/17825044/162470285-03eb261f-f41e-4006-8848-0b966cefde73.png">

After:
<img width="257" alt="image" src="https://user-images.githubusercontent.com/17825044/162470008-9d7f0393-9727-4239-9bc2-1148526d4440.png">